### PR TITLE
Increased MAX_LENGTH_MSR_DEV_NAME

### DIFF
--- a/src/access_x86_msr.c
+++ b/src/access_x86_msr.c
@@ -59,7 +59,7 @@
 
 /* #####   MACROS  -  LOCAL TO THIS SOURCE FILE   ######################### */
 
-#define MAX_LENGTH_MSR_DEV_NAME  20
+#define MAX_LENGTH_MSR_DEV_NAME  24
 #define STRINGIFY(x) #x
 #define TOSTRING(x) STRINGIFY(x)
 


### PR DESCRIPTION
Got an buffer overflow since /dev/cpu/18/msr_safe did not fit within the 20 chars