### PR TITLE
Add the support of the pid and flags parameters (perf_event).

### DIFF
--- a/src/includes/perfmon_perfevent.h
+++ b/src/includes/perfmon_perfevent.h
@@ -310,10 +310,29 @@ int perfmon_setupCountersThread_perfevent(
         }
         if (ret == 0)
         {
-            cpu_event_fds[cpu_id][index] = perf_event_open(&attr, 0, cpu_id, -1, 0);
+            pid_t pid = 0;
+            unsigned long flags = 0;
+
+            for (int j = 0; j < event->numberOfOptions; j++)
+            {
+                switch (event->options[j].type)
+                {
+                    case EVENT_OPTION_PERF_PID:
+                        pid = event->options[j].value;
+                        break;
+                    case EVENT_OPTION_PERF_FLAGS:
+                        flags = event->options[j].value;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            cpu_event_fds[cpu_id][index] = perf_event_open(&attr, pid, cpu_id, -1, flags);
             if (cpu_event_fds[cpu_id][index] < 0)
             {
                 fprintf(stderr, "Setup of event %s on CPU %d failed: %s\n", event->name, cpu_id, strerror(errno));
+                fprintf(stderr, "perf_event_open: pid=%d, flags=%d\n", pid, flags);
                 fprintf(stderr, "Config of event 0x%X\n", attr.config);
                 fprintf(stderr, "Type of event 0x%X\n", attr.type);
                 continue;

--- a/src/includes/perfmon_types.h
+++ b/src/includes/perfmon_types.h
@@ -79,6 +79,10 @@ typedef enum {
     EVENT_OPTION_OCCUPANCY_INVERT, /*!< \brief Invert filter for occupancy counting */
     EVENT_OPTION_IN_TRANS, /*!< \brief Count events during transactions */
     EVENT_OPTION_IN_TRANS_ABORT, /*!< \brief Count events that aborted during transactions */
+#ifdef LIKWID_USE_PERFEVENT
+    EVENT_OPTION_PERF_PID, /*!< \brief PID parameter to use in the perf_event_open call */
+    EVENT_OPTION_PERF_FLAGS, /*!< \brief FLAGS parameters to use in the perf_event_open call */
+#endif
     NUM_EVENT_OPTIONS /*!< \brief Amount of defined options */
 } EventOptionType;
 

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -129,6 +129,10 @@ char* eventOptionTypeName[NUM_EVENT_OPTIONS] = {
     "OCCUPANCY_INVERT",
     "IN_TRANSACTION",
     "IN_TRANSACTION_ABORTED"
+#ifdef LIKWID_USE_PERFEVENT
+    ,"PERF_PID"
+    ,"PERF_FLAGS"
+#endif
 };
 
 /* #####   FUNCTION DEFINITIONS  -  LOCAL TO THIS SOURCE FILE   ########### */
@@ -501,6 +505,18 @@ parseOptions(struct bstrList* tokens, PerfmonEvent* event, RegisterIndex index)
                 event->numberOfOptions = assignOption(event, subtokens->entry[1],
                                     event->numberOfOptions, EVENT_OPTION_OCCUPANCY_FILTER, 0);
             }
+#ifdef LIKWID_USE_PERFEVENT
+            else if (biseqcstr(subtokens->entry[0], "perf_pid") == 1)
+            {
+                event->numberOfOptions = assignOption(event, subtokens->entry[1],
+                                    event->numberOfOptions, EVENT_OPTION_PERF_PID, 0);
+            }
+            else if (biseqcstr(subtokens->entry[0], "perf_flags") == 1)
+            {
+                event->numberOfOptions = assignOption(event, subtokens->entry[1],
+                                    event->numberOfOptions, EVENT_OPTION_PERF_FLAGS, 0);
+            }
+#endif
             else
             {
                 continue;
@@ -510,7 +526,11 @@ parseOptions(struct bstrList* tokens, PerfmonEvent* event, RegisterIndex index)
     }
     for(i=event->numberOfOptions-1;i>=0;i--)
     {
+#ifdef LIKWID_USE_PERFEVENT
+        if (event->options[i].type != EVENT_OPTION_PERF_PID && event->options[i].type != EVENT_OPTION_PERF_FLAGS && !(OPTIONS_TYPE_MASK(event->options[i].type) & (counter_map[index].optionMask|event->optionMask)))
+#else
         if (!(OPTIONS_TYPE_MASK(event->options[i].type) & (counter_map[index].optionMask|event->optionMask)))
+#endif
         {
             DEBUG_PRINT(DEBUGLEV_INFO,Removing Option %s not valid for register %s,
                         eventOptionTypeName[event->options[i].type],


### PR DESCRIPTION
Add the possibility to use the PID and flags parameters for the perf_event_open call when using the perf_event interface (#96).