### PR TITLE
fix likwid-mpirun bug with slurm

### DIFF
--- a/src/applications/likwid-mpirun.lua
+++ b/src/applications/likwid-mpirun.lua
@@ -572,7 +572,7 @@ local function writeHostfileSlurm(hostlist, filename)
     cmd = string.format("scontrol show hostlist %s", table.concat(l,","))
     f = io.popen(cmd, 'r')
     if f ~= nil then
-        likwid.setenv("SLURM_NODELIST", f:read('*a'))
+        likwid.setenv("SLURM_NODELIST", f:read('*l'))
         f:close()
     else
         print_stderr("ERROR: Cannot transform list of hosts to SLURM hostlist format")


### PR DESCRIPTION
- the problem lies in setting SLURM_NODELIST in likwid-mpirun
- currently, the hostlist is read from a scontrol command using a lua
  pipe with f:read('*a')
- this leads to line break at the end of the environment variable
  SLURM_NODELIST, causing srun to segfault
- this can be fixed by using f:read('*l') because the scontrol output
  should always be only one line -> the line break is ignored