### PR TITLE
AMD Zen: Don't invert thread/slice selectors

### DIFF
--- a/src/includes/perfmon_zen.h
+++ b/src/includes/perfmon_zen.h
@@ -126,11 +126,11 @@ int k17_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
             switch (event->options[j].type)
             {
                 case EVENT_OPTION_TID:
-                    flags |= (~((uint64_t)(event->options[j].value & AMD_K17_L3_TID_MASK))) << AMD_K17_L3_TID_SHIFT;
+                    flags |= ((uint64_t)(event->options[j].value & AMD_K17_L3_TID_MASK)) << AMD_K17_L3_TID_SHIFT;
                     has_tid = 1;
                     break;
                 case EVENT_OPTION_MATCH0:
-                    flags |= (~((uint64_t)(event->options[j].value & AMD_K17_L3_SLICE_MASK))) << AMD_K17_L3_SLICE_SHIFT;
+                    flags |= ((uint64_t)(event->options[j].value & AMD_K17_L3_SLICE_MASK)) << AMD_K17_L3_SLICE_SHIFT;
                     has_match0 = 1;
                     break;
                 default:


### PR DESCRIPTION
Is there any reason why these are inverted? If I'm trying to filter events by thread, I usually think of "I'd like to get events from *these* threads", not "I'd like to **not** get events from these threads".