### PR TITLE
Turning on the debug build now also disables optimizations for GCC.

### DIFF
--- a/make/include_GCC.mk
+++ b/make/include_GCC.mk
@@ -12,11 +12,16 @@ ANSI_CFLAGS   =
 #ANSI_CFLAGS += -Wextra
 #ANSI_CFLAGS += -Wall
 
-CFLAGS   =  -O2 -std=c99 -Wno-format -fPIC
+ifeq ($(DEBUG),true)
+CFLAGS   =  -O0
+else
+CFLAGS   =  -O2
+endif
+CFLAGS  += -std=c99 -Wno-format -fPIC
 FCFLAGS  = -module ./  # ifort
 #FCFLAGS  = -J ./  -fsyntax-only  #gfortran
 PASFLAGS  = x86-64
-ASFLAGS  = 
+ASFLAGS  =
 CPPFLAGS =
 LFLAGS   =  -pthread
 

--- a/src/calculator.c
+++ b/src/calculator.c
@@ -174,13 +174,13 @@ num2Str(number num)
     return str;
 }
 
-inline number
+number
 toRadians(number degrees)
 {
     return degrees * PI / 180.0;
 }
 
-inline number
+number
 toDegrees(number radians)
 {
     return radians * 180.0 / PI;


### PR DESCRIPTION
Not using -O0 is a real pita when trying to debug things with gdb.

Unfortunately this step also requires uninlining two functions, which are optimized away in the release build, but cause linker problems when left in.