### PR TITLE
Likwid bench/dynload

### DIFF
--- a/bench/includes/bstrlib_helper.h
+++ b/bench/includes/bstrlib_helper.h
@@ -1,0 +1,1 @@
+../../src/includes/bstrlib_helper.h

--- a/bench/includes/isa_armv7.h
+++ b/bench/includes/isa_armv7.h
@@ -1,0 +1,186 @@
+#ifndef LIKWID_BENCH_ISA_ARMV7_H
+#define LIKWID_BENCH_ISA_ARMV7_H
+
+#include <bstrlib.h>
+#include <bstrlib_helper.h>
+
+#define ARCHNAME "armv7"
+#define WORDLENGTH 4
+
+int header(struct bstrList* code, char* funcname)
+{
+    bstring glline;
+    bstring typeline;
+    bstring label;
+    if (funcname)
+    {
+        glline = bformat(".global %s", funcname);
+        typeline = bformat(".type %s, \%function", funcname);
+        label = bformat("%s :", funcname);
+    }
+    else
+    {
+        glline = bformat(".global kernelfunction");
+        typeline = bformat(".type kernelfunction, \%function");
+        label = bformat("kernelfunction :");
+    }
+
+
+    bstrListAddChar(code, ".cpu    cortex-a15\n.fpu    neon-vfpv4");
+    bstrListAddChar(code, ".data");
+    bstrListAddChar(code, ".text");
+    bstrListAdd(code, glline);
+    bstrListAdd(code, typeline);
+    bstrListAdd(code, label);
+    bstrListAddChar(code, "push     {r4-r7, lr}");
+    bstrListAddChar(code, "add      r7, sp, #12");
+    bstrListAddChar(code, "push     {r8, r10, r11}");
+    bstrListAddChar(code, "vstmdb   sp!, {d8-d15}");
+
+
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(glline);
+    bdestroy(typeline);
+    bdestroy(label);
+    return 0;
+}
+
+int footer(struct bstrList* code, char* funcname)
+{
+    bstring line;
+    if (funcname)
+    {
+        line = bformat(".size %s, .-%s", funcname, funcname);
+    }
+    else
+    {
+        line = bformat(".size kernelfunction, .-kernelfunction");
+    }
+    bstrListAddChar(code, "vldmia   sp!, {d8-d15}");
+    bstrListAddChar(code, "pop      {r8, r10, r11}");
+    bstrListAddChar(code, "pop      {r4-r7, pc}");
+
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
+//    bstrListAddChar(code, "#endif");
+
+    bdestroy(line);
+}
+
+int loopheader(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("%s:", loopname);
+    }
+    else
+    {
+        line = bformat("kernelfunctionloop:");
+    }
+
+    bstrListAddChar(code, "mov   GPR4, #0");
+    bstrListAddChar(code, ".align 2");
+    bstrListAdd(code, line);
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+int loopfooter(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("blt %sb", loopname);
+    }
+    else
+    {
+        line = bformat("blt kernelfunctionloopb");
+    }
+    bstring bstep = bformat("add GPR4, #%d", step);
+    bstrListAdd(code, bstep);
+    bdestroy(bstep);
+    bstrListAddChar(code, "cmp GPR4, GPR1");
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+
+static RegisterMap Registers[] = {
+    {"GPR1", "r0"},
+    {"GPR2", "r1"},
+    {"GPR3", "r2"},
+    {"GPR4", "r3"},
+    {"GPR5", "r4"},
+    {"GPR6", "r5"},
+    {"GPR7", "r6"},
+    {"GPR8", "r7"},
+    {"GPR9", "r8"},
+    {"GPR10", "r9"},
+    {"GPR11", "r10"},
+    {"GPR12", "r11"},
+    {"GPR13", "r12"},
+    {"GPR14", "r13"},
+    {"GPR15", "r14"},
+    {"GPR16", "r15"},
+    {"FPR1", "d0"},
+    {"FPR2", "d1"},
+    {"FPR3", "d2"},
+    {"FPR4", "d3"},
+    {"FPR5", "d4"},
+    {"FPR6", "d5"},
+    {"FPR7", "d6"},
+    {"FPR8", "d7"},
+    {"FPR9", "d8"},
+    {"FPR10", "d9"},
+    {"FPR11", "d10"},
+    {"FPR12", "d11"},
+    {"FPR13", "d12"},
+    {"FPR14", "d13"},
+    {"FPR15", "d14"},
+    {"FPR16", "d15"},
+    {"", ""},
+};
+
+static RegisterMap Arguments[] = {
+    {"ARG1", "r0"},
+    {"ARG2", "r1"},
+    {"ARG3", "r2"},
+    {"ARG4", "r3"},
+    {"ARG7", "[SPTR+8]"},
+    {"ARG8", "[SPTR+12]"},
+    {"ARG9", "[SPTR+16]"},
+    {"ARG10", "[SPTR+20]"},
+    {"ARG11", "[SPTR+24]"},
+    {"ARG12", "[SPTR+28]"},
+    {"ARG13", "[SPTR+32]"},
+    {"ARG14", "[SPTR+36]"},
+    {"ARG15", "[SPTR+40]"},
+    {"ARG16", "[SPTR+44]"},
+    {"ARG17", "[SPTR+48]"},
+    {"ARG18", "[SPTR+52]"},
+    {"ARG19", "[SPTR+56]"},
+    {"ARG20", "[SPTR+60]"},
+    {"ARG21", "[SPTR+64]"},
+    {"ARG22", "[SPTR+68]"},
+    {"ARG23", "[SPTR+72]"},
+    {"ARG24", "[SPTR+76]"},
+    {"", ""},
+};
+
+static RegisterMap Sptr = {"SPTR", "sp"};
+static RegisterMap Bptr = {"BPTR", "rbp"};
+
+#endif

--- a/bench/includes/isa_armv7.h
+++ b/bench/includes/isa_armv7.h
@@ -1,3 +1,31 @@
+/*
+ * =======================================================================================
+ *      Filename:  isa_armv7.h
+ *
+ *      Description:  Definitions used for dynamically compile benchmarks for ARMv7 systems
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Gruber (tg), thomas.roehl@gmail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2019 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
 #ifndef LIKWID_BENCH_ISA_ARMV7_H
 #define LIKWID_BENCH_ISA_ARMV7_H
 
@@ -66,9 +94,9 @@ int footer(struct bstrList* code, char* funcname)
 
     bstrListAddChar(code, "\n");
 
-//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
-//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
-//    bstrListAddChar(code, "#endif");
+    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+    bstrListAddChar(code, ".section .note.GNU-stack,\"\",%progbits");
+    bstrListAddChar(code, "#endif");
 
     bdestroy(line);
 }

--- a/bench/includes/isa_armv8.h
+++ b/bench/includes/isa_armv8.h
@@ -1,0 +1,190 @@
+#ifndef LIKWID_BENCH_ISA_ARMV8_H
+#define LIKWID_BENCH_ISA_ARMV8_H
+
+#define DBL_ALIGNMENT 64
+#define SGL_ALIGNMENT 64
+#define INT_ALIGNMENT 16
+
+#include <bstrlib.h>
+#include <bstrlib_helper.h>
+
+#define ARCHNAME "armv8"
+#define WORDLENGTH 4
+
+int header(struct bstrList* code, char* funcname)
+{
+    bstring glline;
+    bstring typeline;
+    bstring label;
+    if (funcname)
+    {
+        glline = bformat(".global %s", funcname);
+        typeline = bformat(".type %s, @function", funcname);
+        label = bformat("%s :", funcname);
+    }
+    else
+    {
+        glline = bformat(".global kernelfunction");
+        typeline = bformat(".type kernelfunction, @function");
+        label = bformat("kernelfunction :");
+    }
+
+
+    bstrListAddChar(code, ".cpu    generic+fp+simd");
+    bstrListAddChar(code, ".data");
+    bstrListAddChar(code, ".text");
+    bstrListAdd(code, glline);
+    bstrListAdd(code, typeline);
+    bstrListAdd(code, label);
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(glline);
+    bdestroy(typeline);
+    bdestroy(label);
+    return 0;
+}
+
+int footer(struct bstrList* code, char* funcname)
+{
+    bstring line;
+    if (funcname)
+    {
+        line = bformat(".size %s, .-%s", funcname, funcname);
+    }
+    else
+    {
+        line = bformat(".size kernelfunction, .-kernelfunction");
+    }
+    bstrListAddChar(code, ".exit:");
+    bstrListAddChar(code, "ret");
+
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
+//    bstrListAddChar(code, "#endif");
+
+    bdestroy(line);
+}
+
+int loopheader(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("%s:", loopname);
+    }
+    else
+    {
+        line = bformat("kernelfunctionloop:");
+    }
+
+    bstrListAddChar(code, "mov   GPR6, 0");
+    bstrListAdd(code, line);
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+int loopfooter(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("tblt %s", loopname);
+    }
+    else
+    {
+        line = bformat("tblt kernelfunctionloop");
+    }
+    bstring bstep = bformat("add GPR6, GPR6, #%d", step);
+    bstrListAdd(code, bstep);
+    bdestroy(bstep);
+    bstrListAddChar(code, "cmp   GPR6, ARG1");
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+
+static RegisterMap Registers[] = {
+    {"GPR1", "x1"},
+    {"GPR2", "x2"},
+    {"GPR3", "x3"},
+    {"GPR4", "x4"},
+    {"GPR5", "x5"},
+    {"GPR6", "x6"},
+    {"GPR7", "x7"},
+    {"GPR8", "x8"},
+    {"GPR9", "x9"},
+    {"GPR10", "x10"},
+    {"GPR11", "x11"},
+    {"GPR12", "x12"},
+    {"GPR13", "x13"},
+    {"GPR14", "x14"},
+    {"GPR15", "x15"},
+    {"GPR16", "x16"},
+    {"GPR17", "x17"},
+    {"GPR18", "x18"},
+    {"GPR19", "x19"},
+    {"GPR20", "x20"},
+    {"GPR21", "x21"},
+    {"GPR22", "x22"},
+    {"FPR1", "d0"},
+    {"FPR2", "d1"},
+    {"FPR3", "d2"},
+    {"FPR4", "d3"},
+    {"FPR5", "d4"},
+    {"FPR6", "d5"},
+    {"FPR7", "d6"},
+    {"FPR8", "d7"},
+    {"FPR9", "d8"},
+    {"FPR10", "d9"},
+    {"FPR11", "d10"},
+    {"FPR12", "d11"},
+    {"FPR13", "d12"},
+    {"FPR14", "d13"},
+    {"FPR15", "d14"},
+    {"FPR16", "d15"},
+    {"", ""},
+};
+
+static RegisterMap Arguments[] = {
+    {"ARG1", "x0"},
+    {"ARG2", "x1"},
+    {"ARG3", "x2"},
+    {"ARG4", "x3"},
+    {"ARG5", "x4"},
+    {"ARG6", "x5"},
+    {"ARG7", "x6"},
+    {"ARG8", "x7"},
+    {"ARG9", "[SPTR+32]"},
+    {"ARG10", "[SPTR+40]"},
+    {"ARG11", "[SPTR+48]"},
+    {"ARG12", "[SPTR+56]"},
+    {"ARG13", "[SPTR+64]"},
+    {"ARG14", "[SPTR+72]"},
+    {"ARG15", "[SPTR+80]"},
+    {"ARG16", "[SPTR+88]"},
+    {"ARG17", "[SPTR+96]"},
+    {"ARG18", "[SPTR+104]"},
+    {"ARG19", "[SPTR+112]"},
+    {"ARG20", "[SPTR+120]"},
+    {"ARG21", "[SPTR+128]"},
+    {"ARG22", "[SPTR+136]"},
+    {"ARG23", "[SPTR+144]"},
+    {"ARG24", "[SPTR+152]"},
+    {"", ""},
+};
+
+static RegisterMap Sptr = {"SPTR", "sp"};
+static RegisterMap Bptr = {"BPTR", "rbp"};
+
+#endif

--- a/bench/includes/isa_armv8.h
+++ b/bench/includes/isa_armv8.h
@@ -1,9 +1,33 @@
+/*
+ * =======================================================================================
+ *      Filename:  isa_armv8.h
+ *
+ *      Description:  Definitions used for dynamically compile benchmarks for ARMv8 systems
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Gruber (tg), thomas.roehl@gmail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2019 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
 #ifndef LIKWID_BENCH_ISA_ARMV8_H
 #define LIKWID_BENCH_ISA_ARMV8_H
-
-#define DBL_ALIGNMENT 64
-#define SGL_ALIGNMENT 64
-#define INT_ALIGNMENT 16
 
 #include <bstrlib.h>
 #include <bstrlib_helper.h>
@@ -63,9 +87,9 @@ int footer(struct bstrList* code, char* funcname)
 
     bstrListAddChar(code, "\n");
 
-//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
-//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
-//    bstrListAddChar(code, "#endif");
+    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+    bstrListAddChar(code, ".section .note.GNU-stack,\"\",%progbits");
+    bstrListAddChar(code, "#endif");
 
     bdestroy(line);
 }

--- a/bench/includes/isa_x86-64.h
+++ b/bench/includes/isa_x86-64.h
@@ -1,0 +1,198 @@
+#ifndef LIKWID_BENCH_ISA_X8664_H
+#define LIKWID_BENCH_ISA_X8664_H
+
+#include <bstrlib.h>
+#include <bstrlib_helper.h>
+
+#define ARCHNAME "x86-64"
+
+
+int header(struct bstrList* code, char* funcname)
+{
+    bstring glline;
+    bstring typeline;
+    bstring label;
+    if (funcname)
+    {
+        glline = bformat(".global %s", funcname);
+        typeline = bformat(".type %s, @function", funcname);
+        label = bformat("%s :", funcname);
+    }
+    else
+    {
+        glline = bformat(".global kernelfunction");
+        typeline = bformat(".type kernelfunction, @function");
+        label = bformat("kernelfunction :");
+    }
+
+
+    bstrListAddChar(code, ".intel_syntax noprefix");
+    bstrListAddChar(code, ".data");
+    bstrListAddChar(code, ".align 64\nSCALAR:\n.double 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0");
+    bstrListAddChar(code, ".align 64\nSSCALAR:\n.single 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0");
+    bstrListAddChar(code, ".align 64\nISCALAR:\n.int 1, 1, 1, 1, 1, 1, 1, 1");
+    bstrListAddChar(code, ".align 16\nOMM:\n.int 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15");
+    bstrListAddChar(code, ".align 16\nIOMM:\n.int 0,16,32,48,64,80,96,128,144,160,176,192,208,224,240,256");
+    bstrListAddChar(code, ".align 16\nTOMM:\n.int 0,2,4,6,16,18,20,22,32,34,36,38,48,50,52,54");
+    bstrListAddChar(code, ".text");
+    bstrListAdd(code, glline);
+    bstrListAdd(code, typeline);
+    bstrListAdd(code, label);
+    bstrListAddChar(code, "push rbp");
+    bstrListAddChar(code, "mov rbp, rsp");
+    bstrListAddChar(code, "push rbx");
+    bstrListAddChar(code, "push r12");
+    bstrListAddChar(code, "push r13");
+    bstrListAddChar(code, "push r14");
+    bstrListAddChar(code, "push r15");
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(glline);
+    bdestroy(typeline);
+    bdestroy(label);
+    return 0;
+}
+
+int footer(struct bstrList* code, char* funcname)
+{
+    bstring line;
+    if (funcname)
+    {
+        line = bformat(".size %s, .-%s", funcname, funcname);
+    }
+    else
+    {
+        line = bformat(".size kernelfunction, .-kernelfunction");
+    }
+    bstrListAddChar(code, "pop r15");
+    bstrListAddChar(code, "pop r14");
+    bstrListAddChar(code, "pop r13");
+    bstrListAddChar(code, "pop r12");
+    bstrListAddChar(code, "pop rbx");
+    bstrListAddChar(code, "mov  rsp, rbp");
+    bstrListAddChar(code, "pop rbp");
+    bstrListAddChar(code, "ret");
+
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
+//    bstrListAddChar(code, "#endif");
+
+    bdestroy(line);
+}
+
+int loopheader(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("%s:", loopname);
+    }
+    else
+    {
+        line = bformat("kernelfunctionloop:");
+    }
+
+    bstrListAddChar(code, "xor   GPR1, GPR1");
+    bstrListAddChar(code, ".align 16");
+    bstrListAdd(code, line);
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+int loopfooter(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("jl %sb", loopname);
+    }
+    else
+    {
+        line = bformat("jl kernelfunctionloopb");
+    }
+    bstring bstep = bformat("add GPR1, %d", step);
+    bstrListAdd(code, bstep);
+    bdestroy(bstep);
+    bstrListAddChar(code, "cmp   GPR1, ARG1");
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+
+static RegisterMap Registers[] = {
+    {"GPR1", "rax"},
+    {"GPR2", "rbx"},
+    {"GPR3", "rcx"},
+    {"GPR4", "rdx"},
+    {"GPR5", "rsi"},
+    {"GPR6", "rdi"},
+    {"GPR7", "r8"},
+    {"GPR8", "r9"},
+    {"GPR9", "r10"},
+    {"GPR10", "r11"},
+    {"GPR11", "r12"},
+    {"GPR12", "r13"},
+    {"GPR13", "r14"},
+    {"GPR14", "r15"},
+    {"FPR1", "xmm0"},
+    {"FPR2", "xmm1"},
+    {"FPR3", "xmm2"},
+    {"FPR4", "xmm3"},
+    {"FPR5", "xmm4"},
+    {"FPR6", "xmm5"},
+    {"FPR7", "xmm6"},
+    {"FPR8", "xmm7"},
+    {"FPR9", "xmm8"},
+    {"FPR10", "xmm9"},
+    {"FPR11", "xmm10"},
+    {"FPR12", "xmm11"},
+    {"FPR13", "xmm12"},
+    {"FPR14", "xmm13"},
+    {"FPR15", "xmm14"},
+    {"FPR16", "xmm15"},
+    {"", ""},
+};
+
+static RegisterMap Arguments[] = {
+    {"ARG1", "rdi"},
+    {"ARG2", "rsi"},
+    {"ARG3", "rdx"},
+    {"ARG4", "rcx"},
+    {"ARG5", "r8"},
+    {"ARG6", "r9"},
+    {"ARG7", "[BPTR+16]"},
+    {"ARG8", "[BPTR+24]"},
+    {"ARG9", "[BPTR+32]"},
+    {"ARG10", "[BPTR+40]"},
+    {"ARG11", "[BPTR+48]"},
+    {"ARG12", "[BPTR+56]"},
+    {"ARG13", "[BPTR+64]"},
+    {"ARG14", "[BPTR+72]"},
+    {"ARG15", "[BPTR+80]"},
+    {"ARG16", "[BPTR+88]"},
+    {"ARG17", "[BPTR+96]"},
+    {"ARG18", "[BPTR+104]"},
+    {"ARG19", "[BPTR+112]"},
+    {"ARG20", "[BPTR+120]"},
+    {"ARG21", "[BPTR+128]"},
+    {"ARG22", "[BPTR+136]"},
+    {"ARG23", "[BPTR+144]"},
+    {"ARG24", "[BPTR+152]"},
+    {"", ""},
+};
+
+static RegisterMap Sptr = {"SPTR", "rsp"};
+static RegisterMap Bptr = {"BPTR", "rbp"};
+
+#endif

--- a/bench/includes/isa_x86-64.h
+++ b/bench/includes/isa_x86-64.h
@@ -1,3 +1,31 @@
+/*
+ * =======================================================================================
+ *      Filename:  isa_x86-64.h
+ *
+ *      Description:  Definitions used for dynamically compile benchmarks for x86-64 systems
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Gruber (tg), thomas.roehl@gmail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2019 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
 #ifndef LIKWID_BENCH_ISA_X8664_H
 #define LIKWID_BENCH_ISA_X8664_H
 
@@ -78,9 +106,9 @@ int footer(struct bstrList* code, char* funcname)
 
     bstrListAddChar(code, "\n");
 
-//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
-//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
-//    bstrListAddChar(code, "#endif");
+    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+    bstrListAddChar(code, ".section .note.GNU-stack,\"\",%progbits");
+    bstrListAddChar(code, "#endif");
 
     bdestroy(line);
 }

--- a/bench/includes/isa_x86.h
+++ b/bench/includes/isa_x86.h
@@ -1,0 +1,176 @@
+#ifndef LIKWID_BENCH_ISA_X86_H
+#define LIKWID_BENCH_ISA_X86_H
+
+
+#include <bstrlib.h>
+#include <bstrlib_helper.h>
+
+#define ARCHNAME "x86"
+#define WORDLENGTH 4
+
+
+int header(struct bstrList* code, char* funcname)
+{
+    bstring glline;
+    bstring typeline;
+    bstring label;
+    if (funcname)
+    {
+        glline = bformat(".global %s", funcname);
+        typeline = bformat(".type %s, @function", funcname);
+        label = bformat("%s :", funcname);
+    }
+    else
+    {
+        glline = bformat(".global kernelfunction");
+        typeline = bformat(".type kernelfunction, @function");
+        label = bformat("kernelfunction :");
+    }
+
+
+    bstrListAddChar(code, ".intel_syntax noprefix");
+    bstrListAddChar(code, ".data");
+    bstrListAddChar(code, ".align 64\nSCALAR:\n.double 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0");
+    bstrListAddChar(code, ".align 64\nSSCALAR:\n.single 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0");
+    bstrListAddChar(code, ".align 64\nISCALAR:\n.int 1, 1, 1, 1, 1, 1, 1, 1");
+    bstrListAddChar(code, ".align 16\nOMM:\n.int 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15");
+    bstrListAddChar(code, ".align 16\nIOMM:\n.int 0,16,32,48,64,80,96,128,144,160,176,192,208,224,240,256");
+    bstrListAddChar(code, ".align 16\nTOMM:\n.int 0,2,4,6,16,18,20,22,32,34,36,38,48,50,52,54");
+    bstrListAddChar(code, ".text");
+    bstrListAdd(code, glline);
+    bstrListAdd(code, typeline);
+    bstrListAdd(code, label);
+
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(glline);
+    bdestroy(typeline);
+    bdestroy(label);
+    return 0;
+}
+
+int footer(struct bstrList* code, char* funcname)
+{
+    bstring line;
+    if (funcname)
+    {
+        line = bformat(".size %s, .-%s", funcname, funcname);
+    }
+    else
+    {
+        line = bformat(".size kernelfunction, .-kernelfunction");
+    }
+    bstrListAddChar(code, "pop edi");
+    bstrListAddChar(code, "pop esi");
+    bstrListAddChar(code, "pop ebx");
+    bstrListAddChar(code, "mov  esp, ebp");
+    bstrListAddChar(code, "pop ebp");
+    bstrListAddChar(code, "ret");
+
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
+//    bstrListAddChar(code, "#endif");
+
+    bdestroy(line);
+}
+
+int loopheader(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("%s:", loopname);
+    }
+    else
+    {
+        line = bformat("kernelfunctionloop:");
+    }
+
+    bstrListAddChar(code, "xor   GPR1, GPR1");
+    bstrListAddChar(code, ".align 16");
+    bstrListAdd(code, line);
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+int loopfooter(struct bstrList* code, char* loopname, int step)
+{
+    bstring line;
+    if (loopname)
+    {
+        line = bformat("jl %sb", loopname);
+    }
+    else
+    {
+        line = bformat("jl kernelfunctionloopb");
+    }
+    bstring bstep = bformat("add GPR1, %d", step);
+    bstrListAdd(code, bstep);
+    bdestroy(bstep);
+    bstrListAddChar(code, "cmp   GPR1, ARG1");
+    bstrListAdd(code, line);
+
+    bstrListAddChar(code, "\n");
+
+    bdestroy(line);
+    return 0;
+}
+
+
+static RegisterMap Registers[] = {
+    {"GPR1", "eax"},
+    {"GPR2", "ebx"},
+    {"GPR3", "ecx"},
+    {"GPR4", "edx"},
+    {"GPR5", "esi"},
+    {"GPR6", "edi"},
+    {"FPR1", "xmm0"},
+    {"FPR2", "xmm1"},
+    {"FPR3", "xmm2"},
+    {"FPR4", "xmm3"},
+    {"FPR5", "xmm4"},
+    {"FPR6", "xmm5"},
+    {"FPR7", "xmm6"},
+    {"FPR8", "xmm7"},
+    {"", ""},
+};
+
+static RegisterMap Arguments[] = {
+    {"ARG1", "rdi"},
+    {"ARG2", "rsi"},
+    {"ARG3", "rdx"},
+    {"ARG4", "rcx"},
+    {"ARG5", "r8"},
+    {"ARG6", "r9"},
+    {"ARG7", "[BPTR+8]"},
+    {"ARG8", "[BPTR+12]"},
+    {"ARG9", "[BPTR+16]"},
+    {"ARG10", "[BPTR+20]"},
+    {"ARG11", "[BPTR+24]"},
+    {"ARG12", "[BPTR+28]"},
+    {"ARG13", "[BPTR+32]"},
+    {"ARG14", "[BPTR+36]"},
+    {"ARG15", "[BPTR+40]"},
+    {"ARG16", "[BPTR+44]"},
+    {"ARG17", "[BPTR+48]"},
+    {"ARG18", "[BPTR+52]"},
+    {"ARG19", "[BPTR+56]"},
+    {"ARG20", "[BPTR+60]"},
+    {"ARG21", "[BPTR+64]"},
+    {"ARG22", "[BPTR+68]"},
+    {"ARG23", "[BPTR+72]"},
+    {"ARG24", "[BPTR+76]"},
+    {"", ""},
+};
+
+static RegisterMap Sptr = {"SPTR", "esp"};
+static RegisterMap Bptr = {"BPTR", "ebp"};
+
+#endif

--- a/bench/includes/isa_x86.h
+++ b/bench/includes/isa_x86.h
@@ -1,3 +1,31 @@
+/*
+ * =======================================================================================
+ *      Filename:  isa_x86.h
+ *
+ *      Description:  Definitions used for dynamically compile benchmarks for x86 systems
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Gruber (tg), thomas.roehl@gmail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2019 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
 #ifndef LIKWID_BENCH_ISA_X86_H
 #define LIKWID_BENCH_ISA_X86_H
 
@@ -72,9 +100,9 @@ int footer(struct bstrList* code, char* funcname)
 
     bstrListAddChar(code, "\n");
 
-//    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
-//    bstrListAddChar(code, ".section .note.GNU-stack,"",%progbits");
-//    bstrListAddChar(code, "#endif");
+    bstrListAddChar(code, "#if defined(__linux__) && defined(__ELF__)");
+    bstrListAddChar(code, ".section .note.GNU-stack,\"\",%progbits");
+    bstrListAddChar(code, "#endif");
 
     bdestroy(line);
 }

--- a/bench/includes/ptt2asm.h
+++ b/bench/includes/ptt2asm.h
@@ -1,3 +1,31 @@
+/*
+ * =======================================================================================
+ *      Filename:  ptt2asm.h
+ *
+ *      Description:  The interface to dynamically load ptt files
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:  Thomas Gruber (tg), thomas.roehl@gmail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2019 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
 #ifndef LIKWID_BENCH_PTT2ASM_H
 #define LIKWID_BENCH_PTT2ASM_H
 
@@ -51,18 +79,10 @@ static RegisterMap StreamPatterns[] = {
     {"", ""},
 };
 
+struct bstrList* dynbench_getall();
 
-int registerMapLength(RegisterMap* map);
-int registerMapMaxPattern(RegisterMap* map);
-
-
-int ptt2asm(char* pttfile, TestCase **testcase, char* asmfile);
-void free_testcase(TestCase *testcase);
-struct bstrList* get_benchmarks();
-bstring get_user_path();
-bstring get_compiler();
-int compile_file(bstring compiler, bstring flags, bstring asmfile, bstring objfile);
-int open_function(bstring location, TestCase *testcase);
-void close_function(TestCase *testcase);
+int dynbench_test(bstring testname);
+int dynbench_load(bstring testname, TestCase **testcase, char* tmpfolder, char *compilers, char* compileflags);
+int dynbench_close(TestCase* testcase, char* tmpfolder);
 
 #endif

--- a/bench/includes/ptt2asm.h
+++ b/bench/includes/ptt2asm.h
@@ -1,0 +1,68 @@
+#ifndef LIKWID_BENCH_PTT2ASM_H
+#define LIKWID_BENCH_PTT2ASM_H
+
+typedef struct {
+    char* pattern;
+    char* reg;
+} RegisterMap;
+
+static RegisterMap StreamPatterns[] = {
+    {"STR0", "ARG2"},
+    {"STR1", "ARG3"},
+    {"STR2", "ARG4"},
+    {"STR3", "ARG5"},
+    {"STR4", "ARG6"},
+    {"STR5", "[rbp+16]"},
+    {"STR6", "[rbp+24]"},
+    {"STR7", "[rbp+32]"},
+    {"STR8", "[rbp+40]"},
+    {"STR9", "[rbp+48]"},
+    {"STR10", "[rbp+56]"},
+    {"STR11", "[rbp+64]"},
+    {"STR12", "[rbp+72]"},
+    {"STR13", "[rbp+80]"},
+    {"STR14", "[rbp+88]"},
+    {"STR15", "[rbp+96]"},
+    {"STR16", "[rbp+104]"},
+    {"STR17", "[rbp+112]"},
+    {"STR18", "[rbp+120]"},
+    {"STR19", "[rbp+128]"},
+    {"STR20", "[rbp+136]"},
+    {"STR21", "[rbp+144]"},
+    {"STR22", "[rbp+152]"},
+    {"STR23", "[rbp+160]"},
+    {"STR24", "[rbp+168]"},
+    {"STR25", "[rbp+176]"},
+    {"STR26", "[rbp+184]"},
+    {"STR27", "[rbp+192]"},
+    {"STR28", "[rbp+200]"},
+    {"STR29", "[rbp+208]"},
+    {"STR30", "[rbp+216]"},
+    {"STR31", "[rbp+224]"},
+    {"STR32", "[rbp+232]"},
+    {"STR33", "[rbp+240]"},
+    {"STR34", "[rbp+248]"},
+    {"STR35", "[rbp+256]"},
+    {"STR36", "[rbp+264]"},
+    {"STR37", "[rbp+272]"},
+    {"STR38", "[rbp+280]"},
+    {"STR39", "[rbp+288]"},
+    {"STR40", "[rbp+296]"},
+    {"", ""},
+};
+
+
+int registerMapLength(RegisterMap* map);
+int registerMapMaxPattern(RegisterMap* map);
+
+
+int ptt2asm(char* pttfile, TestCase **testcase, char* asmfile);
+void free_testcase(TestCase *testcase);
+struct bstrList* get_benchmarks();
+bstring get_user_path();
+bstring get_compiler();
+int compile_file(bstring compiler, bstring flags, bstring asmfile, bstring objfile);
+int open_function(bstring location, TestCase *testcase);
+void close_function(TestCase *testcase);
+
+#endif

--- a/bench/includes/test_types.h
+++ b/bench/includes/test_types.h
@@ -96,6 +96,8 @@ typedef struct {
     int instr_const;
     int instr_loop;
     int uops;
+    int loadstores;
+    void* dlhandle;
 } TestCase;
 
 typedef struct {

--- a/bench/src/bstrlib_helper.c
+++ b/bench/src/bstrlib_helper.c
@@ -1,0 +1,1 @@
+../../src/bstrlib_helper.c

--- a/bench/src/ptt2asm.c
+++ b/bench/src/ptt2asm.c
@@ -1,0 +1,630 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <errno.h>
+#include <libgen.h>
+#include <dirent.h>
+#include <dlfcn.h>
+
+#include <bstrlib.h>
+#include <bstrlib_helper.h>
+
+#include <test_types.h>
+
+
+#include <ptt2asm.h>
+
+#ifdef __x86_64
+#include <isa_x86-64.h>
+#endif
+#ifdef __i386__
+#include <isa_x86.h>
+#endif
+#ifdef __ARM_ARCH_7A__
+#include <isa_armv7.h>
+#endif
+#ifdef __ARM_ARCH_8A
+#include <isa_armv8.h>
+#endif
+#ifdef _ARCH_PPC
+#include <isa_ppc64.h>
+#endif
+
+static struct bstrList* read_ptt(char *pttfile)
+{
+    int ret = 0;
+    FILE* fp = NULL;
+    char buf[BUFSIZ];
+    struct bstrList* l = NULL;
+
+    if (access(pttfile, R_OK))
+    {
+        return NULL;
+    }
+
+    bstring content = bfromcstr("");
+    fp = fopen(pttfile, "r");
+    if (fp == NULL) {
+        fprintf(stderr, "fopen(%s): errno=%d\n", pttfile, errno);
+        return NULL;
+    }
+    for (;;) {
+        /* Read another chunk */
+        ret = fread(buf, 1, sizeof(buf), fp);
+        if (ret < 0) {
+            fprintf(stderr, "fread(%p, 1, %lu, %p): %d, errno=%d\n", buf, sizeof(buf), fp, ret, errno);
+            return NULL;
+        }
+        else if (ret == 0) {
+            break;
+        }
+        bcatblk(content, buf, ret);
+    }
+    btrimws(content);
+
+    l = bsplit(content, '\n');
+    for (int i = 0; i < l->qty; i++)
+    {
+        btrimws(l->entry[i]);
+    }
+
+    bdestroy(content);
+    return l;
+}
+
+static int write_asm(char* filename, struct bstrList* code)
+{
+    FILE* fp = NULL;
+    char newline = '\n';
+    size_t (*ownfwrite)(const void *ptr, size_t size, size_t nmemb, FILE *stream) = &fwrite;
+    fp = fopen(filename, "w");
+    if (fp)
+    {
+        for (int i = 0; i < code->qty; i++)
+        {
+            ownfwrite(bdata(code->entry[i]), 1, blength(code->entry[i]), fp);
+            ownfwrite(&newline, 1, sizeof(char), fp);
+        }
+        fclose(fp);
+        return 0;
+    }
+    return 1;
+}
+
+#define ANALYSE_PTT_GET_INT(line, pattern, variable) \
+    bstring tmp = bmidstr((line), blength((pattern))+1, blength((line))-blength((pattern))); \
+    btrimws(tmp); \
+    (variable) = ownatoi(bdata(tmp)); \
+    bdestroy(tmp); \
+
+static struct bstrList* analyse_ptt(char* pttfile, TestCase** testcase)
+{
+    struct bstrList* ptt = NULL;
+    TestCase* test = NULL;
+    struct bstrList* code = NULL;
+    bstring bBYTES = bformat("BYTES");
+    bstring bFLOPS = bformat("FLOPS");
+    bstring bSTREAMS = bformat("STREAMS");
+    bstring bTYPE = bformat("TYPE");
+    bstring bTYPEDOUBLE = bformat("DOUBLE");
+    bstring bTYPESINGLE = bformat("SINGLE");
+    bstring bTYPEINT = bformat("INT");
+    bstring bDESC = bformat("DESC");
+    bstring bLOADS = bformat("LOADS");
+    bstring bSTORES = bformat("STORES");
+    bstring bLOADSTORES = bformat("LOADSTORES");
+    bstring bINSTCONST = bformat("INSTR_CONST");
+    bstring bINSTLOOP = bformat("INSTR_LOOP");
+    bstring bUOPS = bformat("UOPS");
+    bstring bBRANCHES = bformat("BRANCHES");
+    bstring bLOOP = bformat("LOOP");
+    int (*ownatoi)(const char*) = &atoi;
+
+    ptt = read_ptt(pttfile);
+
+    if (ptt && ptt->qty > 0)
+    {
+        test = malloc(sizeof(TestCase));
+        if (test)
+        {
+            test->loads = -1;
+            test->stores = -1;
+            test->loadstores = -1;
+            test->branches = -1;
+            test->instr_const = -1;
+            test->instr_loop = -1;
+            test->uops = -1;
+            code = bstrListCreate();
+            for (int i = 0; i < ptt->qty; i++)
+            {
+                if (bstrncmp(ptt->entry[i], bBYTES, blength(bBYTES)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bBYTES, test->bytes);
+                }
+                else if (bstrncmp(ptt->entry[i], bFLOPS, blength(bFLOPS)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bFLOPS, test->flops);
+                }
+                else if (bstrncmp(ptt->entry[i], bSTREAMS, blength(bSTREAMS)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bSTREAMS, test->streams);
+                }
+                else if (bstrncmp(ptt->entry[i], bLOADS, blength(bLOADS)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bLOADS, test->loads);
+                }
+                else if (bstrncmp(ptt->entry[i], bSTORES, blength(bSTORES)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bSTORES, test->stores);
+                }
+                else if (bstrncmp(ptt->entry[i], bLOADSTORES, blength(bLOADSTORES)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bLOADSTORES, test->loadstores);
+                }
+                else if (bstrncmp(ptt->entry[i], bINSTCONST, blength(bINSTCONST)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bINSTCONST, test->instr_const);
+                }
+                else if (bstrncmp(ptt->entry[i], bINSTLOOP, blength(bINSTLOOP)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bINSTLOOP, test->instr_loop);
+                }
+                else if (bstrncmp(ptt->entry[i], bUOPS, blength(bUOPS)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bUOPS, test->uops);
+                }
+                else if (bstrncmp(ptt->entry[i], bBRANCHES, blength(bBRANCHES)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bBRANCHES, test->branches);
+                }
+                else if (bstrncmp(ptt->entry[i], bLOOP, blength(bLOOP)) == BSTR_OK)
+                {
+                    ANALYSE_PTT_GET_INT(ptt->entry[i], bLOOP, test->stride);
+                    bstrListAdd(code, ptt->entry[i]);
+                }
+                else if (bstrncmp(ptt->entry[i], bDESC, blength(bDESC)) == BSTR_OK)
+                {
+                    test->desc = malloc((blength(ptt->entry[i])+2)*sizeof(char));
+                    if (test->desc)
+                    {
+                        int ret = snprintf(test->desc, blength(ptt->entry[i])+1, "%s", bdataofs(ptt->entry[i], blength(bDESC)+1));
+                        if (ret > 0)
+                        {
+                            test->desc[ret] = '\0';
+                        }
+                    }
+                }
+                else if (bstrncmp(ptt->entry[i], bTYPE, blength(bTYPE)) == BSTR_OK)
+                {
+                    bstring btype = bmidstr(ptt->entry[i], blength(bTYPE)+1, blength(ptt->entry[i])-blength(bTYPE));
+                    btrimws(btype);
+                    if (bstrncmp(btype, bTYPEDOUBLE, blength(bTYPEDOUBLE)) == BSTR_OK)
+                    {
+                        test->type = DOUBLE;
+                    }
+                    else if (bstrncmp(btype, bTYPESINGLE, blength(bTYPESINGLE)) == BSTR_OK)
+                    {
+                        test->type = SINGLE;
+                    }
+                    else if (bstrncmp(btype, bTYPEINT, blength(bTYPEINT)) == BSTR_OK)
+                    {
+                        test->type = INT;
+                    }
+                    else
+                    {
+                        fprintf(stderr, "Failed to determine type of benchmark\n");
+                        bdestroy(btype);
+                        bstrListDestroy(code);
+                        free(test);
+                        test = NULL;
+                        code = NULL;
+                        break;
+                    }
+                    bdestroy(btype);
+                }
+                else
+                {
+                    bstrListAdd(code, ptt->entry[i]);
+                }
+            }
+            *testcase = test;
+        }
+        bstrListDestroy(ptt);
+    }
+
+    bdestroy(bBYTES);
+    bdestroy(bFLOPS);
+    bdestroy(bSTREAMS);
+    bdestroy(bTYPE);
+    bdestroy(bTYPEDOUBLE);
+    bdestroy(bTYPESINGLE);
+    bdestroy(bTYPEINT);
+    bdestroy(bDESC);
+    bdestroy(bLOADS);
+    bdestroy(bSTORES);
+    bdestroy(bLOADSTORES);
+    bdestroy(bINSTCONST);
+    bdestroy(bINSTLOOP);
+    bdestroy(bUOPS);
+    bdestroy(bBRANCHES);
+    bdestroy(bLOOP);
+    return code;
+}
+
+static int set_testname(char *pttfile, TestCase* testcase)
+{
+    if ((!testcase)||(!pttfile))
+    {
+        return -EINVAL;
+    }
+    bstring ptt = bfromcstr(basename(pttfile));
+    int dot = bstrrchrp(ptt, '.', blength(ptt)-1);
+    btrunc(ptt, dot);
+    testcase->name = malloc((blength(ptt)+2) * sizeof(char));
+    int ret = snprintf(testcase->name, blength(ptt)+1, "%s", bdata(ptt));
+    if (ret > 0)
+    {
+        testcase->name[ret] = '\0';
+    }
+    bdestroy(ptt);
+    return 0;
+}
+
+
+static struct bstrList* parse_asm(TestCase* testcase, struct bstrList* input)
+{
+    struct bstrList* output = NULL;
+    if (testcase && input)
+    {
+
+        struct bstrList* pre = bstrListCreate();
+        struct bstrList* loop = bstrListCreate();
+        int got_loop = 0;
+        bstring bLOOP = bformat("LOOP");
+        int step = testcase->stride;
+
+        for (int i = 0; i < input->qty; i++)
+        {
+            if (bstrncmp(input->entry[i], bLOOP, blength(bLOOP)) == BSTR_OK)
+            {
+                got_loop = 1;
+                continue;
+            }
+            if (!got_loop)
+            {
+                bstrListAdd(pre, input->entry[i]);
+            }
+            else
+            {
+                bstrListAdd(loop, input->entry[i]);
+            }
+        }
+        bdestroy(bLOOP);
+
+        output = bstrListCreate();
+
+        header(output, testcase->name);
+
+        for (int i = 0; i < pre->qty; i++)
+        {
+            bstrListAdd(output, pre->entry[i]);
+        }
+        loopheader(output, "1", step);
+        for (int i = 0; i < loop->qty; i++)
+        {
+            bstrListAdd(output, loop->entry[i]);
+        }
+        loopfooter(output, "1", step);
+
+        footer(output, testcase->name);
+
+        bstrListDestroy(pre);
+        bstrListDestroy(loop);
+    }
+    return output;
+}
+
+static int searchreplace(bstring line, RegisterMap* map)
+{
+    int maxlen = registerMapMaxPattern(map);
+    int size = registerMapLength(map);
+    for (int s = maxlen; s>= 1; s--)
+    {
+        int c = 0;
+        for (int j = 0; j < size; j++)
+        {
+            if (strlen(map[j].pattern) == s)
+            {
+                bstring pat = bfromcstr(map[j].pattern);
+                bstring reg = bfromcstr(map[j].reg);
+                bfindreplace(line, pat, reg, 0);
+                bdestroy(pat);
+                bdestroy(reg);
+                c++;
+            }
+        }
+        if (c == 0)
+        {
+            break;
+        }
+    }
+    return 0;
+}
+
+static int prepare_code(struct bstrList* code)
+{
+    if (code)
+    {
+        for (int i = 0; i < code->qty; i++)
+        {
+            searchreplace(code->entry[i], StreamPatterns);
+        }
+        for (int i = 0; i < code->qty; i++)
+        {
+            searchreplace(code->entry[i], Registers);
+        }
+        for (int i = 0; i < code->qty; i++)
+        {
+            searchreplace(code->entry[i], Arguments);
+        }
+        for (int i = 0; i < code->qty; i++)
+        {
+            bstring pat = bfromcstr(Sptr.pattern);
+            bstring reg = bfromcstr(Sptr.reg);
+            bfindreplace(code->entry[i], pat, reg, 0);
+            bdestroy(pat);
+            bdestroy(reg);
+        }
+        for (int i = 0; i < code->qty; i++)
+        {
+            bstring pat = bfromcstr(Bptr.pattern);
+            bstring reg = bfromcstr(Bptr.reg);
+            bfindreplace(code->entry[i], pat, reg, 0);
+            bdestroy(pat);
+            bdestroy(reg);
+        }
+    }
+    return 0;
+}
+
+static void print_testcase(TestCase* test)
+{
+    printf("Name: %s\n", test->name);
+    printf("Desc: %s\n", test->desc);
+    printf("Bytes: %d\n", test->bytes);
+    printf("Flops: %d\n", test->flops);
+    printf("Type: %d\n", test->type);
+    printf("Loads: %d\n", test->loads);
+}
+
+
+
+void free_testcase(TestCase *testcase)
+{
+    if (testcase)
+    {
+        free(testcase->name);
+        free(testcase->desc);
+        free(testcase);
+    }
+}
+
+struct bstrList* get_benchmarks()
+{
+    int totalgroups = 0;
+    struct bstrList* list = NULL;
+    DIR *dp = NULL;
+    struct dirent *ep = NULL;
+    DIR * (*ownopendir)(const char* folder) = &opendir;
+    int (*ownaccess)(const char*, int) = &access;
+
+    bstring path = bformat("%s/.likwid/bench/%s", getenv("HOME"), ARCHNAME);
+
+    if (!ownaccess(bdata(path), R_OK|X_OK))
+    {
+        dp = ownopendir(bdata(path));
+        if (dp != NULL)
+        {
+            list = bstrListCreate();
+            while (ep = readdir(dp))
+            {
+                if (strncmp(&(ep->d_name[strlen(ep->d_name)-4]), ".ptt", 4) == 0)
+                {
+                    totalgroups++;
+                    bstring dname = bfromcstr(ep->d_name);
+                    btrunc(dname, blength(dname)-4);
+                    bstrListAdd(list, dname);
+                    bdestroy(dname);
+                }
+            }
+            closedir(dp);
+        }
+    }
+    bdestroy(path);
+    return list;
+}
+
+bstring get_user_path()
+{
+    return bformat("%s/.likwid/bench/%s", getenv("HOME"), ARCHNAME);
+}
+
+bstring get_compiler()
+{
+    bstring path = bfromcstr(getenv("PATH"));
+    struct bstrList *plist = NULL;
+    int (*ownaccess)(const char*, int) = access;
+
+    plist = bsplit(path, ':');
+
+    for (int i = 0; i < plist->qty; i++)
+    {
+        bstring tmp = bformat("%s/gcc", bdata(plist->entry[i]));
+        if (!ownaccess(bdata(tmp), R_OK|X_OK))
+        {
+            bdestroy(path);
+            bstrListDestroy(plist);
+            return tmp;
+        }
+        bdestroy(tmp);
+        tmp = bformat("%s/icc", bdata(plist->entry[i]));
+        if (!ownaccess(bdata(tmp), R_OK|X_OK))
+        {
+            bdestroy(path);
+            bstrListDestroy(plist);
+            return tmp;
+        }
+        bdestroy(tmp);
+        tmp = bformat("%s/pgcc", bdata(plist->entry[i]));
+        if (!ownaccess(bdata(tmp), R_OK|X_OK))
+        {
+            bdestroy(path);
+            bstrListDestroy(plist);
+            return tmp;
+        }
+        bdestroy(tmp);
+    }
+    bdestroy(path);
+    bstrListDestroy(plist);
+    return bfromcstr("");
+}
+
+int compile_file(bstring compiler, bstring flags, bstring asmfile, bstring objfile)
+{
+    if (blength(compiler) == 0 || blength(asmfile) == 0)
+        return -1;
+    char buf[1024];
+    bstring bstdout = bfromcstr("");
+
+
+/*    bcatcstr(outfile, basename(bdata(file)));*/
+/*    btrunc(outfile, blength(outfile)-1);*/
+/*    bconchar(outfile, 'o');*/
+/*    binsert(outfile, 0, outfolder, '\0');*/
+
+    bstring cmd = bformat("%s %s %s -o %s", bdata(compiler), bdata(flags), bdata(asmfile), bdata(objfile));
+
+    FILE * fp = popen(bdata(cmd), "r");
+    if (fp)
+    {
+        for (;;) {
+            /* Read another chunk */
+            int ret = fread(buf, 1, sizeof(buf), fp);
+            if (ret < 0) {
+                fprintf(stderr, "fread(%p, 1, %lu, %p): %d, errno=%d\n", buf, sizeof(buf), fp, ret, errno);
+                bdestroy(cmd);
+                bdestroy(bstdout);
+                return -1;
+            }
+            else if (ret == 0) {
+                break;
+            }
+            bcatblk(bstdout, buf, ret);
+        }
+        pclose(fp);
+    }
+    bdestroy(cmd);
+    bdestroy(bstdout);
+
+    return 0;
+}
+
+
+int open_function(bstring location, TestCase *testcase)
+{
+    void* handle;
+    char *error;
+    FuncPrototype func = NULL;
+    void* (*owndlsym)(void*, const char*) = dlsym;
+
+    dlerror();
+    testcase->dlhandle = dlopen(bdata(location), RTLD_LAZY);
+    if (!testcase->dlhandle) {
+        fprintf(stderr, "Error opening location %s: %s\n", bdata(location), dlerror());
+        return -1;
+    }
+    dlerror();
+    testcase->kernel = owndlsym(testcase->dlhandle, testcase->name);
+    if ((error = dlerror()) != NULL)  {
+        dlclose(testcase->dlhandle);
+        fprintf(stderr, "Error opening function %s: %s\n", testcase->name, error);
+        return -1;
+    }
+    dlerror();
+
+    return 0;
+}
+
+void close_function(TestCase *testcase)
+{
+    if (testcase)
+    {
+        dlclose(testcase->dlhandle);
+        testcase->dlhandle = NULL;
+        testcase->kernel = NULL;
+    }
+}
+
+int ptt2asm(char* pttfile, TestCase **testcase, char* asmfile)
+{
+    int err = 0;
+    TestCase *test = NULL;
+    struct bstrList* code = analyse_ptt(pttfile, &test);
+    if (code)
+    {
+        set_testname(pttfile, test);
+        if (asmfile)
+        {
+            struct bstrList* asmb = parse_asm(test, code);
+            prepare_code(asmb);
+            write_asm(asmfile, asmb);
+            bstrListDestroy(asmb);
+        }
+    }
+    else
+    {
+        err = 1;
+    }
+    bstrListDestroy(code);
+    *testcase = test;
+    return err;
+}
+
+
+int registerMapLength(RegisterMap* map)
+{
+    int i = 0;
+    while (strlen(map[i].pattern) > 0)
+    {
+        i++;
+    }
+    return i;
+}
+
+int registerMapMaxPattern(RegisterMap* map)
+{
+    int i = 0;
+    int max = 0;
+    while (strlen(map[i].pattern) > 0)
+    {
+        if (strlen(map[i].pattern) > max)
+            max = strlen(map[i].pattern);
+        i++;
+    }
+    return max;
+}
+
+/*int main()*/
+/*{*/
+/*    TestCase *testcase;*/
+/*    ptt2asm("x86-64/load.ptt", &testcase, "load.s");*/
+/*    free_testcase(testcase);*/
+
+/*    struct bstrList* l = get_benchmarks();*/
+/*    if (l)*/
+/*    {*/
+/*        for (int i = 0; i < l->qty; i++)*/
+/*            printf("%s\n", bdata(l->entry[i]));*/
+/*    }*/
+/*}*/

--- a/bench/src/ptt2asm.c
+++ b/bench/src/ptt2asm.c
@@ -459,11 +459,11 @@ struct bstrList* dynbench_getall()
         dp = ownopendir(bdata(path));
         if (dp != NULL)
         {
-            list = bstrListCreate();
             while (ep = readdir(dp))
             {
                 if (strncmp(&(ep->d_name[strlen(ep->d_name)-4]), ".ptt", 4) == 0)
                 {
+                    if (!list) list = bstrListCreate();
                     totalgroups++;
                     bstring dname = bfromcstr(ep->d_name);
                     btrunc(dname, blength(dname)-4);

--- a/doc/likwid-bench.1
+++ b/doc/likwid-bench.1
@@ -19,6 +19,8 @@ likwid-bench \- low-level benchmark suite and microbenchmarking framework
 .IR <delimiter> ]
 .RB [ \-i
 .IR <iterations> ]
+.RB [ \-f
+.IR <filepath> ]
 .SH DESCRIPTION
 .B likwid-bench
 is a benchmark suite for low-level (assembly) benchmarks to measure bandwidths and instruction throughput for specific instruction code on x86 systems. The currently included benchmark codes include common data access patterns like load and store but also calculations like vector triad and sum.
@@ -31,7 +33,7 @@ as a wrapper to
 .B likwid-bench.
 This requires to build
 .B likwid-bench
-with instrumentation enabled in config.mk.
+with instrumentation enabled in config.mk. Benchmarks can be dynamically added when a proper ptt file is present at $HOME/.likwid/bench/<arch>/<testname>.ptt . The files are compiled to a .S file and compiled using either gcc, icc or pgcc (searched in $PATH). The default folder is /tmp/<PID>.
 .SH OPTIONS
 .TP
 .B \-\^h
@@ -62,6 +64,9 @@ list properties of a benchmark code.
 .TP
 .B \-\^i <iterations>
 Set the number of iterations per thread (optional)
+.TP
+.B \-\^f <filepath>
+Filepath for the dynamic generation of benchmarks. Default /tmp/. <PID> is always attached
 
 .SH WORKGROUP SYNTAX
 
@@ -103,7 +108,7 @@ benchmark on socket 0 (
 .TP
 .B likwid-bench -t copy -w S0:100kB
 .PP
-Since no 
+Since no
 .B <num_threads>
 is given in the workload expression, each core of socket 0 gets one thread. The workload is split up between all threads and the number of iterations is determined automatically.
 .IP 2. 4

--- a/src/bstrlib_helper.c
+++ b/src/bstrlib_helper.c
@@ -1,11 +1,35 @@
-
+/*
+ * =======================================================================================
+ *
+ *      Filename:  bstrlib_helper.c
+ *
+ *      Description:  Additional functions to the bstrlib library
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Roehl (tr), thomas.roehl@googlemail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2019 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
 
 #include <stdio.h>
 #include <stdlib.h>
-
-
-//#include <unistd.h>
-//#include <string.h>
 
 #include <bstrlib.h>
 #include <errno.h>
@@ -16,7 +40,7 @@ int bstrListAdd(struct bstrList * sl, bstring str)
 	if (sl->qty >= sl->mlen) {
         int mlen = sl->mlen * 2;
         bstring * tbl;
-    
+
 
 	    while (sl->qty >= mlen) {
 	        if (mlen < sl->mlen) return BSTR_ERR;

--- a/src/includes/bstrlib_helper.h
+++ b/src/includes/bstrlib_helper.h
@@ -1,3 +1,33 @@
+/*
+ * =======================================================================================
+ *
+ *      Filename:  bstrlib_helper.h
+ *
+ *      Description:  Additional functions to the bstrlib library (header file)
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Roehl (tr), thomas.roehl@googlemail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2019 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
+
 #ifndef BSTRLIB_HELPER_INCLUDE
 #define BSTRLIB_HELPER_INCLUDE
 


### PR DESCRIPTION
This PR allows the addition of benchmark kernels to likwid-bench without recompilation. likwid-bench searches in $HOME/.likwid/bench/<arch> for PTT files, converts them the arch-specific assembly and compiles the file.