### PR TITLE
Add missing return statements for the perf_event support.

### DIFF
--- a/src/includes/perfmon_perfevent.h
+++ b/src/includes/perfmon_perfevent.h
@@ -374,6 +374,7 @@ int perfmon_stopCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
             VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, RESET_COUNTER);
         }
     }
+    return 0;
 }
 
 int perfmon_readCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSet)
@@ -401,6 +402,7 @@ int perfmon_readCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_ENABLE, 0);
         }
     }
+    return 0;
 }
 
 int perfmon_finalizeCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSet)


### PR DESCRIPTION
Some return statements are missing when using the perf_event support.

To be compliant with the other headers, I added the same statements where they were missing.