### PR TITLE
Create virtual numa node in case detection fails

### DIFF
--- a/src/includes/numa.h
+++ b/src/includes/numa.h
@@ -44,9 +44,9 @@ extern int numaInitialized;
 
 extern int str2int(const char* str);
 
-extern uint64_t getFreeMem(void);
+extern uint64_t proc_getFreeSysMem(void);
 
-extern uint64_t getTotalMem(void);
+extern uint64_t proc_getTotalSysMem(void);
 
 struct numa_functions {
     int (*numa_init) (void);

--- a/src/includes/numa.h
+++ b/src/includes/numa.h
@@ -44,6 +44,10 @@ extern int numaInitialized;
 
 extern int str2int(const char* str);
 
+extern uint64_t getFreeMem(void);
+
+extern uint64_t getTotalMem(void);
+
 struct numa_functions {
     int (*numa_init) (void);
     void (*numa_setInterleaved) (const int*, int);

--- a/src/includes/numa_virtual.h
+++ b/src/includes/numa_virtual.h
@@ -1,15 +1,15 @@
 /*
  * =======================================================================================
  *
- *      Filename:  numa.h
+ *      Filename:  numa_virtual.h
  *
- *      Description:  Header File NUMA module for internal use. External functions are
- *                    defined in likwid.h
+ *      Description:  Header Virtual/Fake NUMA backend
  *
  *      Version:   <VERSION>
  *      Released:  <DATE>
  *
  *      Author:   Thomas Gruber (tr), thomas.roehl@googlemail.com
+ *                Tobias Auerochs, tobi291019@gmail.com
  *      Project:  likwid
  *
  *      Copyright (C) 2016 RRZE, University Erlangen-Nuremberg
@@ -28,27 +28,9 @@
  *
  * =======================================================================================
  */
-#ifndef LIKWID_NUMA
-#define LIKWID_NUMA
+#ifndef LIKWID_NUMA_VIRTUAL
+#define LIKWID_NUMA_VIRTUAL
 
-#include <stdlib.h>
-#include <stdio.h>
-
-#include <types.h>
-#include <likwid.h>
-#include <numa_hwloc.h>
-#include <numa_proc.h>
-#include <numa_virtual.h>
-
-extern int numaInitialized;
-
-extern int str2int(const char* str);
-
-struct numa_functions {
-    int (*numa_init) (void);
-    void (*numa_setInterleaved) (const int*, int);
-    void (*numa_setMembind) (const int*, int);
-    void (*numa_membind) (void*, size_t, int);
-};
+extern int virtual_numa_init(void);
 
 #endif

--- a/src/numa.c
+++ b/src/numa.c
@@ -96,6 +96,87 @@ str2int(const char* str)
     return (int) val;
 }
 
+uint64_t
+getFreeMem(void)
+{
+    FILE *fp;
+    uint64_t free = 0;
+    bstring freeString  = bformat("MemFree:");
+    int i;
+
+    if (!access("/proc/meminfo", R_OK))
+    {
+        if (NULL != (fp = fopen ("/proc/meminfo", "r")))
+        {
+            bstring src = bread ((bNread) fread, fp);
+            struct bstrList* tokens = bsplit(src,(char) '\n');
+            for (i=0;i<tokens->qty;i++)
+            {
+                if (binstr(tokens->entry[i],0,freeString) != BSTR_ERR)
+                {
+                     bstring tmp = bmidstr (tokens->entry[i], 10, blength(tokens->entry[i])-10  );
+                     bltrimws(tmp);
+                     struct bstrList* subtokens = bsplit(tmp,(char) ' ');
+                     free = str2int(bdata(subtokens->entry[0]));
+                     bdestroy(tmp);
+                     bstrListDestroy(subtokens);
+                }
+            }
+            bstrListDestroy(tokens);
+            bdestroy(src);
+            fclose(fp);
+        }
+    }
+    else
+    {
+        bdestroy(freeString);
+        ERROR;
+    }
+    bdestroy(freeString);
+    return free;
+}
+
+uint64_t
+getTotalMem(void)
+{
+    int i;
+    FILE *fp;
+    uint64_t total = 0;
+    bstring totalString  = bformat("MemTotal:");
+
+    if (!access("/proc/meminfo", R_OK))
+    {
+        if (NULL != (fp = fopen ("/proc/meminfo", "r")))
+        {
+            bstring src = bread ((bNread) fread, fp);
+            struct bstrList* tokens = bsplit(src,(char) '\n');
+            for (i=0;i<tokens->qty;i++)
+            {
+                if (binstr(tokens->entry[i],0,totalString) != BSTR_ERR)
+                {
+                     bstring tmp = bmidstr (tokens->entry[i], 10, blength(tokens->entry[i])-10  );
+                     bltrimws(tmp);
+                     struct bstrList* subtokens = bsplit(tmp,(char) ' ');
+                     total = str2int(bdata(subtokens->entry[0]));
+                     bdestroy(tmp);
+                     bstrListDestroy(subtokens);
+                }
+            }
+            bstrListDestroy(tokens);
+            bdestroy(src);
+            fclose(fp);
+        }
+    }
+    else
+    {
+        bdestroy(totalString);
+        ERROR;
+    }
+
+    bdestroy(totalString);
+    return total;
+}
+
 int
 empty_numa_init()
 {

--- a/src/numa.c
+++ b/src/numa.c
@@ -97,7 +97,7 @@ str2int(const char* str)
 }
 
 uint64_t
-getFreeMem(void)
+proc_getFreeSysMem(void)
 {
     FILE *fp;
     uint64_t free = 0;
@@ -137,7 +137,7 @@ getFreeMem(void)
 }
 
 uint64_t
-getTotalMem(void)
+proc_getTotalSysMem(void)
 {
     int i;
     FILE *fp;

--- a/src/numa.c
+++ b/src/numa.c
@@ -100,7 +100,7 @@ int
 empty_numa_init()
 {
     printf("MEMPOLICY NOT supported in kernel!\n");
-    return 0;
+    return virtual_numa_init();
 }
 
 void

--- a/src/numa_hwloc.c
+++ b/src/numa_hwloc.c
@@ -262,36 +262,13 @@ hwloc_numa_init(void)
 #else
         hwloc_type = HWLOC_OBJ_SOCKET;
 #endif
-        numa_info.numberOfNodes = 1;
-
-        numa_info.nodes = (NumaNode*) malloc(sizeof(NumaNode));
-        if (!numa_info.nodes)
+        if (virtual_numa_init() < 0)
         {
-            fprintf(stderr,"No memory to allocate %ld byte for nodes array\n",sizeof(NumaNode));
             return -1;
         }
-        numa_info.nodes[0].id = 0;
+
+        /* Use hwloc to set numberOfProcessors */
         numa_info.nodes[0].numberOfProcessors = 0;
-        numa_info.nodes[0].totalMemory = getTotalNodeMem(0);
-        numa_info.nodes[0].freeMemory = getFreeNodeMem(0);
-        numa_info.nodes[0].processors = (uint32_t*) malloc(numPUs * sizeof(uint32_t));
-        if (!numa_info.nodes[0].processors)
-        {
-            fprintf(stderr,"No memory to allocate %ld byte for processors array of NUMA node %d\n",
-                    numPUs * sizeof(uint32_t),0);
-            return -1;
-        }
-        numa_info.nodes[0].distances = (uint32_t*) malloc(sizeof(uint32_t));
-        if (!numa_info.nodes[0].distances)
-        {
-            fprintf(stderr,"No memory to allocate %ld byte for distances array of NUMA node %d\n",
-                    sizeof(uint32_t),0);
-            return -1;
-        }
-        numa_info.nodes[0].distances[0] = 10;
-        numa_info.nodes[0].numberOfDistances = 1;
-        cores_per_socket = cpuid_topology.numHWThreads/cpuid_topology.numSockets;
-
         for (d=0; d<likwid_hwloc_get_nbobjs_by_type(hwloc_topology, hwloc_type); d++)
         {
             obj = likwid_hwloc_get_obj_by_type(hwloc_topology, hwloc_type, d);

--- a/src/numa_hwloc.c
+++ b/src/numa_hwloc.c
@@ -253,30 +253,7 @@ hwloc_numa_init(void)
        aggregate all sockets in the system into the single virtually created NUMA node */
     if (numa_info.numberOfNodes == 0)
     {
-#if defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A__)
-#if HWLOC_API_VERSION > 0x00020000
-        hwloc_type = HWLOC_OBJ_NUMANODE;
-#else
-        hwloc_type = HWLOC_OBJ_NODE;
-#endif
-#else
-        hwloc_type = HWLOC_OBJ_SOCKET;
-#endif
-        if (virtual_numa_init() < 0)
-        {
-            return -1;
-        }
-
-        /* Use hwloc to set numberOfProcessors */
-        numa_info.nodes[0].numberOfProcessors = 0;
-        for (d=0; d<likwid_hwloc_get_nbobjs_by_type(hwloc_topology, hwloc_type); d++)
-        {
-            obj = likwid_hwloc_get_obj_by_type(hwloc_topology, hwloc_type, d);
-            /* depth is here used as index in the processors array */
-            depth = d * cores_per_socket;
-            numa_info.nodes[0].numberOfProcessors += likwid_hwloc_record_objs_of_type_below_obj(
-                    likwid_hwloc_topology, obj, HWLOC_OBJ_PU, &depth, &numa_info.nodes[0].processors);
-        }
+        return virtual_numa_init();
     }
     else
     {

--- a/src/numa_hwloc.c
+++ b/src/numa_hwloc.c
@@ -84,7 +84,7 @@ getFreeNodeMem(int nodeId)
     bdestroy(filename);
 
     /* Fallback to system-wide free memory */
-    return getFreeMem();
+    return proc_getFreeSysMem();
 }
 
 uint64_t
@@ -125,7 +125,7 @@ getTotalNodeMem(int nodeId)
     bdestroy(procfilename);
 
     /* Fallback to system-wide total memory */
-    return getTotalMem();
+    return proc_getTotalSysMem();
 }
 
 int

--- a/src/numa_hwloc.c
+++ b/src/numa_hwloc.c
@@ -79,40 +79,12 @@ getFreeNodeMem(int nodeId)
         bdestroy(src);
         fclose(fp);
     }
-    else if (!access("/proc/meminfo", R_OK))
-    {
-        bdestroy(filename);
-        filename = bfromcstr("/proc/meminfo");
-        if (NULL != (fp = fopen (bdata(filename), "r")))
-        {
-            bstring src = bread ((bNread) fread, fp);
-            struct bstrList* tokens = bsplit(src,(char) '\n');
-            for (i=0;i<tokens->qty;i++)
-            {
-                if (binstr(tokens->entry[i],0,freeString) != BSTR_ERR)
-                {
-                     bstring tmp = bmidstr (tokens->entry[i], 10, blength(tokens->entry[i])-10  );
-                     bltrimws(tmp);
-                     struct bstrList* subtokens = bsplit(tmp,(char) ' ');
-                     free = str2int(bdata(subtokens->entry[0]));
-                     bdestroy(tmp);
-                     bstrListDestroy(subtokens);
-                }
-            }
-            bstrListDestroy(tokens);
-            bdestroy(src);
-            fclose(fp);
-        }
-    }
-    else
-    {
-        bdestroy(freeString);
-        bdestroy(filename);
-        ERROR;
-    }
+
     bdestroy(freeString);
     bdestroy(filename);
-    return free;
+
+    /* Fallback to system-wide free memory */
+    return getFreeMem();
 }
 
 uint64_t
@@ -147,41 +119,13 @@ getTotalNodeMem(int nodeId)
         bdestroy(src);
         fclose(fp);
     }
-    else if (!access(sptr, R_OK))
-    {
-        if (NULL != (fp = fopen (bdata(procfilename), "r")))
-        {
-            bstring src = bread ((bNread) fread, fp);
-            struct bstrList* tokens = bsplit(src,(char) '\n');
-            for (i=0;i<tokens->qty;i++)
-            {
-                if (binstr(tokens->entry[i],0,totalString) != BSTR_ERR)
-                {
-                     bstring tmp = bmidstr (tokens->entry[i], 10, blength(tokens->entry[i])-10  );
-                     bltrimws(tmp);
-                     struct bstrList* subtokens = bsplit(tmp,(char) ' ');
-                     total = str2int(bdata(subtokens->entry[0]));
-                     bdestroy(tmp);
-                     bstrListDestroy(subtokens);
-                }
-            }
-            bstrListDestroy(tokens);
-            bdestroy(src);
-            fclose(fp);
-        }
-    }
-    else
-    {
-        bdestroy(totalString);
-        bdestroy(sysfilename);
-        bdestroy(procfilename);
-        ERROR;
-    }
 
     bdestroy(totalString);
     bdestroy(sysfilename);
     bdestroy(procfilename);
-    return total;
+
+    /* Fallback to system-wide total memory */
+    return getTotalMem();
 }
 
 int

--- a/src/numa_proc.c
+++ b/src/numa_proc.c
@@ -348,9 +348,8 @@ int proc_numa_init(void)
 
     if (get_mempolicy(NULL, NULL, 0, 0, 0) < 0 && errno == ENOSYS)
     {
-        numa_info.numberOfNodes = 0;
-        numa_info.nodes = NULL;
-        return -1;
+        /* Allocate a virtual node instead and bail out */
+        return virtual_numa_init();
     }
     /* First determine maximum number of nodes */
     //numa_info.numberOfNodes = setConfiguredNodes()+1;

--- a/src/numa_virtual.c
+++ b/src/numa_virtual.c
@@ -74,8 +74,8 @@ virtual_numa_init()
 
     nodes[0].id = 0;
     nodes[0].numberOfProcessors = cpuid_topology.numHWThreads;
-    nodes[0].totalMemory = getTotalMem();
-    nodes[0].freeMemory = getFreeMem();
+    nodes[0].totalMemory = proc_getTotalSysMem();
+    nodes[0].freeMemory = proc_getFreeSysMem();
     for (i = 0; i < cpuid_topology.numHWThreads; i++)
     {
         nodes[0].processors[i] = cpuid_topology.threadPool[i].apicId;

--- a/src/numa_virtual.c
+++ b/src/numa_virtual.c
@@ -1,0 +1,166 @@
+/*
+ * =======================================================================================
+ *
+ *      Filename:  numa_virtual.c
+ *
+ *      Description:  Virtual/Fake NUMA backend
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Gruber (tr), thomas.roehl@googlemail.com
+ *                Tobias Auerochs, tobi291019@gmail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2016 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
+
+/* #####   HEADER FILE INCLUDES   ######################################### */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <error.h>
+
+#include <numa.h>
+#include <topology.h>
+
+/* #####   FUNCTION DEFINITIONS  -  LOCAL TO THIS SOURCE FILE   ########### */
+
+static uint64_t
+getFreeNodeMem(void)
+{
+    FILE *fp;
+    uint64_t free = 0;
+    bstring freeString  = bformat("MemFree:");
+    int i;
+
+    if (!access("/proc/meminfo", R_OK))
+    {
+        if (NULL != (fp = fopen ("/proc/meminfo", "r")))
+        {
+            bstring src = bread ((bNread) fread, fp);
+            struct bstrList* tokens = bsplit(src,(char) '\n');
+            for (i=0;i<tokens->qty;i++)
+            {
+                if (binstr(tokens->entry[i],0,freeString) != BSTR_ERR)
+                {
+                     bstring tmp = bmidstr (tokens->entry[i], 10, blength(tokens->entry[i])-10  );
+                     bltrimws(tmp);
+                     struct bstrList* subtokens = bsplit(tmp,(char) ' ');
+                     free = str2int(bdata(subtokens->entry[0]));
+                     bdestroy(tmp);
+                     bstrListDestroy(subtokens);
+                }
+            }
+            bstrListDestroy(tokens);
+            bdestroy(src);
+            fclose(fp);
+        }
+    }
+    else
+    {
+        bdestroy(freeString);
+        ERROR;
+    }
+    bdestroy(freeString);
+    return free;
+}
+
+static uint64_t
+getTotalNodeMem(void)
+{
+    int i;
+    FILE *fp;
+    uint64_t total = 0;
+    bstring totalString  = bformat("MemTotal:");
+
+    if (!access("/proc/meminfo", R_OK))
+    {
+        if (NULL != (fp = fopen ("/proc/meminfo", "r")))
+        {
+            bstring src = bread ((bNread) fread, fp);
+            struct bstrList* tokens = bsplit(src,(char) '\n');
+            for (i=0;i<tokens->qty;i++)
+            {
+                if (binstr(tokens->entry[i],0,totalString) != BSTR_ERR)
+                {
+                     bstring tmp = bmidstr (tokens->entry[i], 10, blength(tokens->entry[i])-10  );
+                     bltrimws(tmp);
+                     struct bstrList* subtokens = bsplit(tmp,(char) ' ');
+                     total = str2int(bdata(subtokens->entry[0]));
+                     bdestroy(tmp);
+                     bstrListDestroy(subtokens);
+                }
+            }
+            bstrListDestroy(tokens);
+            bdestroy(src);
+            fclose(fp);
+        }
+    }
+    else
+    {
+        bdestroy(totalString);
+        ERROR;
+    }
+
+    bdestroy(totalString);
+    return total;
+}
+
+/* #####   FUNCTION DEFINITIONS  -  EXPORTED FUNCTIONS   ################## */
+
+int
+virtual_numa_init()
+{
+    int i;
+
+    numa_info.numberOfNodes = 1;
+
+    numa_info.nodes = (NumaNode*) malloc(sizeof(NumaNode));
+    if (!numa_info.nodes)
+    {
+        fprintf(stderr,"No memory to allocate %ld byte for nodes array\n",sizeof(NumaNode));
+        return -1;
+    }
+    numa_info.nodes[0].id = 0;
+    numa_info.nodes[0].numberOfProcessors = cpuid_topology.numHWThreads;
+    numa_info.nodes[0].totalMemory = getTotalNodeMem();
+    numa_info.nodes[0].freeMemory = getFreeNodeMem();
+    numa_info.nodes[0].processors = (uint32_t*) malloc(cpuid_topology.numHWThreads * sizeof(uint32_t));
+    if (!numa_info.nodes[0].processors)
+    {
+        fprintf(stderr,"No memory to allocate %ld byte for processors array of NUMA node %d\n",
+                cpuid_topology.numHWThreads * sizeof(uint32_t),0);
+        return -1;
+    }
+    for (i = 0; i < cpuid_topology.numHWThreads; i++)
+    {
+        numa_info.nodes[0].processors[i] = i;
+    }
+    numa_info.nodes[0].distances = (uint32_t*) malloc(sizeof(uint32_t));
+    if (!numa_info.nodes[0].distances)
+    {
+        fprintf(stderr,"No memory to allocate %ld byte for distances array of NUMA node %d\n",
+                sizeof(uint32_t),0);
+        return -1;
+    }
+    numa_info.nodes[0].distances[0] = 10;
+    numa_info.nodes[0].numberOfDistances = 1;
+
+    return 0;
+}


### PR DESCRIPTION
This modifies the error handling to use a "virtual" NUMA node in case no proper one was found, in order to guarantee that there is always at least one, even on systems without any NUMA support (like on the Raspberry Pi 4).

Previously the hwloc backend already handled this on its own, so I extracted that code into a virtual "backend", which is used by both the proc and empty backends as well, in case no better info can be detected.

For memory usage the procfs is used, which was done by the hwloc backend as well, and for the  `numberOfProcessors` the `cpuid_topology.numHWThreads`  value is taken.

In order to avoid any behaviour changes the hwloc backend recomputes the `numberOfProcessors` on its own, not sure if that is a good or bad idea.

I have not gotten around to testing this on any machines with actual NUMA support, but the changes only cover previous error cases that should never occur with multiple NUMA nodes.

I added myself as an author in the two files I created, if it would be preferred without that, that would be fine as well. (The code is mostly pasted from existing parts anyways)

Comments on issues or better approaches to this would be very welcome :)

Fixes #290, showing sensible data there now (CPU type is still missing, but that should be unrelated):
```
--------------------------------------------------------------------------------
CPU name:       BCM2835
CPU type:       nil
CPU stepping:   3
********************************************************************************
Hardware Thread Topology
********************************************************************************
Sockets:                1
Cores per socket:       4
Threads per core:       1
--------------------------------------------------------------------------------
HWThread        Thread          Core            Socket          Available
0               0               0               0               *
1               0               1               0               *
2               0               2               0               *
3               0               3               0               *
--------------------------------------------------------------------------------
Socket 0:               ( 0 1 2 3 )
--------------------------------------------------------------------------------
********************************************************************************
Cache Topology
********************************************************************************
********************************************************************************
NUMA Topology
********************************************************************************
NUMA domains:           1
--------------------------------------------------------------------------------
Domain:                 0
Processors:             ( 0 1 2 3 )
Distances:              10
Free memory:            1570.78 MB
Total memory:           1865.91 MB
--------------------------------------------------------------------------------
```