### PR TITLE
set correct path to liblikwidpin

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -93,6 +93,6 @@ DATE    = 22.12.2016
 RPATHS = -Wl,-rpath=$(INSTALLED_LIBPREFIX)
 LIKWIDLOCKPATH = /var/run/likwid.lock
 LIKWIDSOCKETBASE = /tmp/likwid  # -%d will be added automatically to the socket name
-LIBLIKWIDPIN = $(abspath $(INSTALLED_PREFIX)/lib/liblikwidpin.so.$(VERSION).$(RELEASE))
+LIBLIKWIDPIN = $(abspath $(INSTALLED_LIBPREFIX)/liblikwidpin.so.$(VERSION).$(RELEASE))
 LIKWIDFILTERPATH = $(abspath $(INSTALLED_PREFIX)/share/likwid/filter)
 LIKWIDGROUPPATH = $(abspath $(INSTALLED_PREFIX)/share/likwid/perfgroups)


### PR DESCRIPTION
For LIBLIKWIDPIN the wrong INSTALLED_PREFIX instead of the correct INSTALLED_LIBPREFIX is used to determine the path to the shared object. Fixed this in config.mk.