### PR TITLE
Warn user if there is no any events files found in default directory.

### DIFF
--- a/test/check_events_files.py
+++ b/test/check_events_files.py
@@ -368,7 +368,12 @@ def test_EventParser(opts):
 def resolve_events_files(opts):
 
     if not opts.files:
-        files = opts.input_dir.glob("perfmon_*_events.txt")
+        files = list(opts.input_dir.glob("perfmon_*_events.txt"))
+        if not files:
+            raise Exception("Couldn't find any events files in '{}', "
+                            "please use --input-dir option.\n"
+                            "Use `{} events --help` for details."
+                            .format(opts.input_dir, sys.argv[0]))
     else:
         files = []
         for f in opts.files:


### PR DESCRIPTION
Prompt the user to use --input-dir option if no files found in the default input directory.