### PR TITLE
Changing type of variable 'offset'

### DIFF
--- a/bench/src/bench.c
+++ b/bench/src/bench.c
@@ -135,7 +135,7 @@ runTest(void* arg)
 
     /* pin the thread */
     likwid_pinThread(myData->processors[threadId]);
-    printf("Group: %d Thread %d Global Thread %d running on core %d - Vector length %llu Offset %d\n",
+    printf("Group: %d Thread %d Global Thread %d running on core %d - Vector length %llu Offset %zd\n",
             data->groupId,
             threadId,
             data->globalThreadId,
@@ -456,7 +456,7 @@ void*
 getIterSingle(void* arg)
 {
     int threadId = 0;
-    int offset = 0;
+    size_t offset = 0;
     size_t size = 0, vecsize = 0;
     size_t i;
     ThreadData* data;

--- a/bench/src/bench.c
+++ b/bench/src/bench.c
@@ -69,7 +69,7 @@ void*
 runTest(void* arg)
 {
     int threadId;
-    int offset;
+    size_t offset;
     size_t size;
     size_t vecsize;
     size_t i;


### PR DESCRIPTION
Changing type from 'int' to 'size_t' to avoid overflowing.
At some cases, offset may be bigger than 2 147 483 647, that cause negative number and access to wrong memory address. 
example:
likwid-bench -t copy_avx -w S0:48GB:48 −i 2048