### PR TITLE
likwid-bench: improve peakflops micro benchmark

### DIFF
--- a/bench/x86-64/peakflops.ptt
+++ b/bench/x86-64/peakflops.ptt
@@ -2,6 +2,12 @@ STREAMS 1
 TYPE DOUBLE
 FLOPS 8
 BYTES 8
+DESC Double-precision multiplications and additions with a single load, only scalar operations
+LOADS 1
+STORES 0
+INSTR_CONST 18
+INSTR_LOOP 12
+UOPS 11
 movaps FPR1, [rip+SCALAR]
 movaps FPR2, [rip+SCALAR]
 LOOP 1

--- a/bench/x86-64/peakflops.ptt
+++ b/bench/x86-64/peakflops.ptt
@@ -1,24 +1,45 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 8
+FLOPS 16
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, only scalar operations
 LOADS 1
 STORES 0
-INSTR_CONST 18
-INSTR_LOOP 12
-UOPS 11
+INSTR_CONST 32
+INSTR_LOOP 20
+UOPS 19
 movaps FPR1, [rip+SCALAR]
 movaps FPR2, [rip+SCALAR]
+movaps FPR3, [rip+SCALAR]
+movaps FPR4, [rip+SCALAR]
+movaps FPR5, [rip+SCALAR]
+movaps FPR6, [rip+SCALAR]
+movaps FPR7, [rip+SCALAR]
+movaps FPR8, [rip+SCALAR]
+movaps FPR9, [rip+SCALAR]
+movaps FPR10, [rip+SCALAR]
+movaps FPR11, [rip+SCALAR]
+movaps FPR12, [rip+SCALAR]
+movaps FPR13, [rip+SCALAR]
+movaps FPR14, [rip+SCALAR]
+movaps FPR15, [rip+SCALAR]
+movaps FPR16, [rip+SCALAR]
+.align 32
 LOOP 1
 movsd    FPR2, [STR0 + GPR1 * 8 ]
-addsd     FPR3, FPR2
-addsd     FPR4, FPR2
-addsd     FPR5, FPR2
-mulsd     FPR6, FPR2
-mulsd     FPR7, FPR2
-mulsd     FPR8, FPR2
-mulsd     FPR9, FPR2
-mulsd     FPR10, FPR2
-
-
+addsd     FPR1, FPR2
+addsd     FPR3, FPR4
+mulsd     FPR5, FPR6
+mulsd     FPR7, FPR8
+mulsd     FPR9, FPR10
+addsd     FPR11, FPR12
+addsd     FPR13, FPR14
+mulsd     FPR15, FPR16
+addsd     FPR1, FPR2
+addsd     FPR3, FPR4
+mulsd     FPR5, FPR6
+mulsd     FPR7, FPR8
+mulsd     FPR9, FPR10
+addsd     FPR11, FPR12
+addsd     FPR13, FPR14
+mulsd     FPR15, FPR16

--- a/bench/x86-64/peakflops_avx.ptt
+++ b/bench/x86-64/peakflops_avx.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 12
+FLOPS 15
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for AVX
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovapd ymm0, [rip+SCALAR]
 vmovapd ymm1, [rip+SCALAR]
 vmovapd ymm2, [rip+SCALAR]
 vmovapd ymm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovapd ymm10, [rip+SCALAR]
 vmovapd ymm11, [rip+SCALAR]
 vmovapd ymm12, [rip+SCALAR]
 vmovapd ymm13, [rip+SCALAR]
+vmovapd ymm14, [rip+SCALAR]
+vmovapd ymm15, [rip+SCALAR]
 .align 32
 LOOP 4
 vmovapd    ymm1, [STR0 + GPR1 * 8 ]
+vmulpd     ymm0, ymm0, ymm1
 vaddpd     ymm2, ymm2, ymm1
 vmulpd     ymm3, ymm3, ymm1
 vaddpd     ymm4, ymm4, ymm1
@@ -36,3 +40,5 @@ vaddpd     ymm10, ymm10, ymm1
 vmulpd     ymm11, ymm11, ymm1
 vaddpd     ymm12, ymm12, ymm1
 vmulpd     ymm13, ymm13, ymm1
+vaddpd     ymm14, ymm14, ymm1
+vmulpd     ymm15, ymm15, ymm1

--- a/bench/x86-64/peakflops_avx.ptt
+++ b/bench/x86-64/peakflops_avx.ptt
@@ -2,6 +2,12 @@ STREAMS 1
 TYPE DOUBLE
 FLOPS 12
 BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for AVX
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
 vmovapd ymm1, [rip+SCALAR]
 vmovapd ymm2, [rip+SCALAR]
 vmovapd ymm3, [rip+SCALAR]

--- a/bench/x86-64/peakflops_avx512.ptt
+++ b/bench/x86-64/peakflops_avx512.ptt
@@ -1,0 +1,32 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 12
+BYTES 8
+vmovapd zmm1, [rip+SCALAR]
+vmovapd zmm2, [rip+SCALAR]
+vmovapd zmm3, [rip+SCALAR]
+vmovapd zmm4, [rip+SCALAR]
+vmovapd zmm5, [rip+SCALAR]
+vmovapd zmm6, [rip+SCALAR]
+vmovapd zmm7, [rip+SCALAR]
+vmovapd zmm8, [rip+SCALAR]
+vmovapd zmm9, [rip+SCALAR]
+vmovapd zmm10, [rip+SCALAR]
+vmovapd zmm11, [rip+SCALAR]
+vmovapd zmm12, [rip+SCALAR]
+vmovapd zmm13, [rip+SCALAR]
+.align 32
+LOOP 8
+vmovapd    zmm1, [STR0 + GPR1 * 8 ]
+vaddpd     zmm2, zmm2, zmm1
+vmulpd     zmm3, zmm3, zmm1
+vaddpd     zmm4, zmm4, zmm1
+vmulpd     zmm5, zmm5, zmm1
+vaddpd     zmm6, zmm6, zmm1
+vmulpd     zmm7, zmm7, zmm1
+vaddpd     zmm8, zmm8, zmm1
+vmulpd     zmm9, zmm9, zmm1
+vaddpd     zmm10, zmm10, zmm1
+vmulpd     zmm11, zmm11, zmm1
+vaddpd     zmm12, zmm12, zmm1
+vmulpd     zmm13, zmm13, zmm1

--- a/bench/x86-64/peakflops_avx512.ptt
+++ b/bench/x86-64/peakflops_avx512.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 12
+FLOPS 15
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for AVX-512
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovapd zmm0, [rip+SCALAR]
 vmovapd zmm1, [rip+SCALAR]
 vmovapd zmm2, [rip+SCALAR]
 vmovapd zmm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovapd zmm10, [rip+SCALAR]
 vmovapd zmm11, [rip+SCALAR]
 vmovapd zmm12, [rip+SCALAR]
 vmovapd zmm13, [rip+SCALAR]
+vmovapd zmm14, [rip+SCALAR]
+vmovapd zmm15, [rip+SCALAR]
 .align 32
 LOOP 8
 vmovapd    zmm1, [STR0 + GPR1 * 8 ]
+vmulpd     zmm0, zmm0, zmm1
 vaddpd     zmm2, zmm2, zmm1
 vmulpd     zmm3, zmm3, zmm1
 vaddpd     zmm4, zmm4, zmm1
@@ -36,3 +40,5 @@ vaddpd     zmm10, zmm10, zmm1
 vmulpd     zmm11, zmm11, zmm1
 vaddpd     zmm12, zmm12, zmm1
 vmulpd     zmm13, zmm13, zmm1
+vaddpd     zmm14, zmm14, zmm1
+vmulpd     zmm15, zmm15, zmm1

--- a/bench/x86-64/peakflops_avx512.ptt
+++ b/bench/x86-64/peakflops_avx512.ptt
@@ -2,6 +2,12 @@ STREAMS 1
 TYPE DOUBLE
 FLOPS 12
 BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for AVX-512
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
 vmovapd zmm1, [rip+SCALAR]
 vmovapd zmm2, [rip+SCALAR]
 vmovapd zmm3, [rip+SCALAR]

--- a/bench/x86-64/peakflops_avx512_fma.ptt
+++ b/bench/x86-64/peakflops_avx512_fma.ptt
@@ -1,0 +1,32 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 24
+BYTES 8
+vmovapd zmm1, [rip+SCALAR]
+vmovapd zmm2, [rip+SCALAR]
+vmovapd zmm3, [rip+SCALAR]
+vmovapd zmm4, [rip+SCALAR]
+vmovapd zmm5, [rip+SCALAR]
+vmovapd zmm6, [rip+SCALAR]
+vmovapd zmm7, [rip+SCALAR]
+vmovapd zmm8, [rip+SCALAR]
+vmovapd zmm9, [rip+SCALAR]
+vmovapd zmm10, [rip+SCALAR]
+vmovapd zmm11, [rip+SCALAR]
+vmovapd zmm12, [rip+SCALAR]
+vmovapd zmm13, [rip+SCALAR]
+.align 32
+LOOP 8
+vmovapd    zmm1, [STR0 + GPR1 * 8 ]
+vfmadd213pd     zmm2, zmm2, zmm1
+vfmadd213pd     zmm3, zmm3, zmm1
+vfmadd213pd     zmm4, zmm4, zmm1
+vfmadd213pd     zmm5, zmm5, zmm1
+vfmadd213pd     zmm6, zmm6, zmm1
+vfmadd213pd     zmm7, zmm7, zmm1
+vfmadd213pd     zmm8, zmm8, zmm1
+vfmadd213pd     zmm9, zmm9, zmm1
+vfmadd213pd     zmm10, zmm10, zmm1
+vfmadd213pd     zmm11, zmm11, zmm1
+vfmadd213pd     zmm12, zmm12, zmm1
+vfmadd213pd     zmm13, zmm13, zmm1

--- a/bench/x86-64/peakflops_avx512_fma.ptt
+++ b/bench/x86-64/peakflops_avx512_fma.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 24
+FLOPS 30
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for AVX-512 FMAs
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovapd zmm0, [rip+SCALAR]
 vmovapd zmm1, [rip+SCALAR]
 vmovapd zmm2, [rip+SCALAR]
 vmovapd zmm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovapd zmm10, [rip+SCALAR]
 vmovapd zmm11, [rip+SCALAR]
 vmovapd zmm12, [rip+SCALAR]
 vmovapd zmm13, [rip+SCALAR]
+vmovapd zmm14, [rip+SCALAR]
+vmovapd zmm15, [rip+SCALAR]
 .align 32
 LOOP 8
 vmovapd    zmm1, [STR0 + GPR1 * 8 ]
+vfmadd213pd     zmm0, zmm0, zmm1
 vfmadd213pd     zmm2, zmm2, zmm1
 vfmadd213pd     zmm3, zmm3, zmm1
 vfmadd213pd     zmm4, zmm4, zmm1
@@ -36,3 +40,5 @@ vfmadd213pd     zmm10, zmm10, zmm1
 vfmadd213pd     zmm11, zmm11, zmm1
 vfmadd213pd     zmm12, zmm12, zmm1
 vfmadd213pd     zmm13, zmm13, zmm1
+vfmadd213pd     zmm14, zmm14, zmm1
+vfmadd213pd     zmm15, zmm15, zmm1

--- a/bench/x86-64/peakflops_avx512_fma.ptt
+++ b/bench/x86-64/peakflops_avx512_fma.ptt
@@ -2,6 +2,12 @@ STREAMS 1
 TYPE DOUBLE
 FLOPS 24
 BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for AVX-512 FMAs
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
 vmovapd zmm1, [rip+SCALAR]
 vmovapd zmm2, [rip+SCALAR]
 vmovapd zmm3, [rip+SCALAR]

--- a/bench/x86-64/peakflops_avx_fma.ptt
+++ b/bench/x86-64/peakflops_avx_fma.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 24
+FLOPS 30
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for AVX FMAs
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovapd ymm0, [rip+SCALAR]
 vmovapd ymm1, [rip+SCALAR]
 vmovapd ymm2, [rip+SCALAR]
 vmovapd ymm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovapd ymm10, [rip+SCALAR]
 vmovapd ymm11, [rip+SCALAR]
 vmovapd ymm12, [rip+SCALAR]
 vmovapd ymm13, [rip+SCALAR]
+vmovapd ymm14, [rip+SCALAR]
+vmovapd ymm15, [rip+SCALAR]
 .align 32
 LOOP 4
 vmovapd    ymm1, [STR0 + GPR1 * 8 ]
+vfmadd213pd     ymm0, ymm0, ymm1
 vfmadd213pd     ymm2, ymm2, ymm1
 vfmadd213pd     ymm3, ymm3, ymm1
 vfmadd213pd     ymm4, ymm4, ymm1
@@ -36,3 +40,5 @@ vfmadd213pd     ymm10, ymm10, ymm1
 vfmadd213pd     ymm11, ymm11, ymm1
 vfmadd213pd     ymm12, ymm12, ymm1
 vfmadd213pd     ymm13, ymm13, ymm1
+vfmadd213pd     ymm14, ymm14, ymm1
+vfmadd213pd     ymm15, ymm15, ymm1

--- a/bench/x86-64/peakflops_avx_fma.ptt
+++ b/bench/x86-64/peakflops_avx_fma.ptt
@@ -2,6 +2,12 @@ STREAMS 1
 TYPE DOUBLE
 FLOPS 24
 BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for AVX FMAs
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
 vmovapd ymm1, [rip+SCALAR]
 vmovapd ymm2, [rip+SCALAR]
 vmovapd ymm3, [rip+SCALAR]

--- a/bench/x86-64/peakflops_avx_fma.ptt
+++ b/bench/x86-64/peakflops_avx_fma.ptt
@@ -1,6 +1,6 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 12
+FLOPS 24
 BYTES 8
 vmovapd ymm1, [rip+SCALAR]
 vmovapd ymm2, [rip+SCALAR]
@@ -18,15 +18,15 @@ vmovapd ymm13, [rip+SCALAR]
 .align 32
 LOOP 4
 vmovapd    ymm1, [STR0 + GPR1 * 8 ]
-vaddpd     ymm2, ymm2, ymm1
-vmulpd     ymm3, ymm3, ymm1
-vaddpd     ymm4, ymm4, ymm1
-vmulpd     ymm5, ymm5, ymm1
-vaddpd     ymm6, ymm6, ymm1
-vmulpd     ymm7, ymm7, ymm1
-vaddpd     ymm8, ymm8, ymm1
-vmulpd     ymm9, ymm9, ymm1
-vaddpd     ymm10, ymm10, ymm1
-vmulpd     ymm11, ymm11, ymm1
-vaddpd     ymm12, ymm12, ymm1
-vmulpd     ymm13, ymm13, ymm1
+vfmadd213pd     ymm2, ymm2, ymm1
+vfmadd213pd     ymm3, ymm3, ymm1
+vfmadd213pd     ymm4, ymm4, ymm1
+vfmadd213pd     ymm5, ymm5, ymm1
+vfmadd213pd     ymm6, ymm6, ymm1
+vfmadd213pd     ymm7, ymm7, ymm1
+vfmadd213pd     ymm8, ymm8, ymm1
+vfmadd213pd     ymm9, ymm9, ymm1
+vfmadd213pd     ymm10, ymm10, ymm1
+vfmadd213pd     ymm11, ymm11, ymm1
+vfmadd213pd     ymm12, ymm12, ymm1
+vfmadd213pd     ymm13, ymm13, ymm1

--- a/bench/x86-64/peakflops_sp.ptt
+++ b/bench/x86-64/peakflops_sp.ptt
@@ -1,24 +1,45 @@
 STREAMS 1
 TYPE SINGLE
-FLOPS 8
+FLOPS 16
 BYTES 4
 DESC Single-precision multiplications and additions with a single load, only scalar operations
 LOADS 1
 STORES 0
-INSTR_CONST 18
-INSTR_LOOP 12
-UOPS 11
+INSTR_CONST 32
+INSTR_LOOP 20
+UOPS 19
 movaps FPR1, [rip+SCALAR]
 movaps FPR2, [rip+SCALAR]
+movaps FPR3, [rip+SCALAR]
+movaps FPR4, [rip+SCALAR]
+movaps FPR5, [rip+SCALAR]
+movaps FPR6, [rip+SCALAR]
+movaps FPR7, [rip+SCALAR]
+movaps FPR8, [rip+SCALAR]
+movaps FPR9, [rip+SCALAR]
+movaps FPR10, [rip+SCALAR]
+movaps FPR11, [rip+SCALAR]
+movaps FPR12, [rip+SCALAR]
+movaps FPR13, [rip+SCALAR]
+movaps FPR14, [rip+SCALAR]
+movaps FPR15, [rip+SCALAR]
+movaps FPR16, [rip+SCALAR]
+.align 32
 LOOP 1
 movss    FPR2, [STR0 + GPR1 * 4 ]
-addss     FPR3, FPR2
-addss     FPR4, FPR2
-addss     FPR5, FPR2
-mulss     FPR6, FPR2
-mulss     FPR7, FPR2
-mulss     FPR8, FPR2
-mulss     FPR9, FPR2
-mulss     FPR10, FPR2
-
-
+addss     FPR1, FPR2
+addss     FPR3, FPR4
+mulss     FPR5, FPR6
+mulss     FPR7, FPR8
+mulss     FPR9, FPR10
+addss     FPR11, FPR12
+addss     FPR13, FPR14
+mulss     FPR15, FPR16
+addss     FPR1, FPR2
+addss     FPR3, FPR4
+mulss     FPR5, FPR6
+mulss     FPR7, FPR8
+mulss     FPR9, FPR10
+addss     FPR11, FPR12
+addss     FPR13, FPR14
+mulss     FPR15, FPR16

--- a/bench/x86-64/peakflops_sp.ptt
+++ b/bench/x86-64/peakflops_sp.ptt
@@ -1,0 +1,24 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 8
+BYTES 4
+DESC Single-precision multiplications and additions with a single load, only scalar operations
+LOADS 1
+STORES 0
+INSTR_CONST 18
+INSTR_LOOP 12
+UOPS 11
+movaps FPR1, [rip+SCALAR]
+movaps FPR2, [rip+SCALAR]
+LOOP 1
+movss    FPR2, [STR0 + GPR1 * 4 ]
+addss     FPR3, FPR2
+addss     FPR4, FPR2
+addss     FPR5, FPR2
+mulss     FPR6, FPR2
+mulss     FPR7, FPR2
+mulss     FPR8, FPR2
+mulss     FPR9, FPR2
+mulss     FPR10, FPR2
+
+

--- a/bench/x86-64/peakflops_sp_avx.ptt
+++ b/bench/x86-64/peakflops_sp_avx.ptt
@@ -1,0 +1,38 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 12
+BYTES 4
+DESC Single-precision multiplications and additions with a single load, optimized for AVX
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
+vmovaps ymm1, [rip+SCALAR]
+vmovaps ymm2, [rip+SCALAR]
+vmovaps ymm3, [rip+SCALAR]
+vmovaps ymm4, [rip+SCALAR]
+vmovaps ymm5, [rip+SCALAR]
+vmovaps ymm6, [rip+SCALAR]
+vmovaps ymm7, [rip+SCALAR]
+vmovaps ymm8, [rip+SCALAR]
+vmovaps ymm9, [rip+SCALAR]
+vmovaps ymm10, [rip+SCALAR]
+vmovaps ymm11, [rip+SCALAR]
+vmovaps ymm12, [rip+SCALAR]
+vmovaps ymm13, [rip+SCALAR]
+.align 32
+LOOP 8
+vmovaps    ymm1, [STR0 + GPR1 * 4 ]
+vaddps     ymm2, ymm2, ymm1
+vmulps     ymm3, ymm3, ymm1
+vaddps     ymm4, ymm4, ymm1
+vmulps     ymm5, ymm5, ymm1
+vaddps     ymm6, ymm6, ymm1
+vmulps     ymm7, ymm7, ymm1
+vaddps     ymm8, ymm8, ymm1
+vmulps     ymm9, ymm9, ymm1
+vaddps     ymm10, ymm10, ymm1
+vmulps     ymm11, ymm11, ymm1
+vaddps     ymm12, ymm12, ymm1
+vmulps     ymm13, ymm13, ymm1

--- a/bench/x86-64/peakflops_sp_avx.ptt
+++ b/bench/x86-64/peakflops_sp_avx.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE SINGLE
-FLOPS 12
+FLOPS 15
 BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for AVX
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovaps ymm0, [rip+SCALAR]
 vmovaps ymm1, [rip+SCALAR]
 vmovaps ymm2, [rip+SCALAR]
 vmovaps ymm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovaps ymm10, [rip+SCALAR]
 vmovaps ymm11, [rip+SCALAR]
 vmovaps ymm12, [rip+SCALAR]
 vmovaps ymm13, [rip+SCALAR]
+vmovaps ymm14, [rip+SCALAR]
+vmovaps ymm15, [rip+SCALAR]
 .align 32
 LOOP 8
 vmovaps    ymm1, [STR0 + GPR1 * 4 ]
+vmulps     ymm0, ymm0, ymm1
 vaddps     ymm2, ymm2, ymm1
 vmulps     ymm3, ymm3, ymm1
 vaddps     ymm4, ymm4, ymm1
@@ -36,3 +40,5 @@ vaddps     ymm10, ymm10, ymm1
 vmulps     ymm11, ymm11, ymm1
 vaddps     ymm12, ymm12, ymm1
 vmulps     ymm13, ymm13, ymm1
+vaddps     ymm14, ymm14, ymm1
+vmulps     ymm15, ymm15, ymm1

--- a/bench/x86-64/peakflops_sp_avx512.ptt
+++ b/bench/x86-64/peakflops_sp_avx512.ptt
@@ -1,0 +1,38 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 12
+BYTES 4
+DESC Single-precision multiplications and additions with a single load, optimized for AVX-512
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
+vmovaps zmm1, [rip+SCALAR]
+vmovaps zmm2, [rip+SCALAR]
+vmovaps zmm3, [rip+SCALAR]
+vmovaps zmm4, [rip+SCALAR]
+vmovaps zmm5, [rip+SCALAR]
+vmovaps zmm6, [rip+SCALAR]
+vmovaps zmm7, [rip+SCALAR]
+vmovaps zmm8, [rip+SCALAR]
+vmovaps zmm9, [rip+SCALAR]
+vmovaps zmm10, [rip+SCALAR]
+vmovaps zmm11, [rip+SCALAR]
+vmovaps zmm12, [rip+SCALAR]
+vmovaps zmm13, [rip+SCALAR]
+.align 32
+LOOP 16
+vmovaps    zmm1, [STR0 + GPR1 * 4 ]
+vaddps     zmm2, zmm2, zmm1
+vmulps     zmm3, zmm3, zmm1
+vaddps     zmm4, zmm4, zmm1
+vmulps     zmm5, zmm5, zmm1
+vaddps     zmm6, zmm6, zmm1
+vmulps     zmm7, zmm7, zmm1
+vaddps     zmm8, zmm8, zmm1
+vmulps     zmm9, zmm9, zmm1
+vaddps     zmm10, zmm10, zmm1
+vmulps     zmm11, zmm11, zmm1
+vaddps     zmm12, zmm12, zmm1
+vmulps     zmm13, zmm13, zmm1

--- a/bench/x86-64/peakflops_sp_avx512.ptt
+++ b/bench/x86-64/peakflops_sp_avx512.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE SINGLE
-FLOPS 12
+FLOPS 15
 BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for AVX-512
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovaps zmm0, [rip+SCALAR]
 vmovaps zmm1, [rip+SCALAR]
 vmovaps zmm2, [rip+SCALAR]
 vmovaps zmm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovaps zmm10, [rip+SCALAR]
 vmovaps zmm11, [rip+SCALAR]
 vmovaps zmm12, [rip+SCALAR]
 vmovaps zmm13, [rip+SCALAR]
+vmovaps zmm14, [rip+SCALAR]
+vmovaps zmm15, [rip+SCALAR]
 .align 32
 LOOP 16
 vmovaps    zmm1, [STR0 + GPR1 * 4 ]
+vmulps     zmm0, zmm0, zmm1
 vaddps     zmm2, zmm2, zmm1
 vmulps     zmm3, zmm3, zmm1
 vaddps     zmm4, zmm4, zmm1
@@ -36,3 +40,5 @@ vaddps     zmm10, zmm10, zmm1
 vmulps     zmm11, zmm11, zmm1
 vaddps     zmm12, zmm12, zmm1
 vmulps     zmm13, zmm13, zmm1
+vaddps     zmm14, zmm14, zmm1
+vmulps     zmm15, zmm15, zmm1

--- a/bench/x86-64/peakflops_sp_avx512_fma.ptt
+++ b/bench/x86-64/peakflops_sp_avx512_fma.ptt
@@ -1,0 +1,38 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 24
+BYTES 4
+DESC Single-precision multiplications and additions with a single load, optimized for AVX-512 FMAs
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
+vmovaps zmm1, [rip+SCALAR]
+vmovaps zmm2, [rip+SCALAR]
+vmovaps zmm3, [rip+SCALAR]
+vmovaps zmm4, [rip+SCALAR]
+vmovaps zmm5, [rip+SCALAR]
+vmovaps zmm6, [rip+SCALAR]
+vmovaps zmm7, [rip+SCALAR]
+vmovaps zmm8, [rip+SCALAR]
+vmovaps zmm9, [rip+SCALAR]
+vmovaps zmm10, [rip+SCALAR]
+vmovaps zmm11, [rip+SCALAR]
+vmovaps zmm12, [rip+SCALAR]
+vmovaps zmm13, [rip+SCALAR]
+.align 32
+LOOP 16
+vmovaps    zmm1, [STR0 + GPR1 * 4 ]
+vfmadd213ps     zmm2, zmm2, zmm1
+vfmadd213ps     zmm3, zmm3, zmm1
+vfmadd213ps     zmm4, zmm4, zmm1
+vfmadd213ps     zmm5, zmm5, zmm1
+vfmadd213ps     zmm6, zmm6, zmm1
+vfmadd213ps     zmm7, zmm7, zmm1
+vfmadd213ps     zmm8, zmm8, zmm1
+vfmadd213ps     zmm9, zmm9, zmm1
+vfmadd213ps     zmm10, zmm10, zmm1
+vfmadd213ps     zmm11, zmm11, zmm1
+vfmadd213ps     zmm12, zmm12, zmm1
+vfmadd213ps     zmm13, zmm13, zmm1

--- a/bench/x86-64/peakflops_sp_avx512_fma.ptt
+++ b/bench/x86-64/peakflops_sp_avx512_fma.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE SINGLE
-FLOPS 24
+FLOPS 30
 BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for AVX-512 FMAs
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovaps zmm0, [rip+SCALAR]
 vmovaps zmm1, [rip+SCALAR]
 vmovaps zmm2, [rip+SCALAR]
 vmovaps zmm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovaps zmm10, [rip+SCALAR]
 vmovaps zmm11, [rip+SCALAR]
 vmovaps zmm12, [rip+SCALAR]
 vmovaps zmm13, [rip+SCALAR]
+vmovaps zmm14, [rip+SCALAR]
+vmovaps zmm15, [rip+SCALAR]
 .align 32
 LOOP 16
 vmovaps    zmm1, [STR0 + GPR1 * 4 ]
+vfmadd213ps     zmm0, zmm0, zmm1
 vfmadd213ps     zmm2, zmm2, zmm1
 vfmadd213ps     zmm3, zmm3, zmm1
 vfmadd213ps     zmm4, zmm4, zmm1
@@ -36,3 +40,5 @@ vfmadd213ps     zmm10, zmm10, zmm1
 vfmadd213ps     zmm11, zmm11, zmm1
 vfmadd213ps     zmm12, zmm12, zmm1
 vfmadd213ps     zmm13, zmm13, zmm1
+vfmadd213ps     zmm14, zmm14, zmm1
+vfmadd213ps     zmm15, zmm15, zmm1

--- a/bench/x86-64/peakflops_sp_avx_fma.ptt
+++ b/bench/x86-64/peakflops_sp_avx_fma.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE SINGLE
-FLOPS 24
+FLOPS 30
 BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for AVX FMAs
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 19
+UOPS 18
+vmovaps ymm0, [rip+SCALAR]
 vmovaps ymm1, [rip+SCALAR]
 vmovaps ymm2, [rip+SCALAR]
 vmovaps ymm3, [rip+SCALAR]
@@ -21,9 +22,12 @@ vmovaps ymm10, [rip+SCALAR]
 vmovaps ymm11, [rip+SCALAR]
 vmovaps ymm12, [rip+SCALAR]
 vmovaps ymm13, [rip+SCALAR]
+vmovaps ymm14, [rip+SCALAR]
+vmovaps ymm15, [rip+SCALAR]
 .align 32
 LOOP 8
 vmovaps    ymm1, [STR0 + GPR1 * 4 ]
+vfmadd213ps     ymm0, ymm0, ymm1
 vfmadd213ps     ymm2, ymm2, ymm1
 vfmadd213ps     ymm3, ymm3, ymm1
 vfmadd213ps     ymm4, ymm4, ymm1
@@ -36,3 +40,5 @@ vfmadd213ps     ymm10, ymm10, ymm1
 vfmadd213ps     ymm11, ymm11, ymm1
 vfmadd213ps     ymm12, ymm12, ymm1
 vfmadd213ps     ymm13, ymm13, ymm1
+vfmadd213ps     ymm14, ymm14, ymm1
+vfmadd213ps     ymm15, ymm15, ymm1

--- a/bench/x86-64/peakflops_sp_avx_fma.ptt
+++ b/bench/x86-64/peakflops_sp_avx_fma.ptt
@@ -1,0 +1,38 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 24
+BYTES 4
+DESC Single-precision multiplications and additions with a single load, optimized for AVX FMAs
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
+vmovaps ymm1, [rip+SCALAR]
+vmovaps ymm2, [rip+SCALAR]
+vmovaps ymm3, [rip+SCALAR]
+vmovaps ymm4, [rip+SCALAR]
+vmovaps ymm5, [rip+SCALAR]
+vmovaps ymm6, [rip+SCALAR]
+vmovaps ymm7, [rip+SCALAR]
+vmovaps ymm8, [rip+SCALAR]
+vmovaps ymm9, [rip+SCALAR]
+vmovaps ymm10, [rip+SCALAR]
+vmovaps ymm11, [rip+SCALAR]
+vmovaps ymm12, [rip+SCALAR]
+vmovaps ymm13, [rip+SCALAR]
+.align 32
+LOOP 8
+vmovaps    ymm1, [STR0 + GPR1 * 4 ]
+vfmadd213ps     ymm2, ymm2, ymm1
+vfmadd213ps     ymm3, ymm3, ymm1
+vfmadd213ps     ymm4, ymm4, ymm1
+vfmadd213ps     ymm5, ymm5, ymm1
+vfmadd213ps     ymm6, ymm6, ymm1
+vfmadd213ps     ymm7, ymm7, ymm1
+vfmadd213ps     ymm8, ymm8, ymm1
+vfmadd213ps     ymm9, ymm9, ymm1
+vfmadd213ps     ymm10, ymm10, ymm1
+vfmadd213ps     ymm11, ymm11, ymm1
+vfmadd213ps     ymm12, ymm12, ymm1
+vfmadd213ps     ymm13, ymm13, ymm1

--- a/bench/x86-64/peakflops_sp_sse.ptt
+++ b/bench/x86-64/peakflops_sp_sse.ptt
@@ -1,13 +1,15 @@
 STREAMS 1
 TYPE SINGLE
-FLOPS 12
-BYTES 8
+FLOPS 16
+BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimised for SSE
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 20
+UOPS 19
+movaps xmm0, [rip+SCALAR]
+movaps xmm1, [rip+SCALAR]
 movaps xmm2, [rip+SCALAR]
 movaps xmm3, [rip+SCALAR]
 movaps xmm4, [rip+SCALAR]
@@ -20,18 +22,24 @@ movaps xmm10, [rip+SCALAR]
 movaps xmm11, [rip+SCALAR]
 movaps xmm12, [rip+SCALAR]
 movaps xmm13, [rip+SCALAR]
+movaps xmm14, [rip+SCALAR]
+movaps xmm15, [rip+SCALAR]
 .align 32
 LOOP 4
-movaps    xmm1, [STR0 + GPR1 * 4 ]
-addps     xmm2, xmm1
-mulps     xmm3, xmm1
-addps     xmm4, xmm1
-mulps     xmm5, xmm1
-addps     xmm6, xmm1
-mulps     xmm7, xmm1
-addps     xmm8, xmm1
-mulps     xmm9, xmm1
-addps     xmm10, xmm1
-mulps     xmm11, xmm1
-addps     xmm12, xmm1
-mulps     xmm13, xmm1
+movaps    xmm2, [STR0 + GPR1 * 4 ]
+addps     xmm1, xmm2
+mulps     xmm3, xmm4
+addps     xmm5, xmm6
+mulps     xmm7, xmm8
+addps     xmm9, xmm10
+mulps     xmm11, xmm12
+addps     xmm13, xmm14
+mulps     xmm15, xmm0
+addps     xmm1, xmm2
+mulps     xmm3, xmm4
+addps     xmm5, xmm6
+mulps     xmm7, xmm8
+addps     xmm9, xmm10
+mulps     xmm11, xmm12
+addps     xmm13, xmm14
+mulps     xmm15, xmm0

--- a/bench/x86-64/peakflops_sp_sse.ptt
+++ b/bench/x86-64/peakflops_sp_sse.ptt
@@ -1,0 +1,37 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 12
+BYTES 8
+DESC Single-precision multiplications and additions with a single load, optimised for SSE
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
+movaps xmm2, [rip+SCALAR]
+movaps xmm3, [rip+SCALAR]
+movaps xmm4, [rip+SCALAR]
+movaps xmm5, [rip+SCALAR]
+movaps xmm6, [rip+SCALAR]
+movaps xmm7, [rip+SCALAR]
+movaps xmm8, [rip+SCALAR]
+movaps xmm9, [rip+SCALAR]
+movaps xmm10, [rip+SCALAR]
+movaps xmm11, [rip+SCALAR]
+movaps xmm12, [rip+SCALAR]
+movaps xmm13, [rip+SCALAR]
+.align 32
+LOOP 4
+movaps    xmm1, [STR0 + GPR1 * 4 ]
+addps     xmm2, xmm1
+mulps     xmm3, xmm1
+addps     xmm4, xmm1
+mulps     xmm5, xmm1
+addps     xmm6, xmm1
+mulps     xmm7, xmm1
+addps     xmm8, xmm1
+mulps     xmm9, xmm1
+addps     xmm10, xmm1
+mulps     xmm11, xmm1
+addps     xmm12, xmm1
+mulps     xmm13, xmm1

--- a/bench/x86-64/peakflops_sse.ptt
+++ b/bench/x86-64/peakflops_sse.ptt
@@ -8,30 +8,30 @@ STORES 0
 INSTR_CONST 28
 INSTR_LOOP 16
 UOPS 15
-vmovapd xmm2, [rip+SCALAR]
-vmovapd xmm3, [rip+SCALAR]
-vmovapd xmm4, [rip+SCALAR]
-vmovapd xmm5, [rip+SCALAR]
-vmovapd xmm6, [rip+SCALAR]
-vmovapd xmm7, [rip+SCALAR]
-vmovapd xmm8, [rip+SCALAR]
-vmovapd xmm9, [rip+SCALAR]
-vmovapd xmm10, [rip+SCALAR]
-vmovapd xmm11, [rip+SCALAR]
-vmovapd xmm12, [rip+SCALAR]
-vmovapd xmm13, [rip+SCALAR]
+movapd xmm2, [rip+SCALAR]
+movapd xmm3, [rip+SCALAR]
+movapd xmm4, [rip+SCALAR]
+movapd xmm5, [rip+SCALAR]
+movapd xmm6, [rip+SCALAR]
+movapd xmm7, [rip+SCALAR]
+movapd xmm8, [rip+SCALAR]
+movapd xmm9, [rip+SCALAR]
+movapd xmm10, [rip+SCALAR]
+movapd xmm11, [rip+SCALAR]
+movapd xmm12, [rip+SCALAR]
+movapd xmm13, [rip+SCALAR]
 .align 32
 LOOP 2
-vmovapd    xmm1, [STR0 + GPR1 * 8 ]
-vaddpd     xmm2, xmm2, xmm1
-vmulpd     xmm3, xmm3, xmm1
-vaddpd     xmm4, xmm4, xmm1
-vmulpd     xmm5, xmm5, xmm1
-vaddpd     xmm6, xmm6, xmm1
-vmulpd     xmm7, xmm7, xmm1
-vaddpd     xmm8, xmm8, xmm1
-vmulpd     xmm9, xmm9, xmm1
-vaddpd     xmm10, xmm10, xmm1
-vmulpd     xmm11, xmm11, xmm1
-vaddpd     xmm12, xmm12, xmm1
-vmulpd     xmm13, xmm13, xmm1
+movapd    xmm1, [STR0 + GPR1 * 8 ]
+addpd     xmm2, xmm1
+mulpd     xmm3, xmm1
+addpd     xmm4, xmm1
+mulpd     xmm5, xmm1
+addpd     xmm6, xmm1
+mulpd     xmm7, xmm1
+addpd     xmm8, xmm1
+mulpd     xmm9, xmm1
+addpd     xmm10, xmm1
+mulpd     xmm11, xmm1
+addpd     xmm12, xmm1
+mulpd     xmm13, xmm1

--- a/bench/x86-64/peakflops_sse.ptt
+++ b/bench/x86-64/peakflops_sse.ptt
@@ -1,26 +1,31 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 8
+FLOPS 12
 BYTES 8
-movaps xmm1, [rip+SCALAR]
-movaps xmm2, [rip+SCALAR]
-movaps xmm3, [rip+SCALAR]
-movaps xmm4, [rip+SCALAR]
-movaps xmm5, [rip+SCALAR]
-movaps xmm6, [rip+SCALAR]
-movaps xmm7, [rip+SCALAR]
-movaps xmm8, [rip+SCALAR]
-movaps xmm9, [rip+SCALAR]
+vmovapd xmm2, [rip+SCALAR]
+vmovapd xmm3, [rip+SCALAR]
+vmovapd xmm4, [rip+SCALAR]
+vmovapd xmm5, [rip+SCALAR]
+vmovapd xmm6, [rip+SCALAR]
+vmovapd xmm7, [rip+SCALAR]
+vmovapd xmm8, [rip+SCALAR]
+vmovapd xmm9, [rip+SCALAR]
+vmovapd xmm10, [rip+SCALAR]
+vmovapd xmm11, [rip+SCALAR]
+vmovapd xmm12, [rip+SCALAR]
+vmovapd xmm13, [rip+SCALAR]
 .align 32
 LOOP 2
-movapd    xmm1, [STR0 + GPR1 * 8 ]
-addpd     xmm2, xmm1
-mulpd     xmm3, xmm1
-addpd     xmm4, xmm1
-mulpd     xmm5, xmm1
-addpd     xmm6, xmm1
-mulpd     xmm7, xmm1
-addpd     xmm8, xmm1
-mulpd     xmm9, xmm1
-
-
+vmovapd    xmm1, [STR0 + GPR1 * 8 ]
+vaddpd     xmm2, xmm2, xmm1
+vmulpd     xmm3, xmm3, xmm1
+vaddpd     xmm4, xmm4, xmm1
+vmulpd     xmm5, xmm5, xmm1
+vaddpd     xmm6, xmm6, xmm1
+vmulpd     xmm7, xmm7, xmm1
+vaddpd     xmm8, xmm8, xmm1
+vmulpd     xmm9, xmm9, xmm1
+vaddpd     xmm10, xmm10, xmm1
+vmulpd     xmm11, xmm11, xmm1
+vaddpd     xmm12, xmm12, xmm1
+vmulpd     xmm13, xmm13, xmm1

--- a/bench/x86-64/peakflops_sse.ptt
+++ b/bench/x86-64/peakflops_sse.ptt
@@ -1,13 +1,14 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 12
-BYTES 4
+FLOPS 16
+BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimised for SSE
 LOADS 1
 STORES 0
-INSTR_CONST 28
-INSTR_LOOP 16
-UOPS 15
+INSTR_CONST 32
+INSTR_LOOP 20
+UOPS 19
+movapd xmm0, [rip+SCALAR]
 movapd xmm2, [rip+SCALAR]
 movapd xmm3, [rip+SCALAR]
 movapd xmm4, [rip+SCALAR]
@@ -20,18 +21,24 @@ movapd xmm10, [rip+SCALAR]
 movapd xmm11, [rip+SCALAR]
 movapd xmm12, [rip+SCALAR]
 movapd xmm13, [rip+SCALAR]
+movapd xmm14, [rip+SCALAR]
+movapd xmm15, [rip+SCALAR]
 .align 32
 LOOP 2
 movapd    xmm1, [STR0 + GPR1 * 8 ]
-addpd     xmm2, xmm1
-mulpd     xmm3, xmm1
-addpd     xmm4, xmm1
-mulpd     xmm5, xmm1
-addpd     xmm6, xmm1
-mulpd     xmm7, xmm1
-addpd     xmm8, xmm1
-mulpd     xmm9, xmm1
-addpd     xmm10, xmm1
-mulpd     xmm11, xmm1
-addpd     xmm12, xmm1
-mulpd     xmm13, xmm1
+addpd     xmm1, xmm2
+mulpd     xmm3, xmm4
+addpd     xmm5, xmm6
+mulpd     xmm7, xmm8
+addpd     xmm9, xmm10
+mulpd     xmm11, xmm12
+addpd     xmm13, xmm14
+mulpd     xmm15, xmm0
+addpd     xmm1, xmm2
+mulpd     xmm3, xmm4
+addpd     xmm5, xmm6
+mulpd     xmm7, xmm8
+addpd     xmm9, xmm10
+mulpd     xmm11, xmm12
+addpd     xmm13, xmm14
+mulpd     xmm15, xmm0

--- a/bench/x86-64/peakflops_sse.ptt
+++ b/bench/x86-64/peakflops_sse.ptt
@@ -2,6 +2,12 @@ STREAMS 1
 TYPE DOUBLE
 FLOPS 12
 BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimised for SSE
+LOADS 1
+STORES 0
+INSTR_CONST 28
+INSTR_LOOP 16
+UOPS 15
 vmovapd xmm2, [rip+SCALAR]
 vmovapd xmm3, [rip+SCALAR]
 vmovapd xmm4, [rip+SCALAR]

--- a/bench/x86-64/peakflops_sse.ptt
+++ b/bench/x86-64/peakflops_sse.ptt
@@ -1,7 +1,7 @@
 STREAMS 1
 TYPE DOUBLE
 FLOPS 12
-BYTES 8
+BYTES 4
 DESC Double-precision multiplications and additions with a single load, optimised for SSE
 LOADS 1
 STORES 0


### PR DESCRIPTION
* add different variants AVX/AVX-512 with/without FMAs, similar to the other benchmarks
* higher unrolling of AVX/SSE variants to obtain better results (on Haswell)
* add missing description and annotation (number of instructions etc)