### PR TITLE
Add support for generic event

### DIFF
--- a/src/includes/perfmon_types.h
+++ b/src/includes/perfmon_types.h
@@ -83,6 +83,8 @@ typedef enum {
     EVENT_OPTION_PERF_PID, /*!< \brief PID parameter to use in the perf_event_open call */
     EVENT_OPTION_PERF_FLAGS, /*!< \brief FLAGS parameters to use in the perf_event_open call */
 #endif
+    EVENT_OPTION_GENERIC_CONFIG, /*!< \brief Configuration bitmask for generic event */
+    EVENT_OPTION_GENERIC_UMASK, /*!< \brief Umask bitmask for generic event */
     NUM_EVENT_OPTIONS /*!< \brief Amount of defined options */
 } EventOptionType;
 
@@ -135,6 +137,8 @@ extern char* eventOptionTypeName[NUM_EVENT_OPTIONS];
 #define EVENT_OPTION_OCCUPANCY_INVERT_MASK (1ULL<<EVENT_OPTION_OCCUPANCY_INVERT)
 #define EVENT_OPTION_IN_TRANS_MASK (1ULL<<EVENT_OPTION_IN_TRANS)
 #define EVENT_OPTION_IN_TRANS_ABORT_MASK (1ULL<<EVENT_OPTION_IN_TRANS_ABORT)
+#define EVENT_OPTION_GENERIC_CONFIG_MASK (1ULL<<EVENT_OPTION_GENERIC_CONFIG)
+#define EVENT_OPTION_GENERIC_UMASK_MASK (1ULL<<EVENT_OPTION_GENERIC_UMASK)
 /** @endcond */
 
 /*! \brief Structure specifying thread to CPU relation
@@ -168,7 +172,7 @@ the event options are hold here.
 */
 typedef struct {
     const char*     name; /*!< \brief Name of the event */
-    const char*     limit; /*!< \brief Valid counters for the event */
+    char*           limit; /*!< \brief Valid counters for the event */
     uint16_t        eventId; /*!< \brief ID of the event */
     uint8_t         umask; /*!< \brief Most events need to specify a mask to limit counting */
     uint8_t         cfgBits; /*!< \brief Misc configuration bits */


### PR DESCRIPTION
Issue #57 

This adds an event GENERIC_EVENT that can be used with all counters like:
GENERIC_EVENT:<counter>:CONFIG=0x00:UMASK=0x00 (:other options available for the counter)

