### PR TITLE
Fix for L2 to L3 evict volume metric in all CACHES.txt

### DIFF
--- a/groups/broadwellD/CACHES.txt
+++ b/groups/broadwellD/CACHES.txt
@@ -73,7 +73,7 @@ L1 to/from L2 data volume [GBytes] 1.0E-09*(PMC0+PMC1)*64.0
 L3 to L2 load bandwidth [MBytes/s]  1.0E-06*PMC2*64.0/time
 L3 to L2 load data volume [GBytes]  1.0E-09*PMC2*64.0
 L2 to L3 evict bandwidth [MBytes/s]  1.0E-06*PMC3*64.0/time
-L2 to L3 evict data volume [GBytes]  1.0E-06*PMC3*64.0
+L2 to L3 evict data volume [GBytes]  1.0E-09*PMC3*64.0
 L2 to/from L3 bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*64.0/time
 L2 to/from L3 data volume [GBytes] 1.0E-09*(PMC2+PMC3)*64.0
 System to L3 bandwidth [MBytes/s] 1.0E-06*(CBOX0C0+CBOX1C0+CBOX2C0+CBOX3C0+CBOX4C0+CBOX5C0+CBOX6C0+CBOX7C0+CBOX8C0+CBOX9C0+CBOX10C0+CBOX11C0+CBOX12C0+CBOX13C0+CBOX14C0+CBOX15C0)*64.0/time

--- a/groups/broadwellEP/CACHES.txt
+++ b/groups/broadwellEP/CACHES.txt
@@ -85,7 +85,7 @@ L1 to/from L2 data volume [GBytes] 1.0E-09*(PMC0+PMC1)*64.0
 L3 to L2 load bandwidth [MBytes/s]  1.0E-06*PMC2*64.0/time
 L3 to L2 load data volume [GBytes]  1.0E-09*PMC2*64.0
 L2 to L3 evict bandwidth [MBytes/s]  1.0E-06*PMC3*64.0/time
-L2 to L3 evict data volume [GBytes]  1.0E-06*PMC3*64.0
+L2 to L3 evict data volume [GBytes]  1.0E-09*PMC3*64.0
 L2 to/from L3 bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*64.0/time
 L2 to/from L3 data volume [GBytes] 1.0E-09*(PMC2+PMC3)*64.0
 System to L3 bandwidth [MBytes/s] 1.0E-06*(CBOX0C0+CBOX1C0+CBOX2C0+CBOX3C0+CBOX4C0+CBOX5C0+CBOX6C0+CBOX7C0+CBOX8C0+CBOX9C0+CBOX10C0+CBOX11C0+CBOX12C0+CBOX13C0+CBOX14C0+CBOX15C0+CBOX16C0+CBOX17C0+CBOX18C0+CBOX19C0+CBOX20C0+CBOX21C0)*64.0/time

--- a/groups/haswell/CACHES.txt
+++ b/groups/haswell/CACHES.txt
@@ -33,7 +33,7 @@ L1 to/from L2 data volume [GBytes] 1.0E-09*(PMC0+PMC1)*64.0
 L3 to L2 load bandwidth [MBytes/s]  1.0E-06*PMC2*64.0/time
 L3 to L2 load data volume [GBytes]  1.0E-09*PMC2*64.0
 L2 to L3 evict bandwidth [MBytes/s]  1.0E-06*PMC3*64.0/time
-L2 to L3 evict data volume [GBytes]  1.0E-06*PMC3*64.0
+L2 to L3 evict data volume [GBytes]  1.0E-09*PMC3*64.0
 L2 to/from L3 bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*64.0/time
 L2 to/from L3 data volume [GBytes] 1.0E-09*(PMC2+PMC3)*64.0
 System to L3 bandwidth [MBytes/s] 1.0E-06*(CBOX0C0+CBOX1C0+CBOX2C0+CBOX3C0)*64.0/time

--- a/groups/haswellEP/CACHES.txt
+++ b/groups/haswellEP/CACHES.txt
@@ -73,7 +73,7 @@ L1 to/from L2 data volume [GBytes] 1.0E-09*(PMC0+PMC1)*64.0
 L3 to L2 load bandwidth [MBytes/s]  1.0E-06*PMC2*64.0/time
 L3 to L2 load data volume [GBytes]  1.0E-09*PMC2*64.0
 L2 to L3 evict bandwidth [MBytes/s]  1.0E-06*PMC3*64.0/time
-L2 to L3 evict data volume [GBytes]  1.0E-06*PMC3*64.0
+L2 to L3 evict data volume [GBytes]  1.0E-09*PMC3*64.0
 L2 to/from L3 bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*64.0/time
 L2 to/from L3 data volume [GBytes] 1.0E-09*(PMC2+PMC3)*64.0
 System to L3 bandwidth [MBytes/s] 1.0E-06*(CBOX0C0+CBOX1C0+CBOX2C0+CBOX3C0+CBOX4C0+CBOX5C0+CBOX6C0+CBOX7C0+CBOX8C0+CBOX9C0+CBOX10C0+CBOX11C0+CBOX12C0+CBOX13C0)*64.0/time

--- a/groups/ivybridgeEP/CACHES.txt
+++ b/groups/ivybridgeEP/CACHES.txt
@@ -71,7 +71,7 @@ L1 to/from L2 data volume [GBytes] 1.0E-09*(PMC0+PMC1)*64.0
 L3 to L2 load bandwidth [MBytes/s]  1.0E-06*PMC2*64.0/time
 L3 to L2 load data volume [GBytes]  1.0E-09*PMC2*64.0
 L2 to L3 evict bandwidth [MBytes/s]  1.0E-06*PMC3*64.0/time
-L2 to L3 evict data volume [GBytes]  1.0E-06*PMC3*64.0
+L2 to L3 evict data volume [GBytes]  1.0E-09*PMC3*64.0
 L2 to/from L3 bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*64.0/time
 L2 to/from L3 data volume [GBytes] 1.0E-09*(PMC2+PMC3)*64.0
 System to L3 bandwidth [MBytes/s] 1.0E-06*(CBOX0C0:STATE=0x3F+CBOX1C0:STATE=0x3F+CBOX2C0:STATE=0x3F+CBOX3C0:STATE=0x3F+CBOX4C0:STATE=0x3F+CBOX5C0:STATE=0x3F+CBOX6C0:STATE=0x3F+CBOX7C0:STATE=0x3F+CBOX8C0:STATE=0x3F+CBOX9C0:STATE=0x3F+CBOX10C0:STATE=0x3F+CBOX11C0:STATE=0x3F+CBOX12C0:STATE=0x3F+CBOX13C0:STATE=0x3F+CBOX14C0:STATE=0x3F)*64.0/time

--- a/groups/sandybridgeEP/CACHES.txt
+++ b/groups/sandybridgeEP/CACHES.txt
@@ -47,7 +47,7 @@ L1 to/from L2 data volume [GBytes] 1.0E-09*(PMC0+PMC1)*64.0
 L3 to L2 load bandwidth [MBytes/s]  1.0E-06*PMC2*64.0/time
 L3 to L2 load data volume [GBytes]  1.0E-09*PMC2*64.0
 L2 to L3 evict bandwidth [MBytes/s]  1.0E-06*PMC3*64.0/time
-L2 to L3 evict data volume [GBytes]  1.0E-06*PMC3*64.0
+L2 to L3 evict data volume [GBytes]  1.0E-09*PMC3*64.0
 L2 to/from L3 bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*64.0/time
 L2 to/from L3 data volume [GBytes] 1.0E-09*(PMC2+PMC3)*64.0
 System to L3 bandwidth [MBytes/s] 1.0E-06*(CBOX0C0:STATE=0x3F+CBOX1C0:STATE=0x3F+CBOX2C0:STATE=0x3F+CBOX3C0:STATE=0x3F+CBOX4C0:STATE=0x3F+CBOX5C0:STATE=0x3F+CBOX6C0:STATE=0x3F+CBOX7C0:STATE=0x3F)*64.0/time


### PR DESCRIPTION
Fixed a typo.