### PR TITLE
Add initialization per thread 

### DIFF
--- a/bench/includes/allocator.h
+++ b/bench/includes/allocator.h
@@ -45,6 +45,7 @@ extern void allocator_allocateVector(void** ptr,
                 int offset,
                 DataType type,
                 int stride,
-                bstring domain);
+                bstring domain,
+                int init_per_thread);
 
 #endif /*ALLOCATOR_H*/

--- a/bench/includes/strUtil.h
+++ b/bench/includes/strUtil.h
@@ -50,6 +50,7 @@ typedef struct {
     uint32_t numberOfThreads;
     int* processorIds;
     uint64_t size;
+    int init_per_thread;
     Stream* streams;
 } Workgroup;
 

--- a/bench/includes/test_types.h
+++ b/bench/includes/test_types.h
@@ -105,6 +105,7 @@ typedef struct {
     const TestCase* test;
     uint64_t   cycles;
     uint32_t numberOfThreads;
+    int    init_per_thread;
     int* processors;
     void** streams;
 } ThreadUserData;

--- a/bench/likwid-bench.c
+++ b/bench/likwid-bench.c
@@ -72,7 +72,12 @@ extern void* getIterSingle(void* arg);
     printf("-l <TEST>\t list properties of benchmark \n"); \
     printf("-t <TEST>\t type of test \n"); \
     printf("-w\t\t <thread_domain>:<size>[:<num_threads>[:<chunk size>:<stride>]-<streamId>:<domain_id>[:<offset>]\n"); \
-    printf("\t\t <size> in kB, MB or GB  (mandatory)\n"); \
+    printf("-W\t\t <thread_domain>:<size>[:<num_threads>[:<chunk size>:<stride>]]\n"); \
+    printf("\t\t <size> in kB, MB or GB (mandatory)\n"); \
+    printf("\n"); \
+    printf("Difference between -w and -W :\n"); \
+    printf("-w allocates the streams in the thread_domain with one thread and support placement of streams\n"); \
+    printf("-W allocates the streams chunk-wise by each thread in the thread_domain\n"); \
     printf("\n"); \
     printf("Usage: \n"); \
     printf("# Run the store benchmark on all CPUs of the system with a vector size of 1 GB\n"); \
@@ -151,7 +156,7 @@ int main(int argc, char** argv)
         exit(EXIT_SUCCESS);
     }
 
-    while ((c = getopt (argc, argv, "w:t:s:l:aphvi:")) != -1) {
+    while ((c = getopt (argc, argv, "W:w:t:s:l:aphvi:")) != -1) {
         switch (c)
         {
             case 'h':
@@ -164,6 +169,7 @@ int main(int argc, char** argv)
                 ownprintf(TESTS"\n");
                 exit (EXIT_SUCCESS);
             case 'w':
+            case 'W':
                 numberOfWorkgroups++;
                 break;
             case 's':
@@ -343,16 +349,22 @@ int main(int argc, char** argv)
 
     allocator_init(numberOfWorkgroups * MAX_STREAMS);
     groups = (Workgroup*) malloc(numberOfWorkgroups*sizeof(Workgroup));
+    memset(groups, 0, numberOfWorkgroups*sizeof(Workgroup));
     tmp = 0;
 
     optind = 0;
-    while ((c = getopt (argc, argv, "w:t:s:l:i:aphv")) != -1)
+    while ((c = getopt (argc, argv, "W:w:t:s:l:i:aphv")) != -1)
     {
         switch (c)
         {
             case 'w':
+            case 'W':
                 currentWorkgroup = groups+tmp;
                 bstring groupstr = bfromcstr(optarg);
+                if (c == 'W')
+                {
+                    currentWorkgroup->init_per_thread = 1;
+                }
                 i = bstr_to_workgroup(currentWorkgroup, groupstr, test->type, test->streams);
                 bdestroy(groupstr);
                 size_t newsize = 0;
@@ -404,7 +416,8 @@ int main(int argc, char** argv)
                                                     currentWorkgroup->streams[i].offset,
                                                     test->type,
                                                     test->stride,
-                                                    currentWorkgroup->streams[i].domain);
+                                                    currentWorkgroup->streams[i].domain,
+                                                    currentWorkgroup->init_per_thread && nrThreads > 1);
                     }
                     tmp++;
                 }
@@ -413,7 +426,20 @@ int main(int argc, char** argv)
                     exit(EXIT_FAILURE);
                 }
                 if (newsize != currentWorkgroup->size)
+                {
                     currentWorkgroup->size = newsize;
+                }
+                if (nrThreads > 1)
+                {
+                    if (currentWorkgroup->init_per_thread)
+                    {
+                        printf("Initialization: Each thread in domain initializes its own stream chunks\n");
+                    }
+                    else
+                    {
+                        printf("Initialization: First thread in domain initializes the whole stream\n");
+                    }
+                }
                 break;
             default:
                 continue;
@@ -468,6 +494,7 @@ int main(int argc, char** argv)
         myData.test = test;
         myData.cycles = 0;
         myData.numberOfThreads = groups[i].numberOfThreads;
+        myData.init_per_thread = groups[i].init_per_thread;
         myData.processors = (int*) malloc(myData.numberOfThreads * sizeof(int));
         myData.streams = (void**) malloc(test->streams * sizeof(void*));
 

--- a/bench/src/allocator.c
+++ b/bench/src/allocator.c
@@ -96,7 +96,8 @@ allocator_allocateVector(
         int offset,
         DataType type,
         int stride,
-        bstring domainString)
+        bstring domainString,
+        int init_per_thread)
 {
     int i;
     size_t bytesize = 0;
@@ -161,48 +162,50 @@ allocator_allocateVector(
             offset,
             LLU_CAST elements);
 
-    switch ( type )
+    if (!init_per_thread)
     {
-        case INT:
-            {
-                int* sptr = (int*) (*ptr);
-                sptr += offset;
-
-                for ( uint64_t i=0; i < size; i++ )
+        switch ( type )
+        {
+            case INT:
                 {
-                    sptr[i] = 1;
+                    int* sptr = (int*) (*ptr);
+                    sptr += offset;
+
+                    for ( uint64_t i=0; i < size; i++ )
+                    {
+                        sptr[i] = 1;
+                    }
+                    *ptr = (void*) sptr;
+
                 }
-                *ptr = (void*) sptr;
+                break;
 
-            }
-            break;
-
-        case SINGLE:
-            {
-                float* sptr = (float*) (*ptr);
-                sptr += offset;
-
-                for ( uint64_t i=0; i < size; i++ )
+            case SINGLE:
                 {
-                    sptr[i] = 1.0;
+                    float* sptr = (float*) (*ptr);
+                    sptr += offset;
+
+                    for ( uint64_t i=0; i < size; i++ )
+                    {
+                        sptr[i] = 1.0;
+                    }
+                    *ptr = (void*) sptr;
+
                 }
-                *ptr = (void*) sptr;
+                break;
 
-            }
-            break;
-
-        case DOUBLE:
-            {
-                double* dptr = (double*) (*ptr);
-                dptr += offset;
-
-                for ( uint64_t i=0; i < size; i++ )
+            case DOUBLE:
                 {
-                    dptr[i] = 1.0;
+                    double* dptr = (double*) (*ptr);
+                    dptr += offset;
+
+                    for ( uint64_t i=0; i < size; i++ )
+                    {
+                        dptr[i] = 1.0;
+                    }
+                    *ptr = (void*) dptr;
                 }
-                *ptr = (void*) dptr;
-            }
-            break;
+                break;
+        }
     }
 }
-

--- a/bench/src/strUtil.c
+++ b/bench/src/strUtil.c
@@ -225,6 +225,11 @@ parse_streams(Workgroup* group, const_bstring str, int numberOfStreams)
 {
     struct bstrList* tokens;
     struct bstrList* subtokens;
+    if (group->init_per_thread)
+    {
+        fprintf(stderr, "Error: Cannot place stream in different stream when initialization per thread is selected.\n");
+        return -1;
+    }
     tokens = bsplit(str,',');
 
     if (tokens->qty < numberOfStreams)
@@ -297,8 +302,13 @@ bstr_to_workgroup(Workgroup* group, const_bstring str, DataType type, int number
             bstrListDestroy(tokens);
             return 1;
         }
-        parse_streams(group, tokens->entry[1], numberOfStreams);
+        parseStreams = parse_streams(group, tokens->entry[1], numberOfStreams);
         bdestroy(domain);
+        if (parseStreams)
+        {
+            bstrListDestroy(tokens);
+            return parseStreams;
+        }
     }
     else if (tokens->qty == 1)
     {

--- a/doc/likwid-bench.1
+++ b/doc/likwid-bench.1
@@ -11,6 +11,8 @@ likwid-bench \- low-level benchmark suite and microbenchmarking framework
 .IR <min_time> ]
 .RB [ \-w
 .IR <workgroup_expression> ]
+.RB [ \-W
+.IR <workgroup_expression_short> ]
 .RB [ \-l
 .IR <testname> ]
 .RB [ \-d
@@ -50,7 +52,10 @@ The amount of iterations is determined using this value. Default: 1 second.
 Name of the benchmark code to run (mandatory).
 .TP
 .B \-\^w <workgroup_expression>
-Specify the affinity domain, thread count and data set size for the current benchmarking run (mandatory).
+Specify the affinity domain, thread count and data set size for the current benchmarking run (mandatory). First thread in thread domain initializes the stream.
+.TP
+.B \-\^W <workgroup_expression_short>
+Specify the affinity domain, thread count and data set size for the current benchmarking run (mandatory). Each thread in the workgroup initializes its own chunk of the stream.
 .TP
 .B \-\^l <testname>
 list properties of a benchmark code.
@@ -82,8 +87,9 @@ can be provided. Optionally for every stream (array, vector) the placement can b
 the threads are running in. To place the data in a different domain for every stream of a benchmark case (the total number of streams can be aquired by the
 .B \-l
 option) the domain to place the data in can be specified. Multiple streams are comma separated. Either the placement is provided or all streams have to be explicitly placed. Please refer to the Wiki pages on
-.B http://code.google.com/p/likwid/wiki/LikwidBench
+.B https://github.com/RRZE-HPC/likwid/wiki/Likwid-Bench
 for further details and examples on usage.
+With -W each thread initializes its own chunk of the streams but pleacement of the streams is deactivated.
 
 
 .SH EXAMPLE


### PR DESCRIPTION
with a new command line option and update documentation.

The first-touch mode can be activated with -W instead of -w for a group. Stream placement is not available in first-touch mode.

This PR is similar to #212 but enables both modes and introduces a command line option. In #212 the first-touch mode is made the default.