### PR TITLE
Do not restrict access daemon to single CPU

### DIFF
--- a/src/access_client.c
+++ b/src/access_client.c
@@ -135,13 +135,6 @@ access_client_startDaemon(int cpu_id)
 
     if (pid == 0)
     {
-        if (cpu_id >= 0)
-        {
-            cpu_set_t cpuset;
-            CPU_ZERO(&cpuset);
-            CPU_SET(cpu_id, &cpuset);
-            sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);
-        }
         ret = execve (exeprog, newargv, newenv);
 
         if (ret < 0)


### PR DESCRIPTION
I think this comes from a time where likwid would start one daemon
per CPU. Nowadays there is only one daemon (unless you are in a
threaded environment?) and consequently reading hardware registers
becomes really slow if there is a user application also pinned to
that CPU.