### PR TITLE
fix missing uncore measurements with likwid-mpirun

### DIFF
--- a/src/applications/likwid-mpirun.lua
+++ b/src/applications/likwid-mpirun.lua
@@ -1101,7 +1101,7 @@ local function setPerfStrings(perflist, cpuexprs)
                 local slist = {}
                 for j, cpu in pairs(cpuexpr) do
                     for l, socklist in pairs(socketList) do
-                        if inList(cpu, socklist) then
+                        if inList(tonumber(cpu), socklist) then
                             table.insert(slist, l)
                         end
                     end


### PR DESCRIPTION
- to check for the first core in a socket, a comparison of the cpu id is
  done; unfortunately, the comparison is between a string and integers
- converting the cpu id to a number fixes the comparison and the uncore
  counters (e.g., memory related counters) are read by the first cores
  in each socket