### PR TITLE
Add check for event name duplicates

### DIFF
--- a/test/check_events_files.py
+++ b/test/check_events_files.py
@@ -222,6 +222,7 @@ class EventParser():
         self.options, self.default_options = None, None
         self.opts = opts
         self.nerrors = 0
+        self.line_num = 0
 
 
     def load(self, afile, opts):
@@ -245,7 +246,6 @@ class EventParser():
 
     def parse_lines(self, afile):
 
-        self.line_num = 0
         for l in afile:
             self.line_num += 1
             l = l.strip()

--- a/test/check_events_files.py
+++ b/test/check_events_files.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-#!/usr/bin/python3
 
 # =======================================================================================
 #
@@ -25,7 +25,7 @@
 #      this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # =======================================================================================
-
+from collections import OrderedDict
 import json
 from pathlib import Path
 import sys
@@ -127,26 +127,37 @@ class EventParser():
 
         self.Event = ( self.Umask | self.Evt | self.Options | self.DefaultOptions | Comment ) + StringEnd()
 
-        self.event_head, self.event_count, self.events = None, 0, []
+        self.event_head, self.event_count, self.events = None, 0, OrderedDict()
         self.options, self.default_options = None, None
 
 
     def _set_event(self, s, loc, token):
 
-        if self.event_head and self.event_count == 0:
-            if token['name'].startswith(self.event_head['name']):
-                err('\n{}:{}:', self.fname, self.line_num)
-                err("Expected: 'UMASK_{}'", token['name'])
-                err("Found:    'EVENT_{}'", token['name'])
-            else:
-                err('\n{}:{}:', self.fname, self.line_num)
-                err("Expected: 'UMASK_{}_....'", self.event_head['name'])
-                err("Found:    'EVENT_{}'", token['name'])
-
-        self.event_head, self.event_count = token.asDict(), 0
+        event_head = token.asDict()
         for key in ('number', 'subsystem'):
-            value = self.event_head[key]
-            self.event_head[key] = value if len(value) > 1 else value[0]
+            value = event_head[key]
+            event_head[key] = tuple(value) if len(value) > 1 else value[0]
+        event_head.update(line_num = self.line_num)
+
+        if self.event_head:
+            if event_head['name'] == self.event_head['name'] and event_head['subsystem'] == self.event_head['subsystem']:
+                self.nerrors += 1
+                err("\n{}:{}:\nDuplicate event name: {}"
+                    "\nPrevious declaration is here:\n{}:{}:\n",
+                    self.fname, self.line_num, event_head['name'], self.fname, self.event_head['line_num'])
+            if self.event_count == 0:
+                if event_head['name'].startswith(self.event_head['name']):
+                    self.nerrors += 1
+                    err('\n{}:{}:', self.fname, self.line_num)
+                    err("Expected: 'UMASK_{}'", event_head['name'])
+                    err("Found:    'EVENT_{}'", event_head['name'])
+                else:
+                    self.nerrors += 1
+                    err('\n{}:{}:', self.fname, self.line_num)
+                    err("Expected: 'UMASK_{}_....'", self.event_head['name'])
+                    err("Found:    'EVENT_{}'", event_head['name'])
+
+        self.event_head, self.event_count = event_head, 0
 
 
     def _set_options(self, s, loc, token):
@@ -184,23 +195,41 @@ class EventParser():
 
         event = self.event_head.copy()
         event.update(name=token['name'],
-                     umask = token['umask'] if len(token['umask']) > 1 else token['umask'][0]
+                     umask = token['umask'] if len(token['umask']) > 1 else token['umask'][0],
+                     line_num = self.line_num
                      )
+
+        key = event['subsystem'], event['name']
+        if key in self.events:
+            self.nerrors += 1
+            err("\n{}:{}:\nDuplicate event name: {}"
+                "\nPrevious declaration is here:\n{}:{}:\n",
+                self.fname, self.line_num, event['name'], self.fname, self.events[key]['line_num'])
+
         if self.options is not None:
             event['options'], self.options = self.options, None
         if self.default_options is not None:
             event['default_options'], self.default_options = self.default_options, None
-        self.events.append(event)
+
+        self.events[key] = event
         self.event_count += 1
 
 
     def reset(self, fname, opts):
 
         self.fname = fname
-        self.event_head, self.event_count, self.events = None, 0, []
+        self.event_head, self.event_count, self.events = None, 0, OrderedDict()
         self.options, self.default_options = None, None
         self.opts = opts
         self.nerrors = 0
+
+
+    def load(self, afile, opts):
+        import copy
+        lopts = copy.deepcopy(opts)
+        lopts.naming = False
+        self.check(afile, lopts)
+        return self.events
 
 
     def check(self, afile, opts):
@@ -234,7 +263,9 @@ class EventParser():
 
     def to_json(self, f, indent=4, sort_keys=True):
 
-        json.dump(self.events, f, indent=indent, sort_keys=sort_keys)
+        json.dump([ dict([ (k, v) for k, v in V.items() if k != 'line_num' ])
+                    for V in self.events.values() ],
+                  f, indent=indent, sort_keys=sort_keys)
 
 
 


### PR DESCRIPTION
Please consider this PR which introduces checks for event names uniqueness.
Running the updated script as 
`<path_to_likwid>/test/check_events_files.py events -v
`
produces ~90 cases when the same name is used for events with different UMASK.