### PR TITLE
Allow arbitrary thread numbers per work group in likwid-bench

### DIFF
--- a/bench/includes/threads.h
+++ b/bench/includes/threads.h
@@ -32,6 +32,7 @@
 
 #include <pthread.h>
 #include <threads_types.h>
+#include <strUtil.h>
 
 #define THREADS_BARRIER pthread_barrier_wait(&threads_barrier)
 #define MIN_ITERATIONS 10
@@ -107,7 +108,8 @@ extern void threads_destroy(int numberOfGroups, int numberOfStreams);
 /**
  * @brief  Create Thread groups
  * @param  numberOfGroups The number of groups to create
+ * @param  groups Pointer to the groups data
  */
-extern void threads_createGroups(int numberOfGroups);
+extern void threads_createGroups(int numberOfGroups, Workgroup *groups);
 
 #endif /* THREADS_H */

--- a/bench/likwid-bench.c
+++ b/bench/likwid-bench.c
@@ -421,8 +421,6 @@ int main(int argc, char** argv)
         }
     }
 
-    /* :WARNING:05/04/2010 08:58:05 AM:jt: At the moment the thread
-     * module only allows equally sized thread groups*/
     for (i=0; i<numberOfWorkgroups; i++)
     {
         globalNumberOfThreads += groups[i].numberOfThreads;
@@ -438,7 +436,7 @@ int main(int argc, char** argv)
 
 
     threads_init(globalNumberOfThreads);
-    threads_createGroups(numberOfWorkgroups);
+    threads_createGroups(numberOfWorkgroups, groups);
 
     /* we configure global barriers only */
     barrier_init(1);

--- a/bench/src/threads.c
+++ b/bench/src/threads.c
@@ -37,6 +37,7 @@
 
 #include <errno.h>
 #include <threads.h>
+#include <strUtil.h>
 
 /* #####   EXPORTED VARIABLES   ########################################### */
 
@@ -135,21 +136,11 @@ threads_create(void *(*startRoutine)(void*))
 }
 
 void
-threads_createGroups(int numberOfGroups)
+threads_createGroups(int numberOfGroups, Workgroup *groups)
 {
     int i;
     int j;
-    int numThreadsPerGroup;
     int globalId = 0;
-
-    if (numThreads % numberOfGroups)
-    {
-        fprintf(stderr, "ERROR: Not enough threads %d to create %d groups\n",numThreads,numberOfGroups);
-    }
-    else
-    {
-        numThreadsPerGroup = numThreads / numberOfGroups;
-    }
 
     threads_groups = (ThreadGroup*) malloc(numberOfGroups * sizeof(ThreadGroup));
     if (!threads_groups)
@@ -160,20 +151,20 @@ threads_createGroups(int numberOfGroups)
 
     for (i = 0; i < numberOfGroups; i++)
     {
-        threads_groups[i].numberOfThreads = numThreadsPerGroup;
-        threads_groups[i].threadIds = (int*) malloc(numThreadsPerGroup * sizeof(int));
+        threads_groups[i].numberOfThreads = groups[i].numberOfThreads;
+        threads_groups[i].threadIds = (int*) malloc(threads_groups[i].numberOfThreads * sizeof(int));
         if (!threads_groups[i].threadIds)
         {
             fprintf(stderr, "ERROR: Cannot allocate threadID list for thread groups - %s\n", strerror(errno));
             exit(EXIT_FAILURE);
         }
 
-        for (j = 0; j < numThreadsPerGroup; j++)
+        for (j = 0; j < threads_groups[i].numberOfThreads; j++)
         {
             threads_data[globalId].threadId = j;
             threads_data[globalId].groupId = i;
             threads_data[globalId].numberOfGroups = numberOfGroups;
-            threads_data[globalId].numberOfThreads = numThreadsPerGroup;
+            threads_data[globalId].numberOfThreads = threads_groups[i].numberOfThreads;
             threads_groups[i].threadIds[j] = globalId++;
         }
     }


### PR DESCRIPTION
Up to now, different work groups must have the same thread number for likwid-bench to work properly. With this change, different work groups can have different numbers of threads, which is useful for e.g., when one wants to have 2 threads on the first socket and only one on the second.

Example: `likwid-bench -t copy -w S0:10MB:2 -w S1:10MB:1`