### PR TITLE
Add tests to .travis.yml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,7 @@ script:
   - make -C test streamGCC
   - /usr/local/bin/likwid-perfctr -i
   - /usr/local/bin/likwid-bench -t copy -w N:100MB:2
+  - make -C test test-msr-access
+  - sudo test/test-msr-access
+  - make -C test test-likwidAPI
+  - test/test-likwidAPI


### PR DESCRIPTION
Check why travis-ci fails with unreadable registers. Locally LIKWID works fine but not in the travis-ci VM.