### PR TITLE
Fixed double `free`

### DIFF
--- a/src/calculator.c
+++ b/src/calculator.c
@@ -757,7 +757,6 @@ int tokenize(char *str, char *(**tokensRef))
             tmp = (char**)realloc(tokens, numTokens * sizeof(char*));
             if (tmp == NULL)
             {
-                free(newToken);
                 if (tokens != NULL)
                 {
                     for(i=0;i<numTokens-1;i++)


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. Error, found using PVS-Studio:
likwid/src/calculator.c     771     err     V586 The 'free' function is called twice for deallocation of the same memory space. Inspect the first argument. Check lines: 760, 771.