### PR TITLE
Fixed likwid-markers.h -> likwid-marker.h in likwid.h

### DIFF
--- a/src/includes/likwid.h
+++ b/src/includes/likwid.h
@@ -53,7 +53,7 @@ extern "C" {
 #endif
 
 #ifndef LIKWID_MARKER_INIT
-#include <likwid-markers.h>
+#include <likwid-marker.h>
 #endif
 
 /*


### PR DESCRIPTION
## Typo here
```c++
#ifndef LIKWID_MARKER_INIT
#include <likwid-markers.h>
#endif
```
## Changed to
```c++
#ifndef LIKWID_MARKER_INIT
#include <likwid-marker.h>
#endif
```
