### PR TITLE
#297 improve examples

### DIFF
--- a/examples/C-internalMarkerAPI.c
+++ b/examples/C-internalMarkerAPI.c
@@ -48,8 +48,15 @@ int main(int argc, char* argv[])
      * specified in `/<LIKWID_PREFIX>/share/likwid/perfgroups/<ARCHITECTURE>/`
      * (default prefix is `/usr/local`). The final group is a custom group
      * specified with EVENT_NAME:COUNTER_NAME
+     *
+     * Be aware that the groups chosen below are supported in most but not all
+     * architectures supported by likwid. For a more compatible set of groups,
+     * see commented group set. The second, more compatible set will work for
+     * all architectures supported by likwid except nvidiagpus and Xeon Phi
+     * (KNC). 
      */
-    char groups[] = "L2|L3|FLOPS_DP|INSTR_RETIRED_ANY:FIXC0";
+    char groups[] = "L2|FLOPS_DP|INSTR_RETIRED_ANY:FIXC0";
+    // char groups[] = "BRANCH|INSTR_RETIRED_ANY:FIXC0";
 
     /* list of processors that we will use */
     char cpulist[] = "0,2,3";
@@ -104,12 +111,24 @@ int main(int argc, char* argv[])
 {
     likwid_pinThread(cpus[omp_get_thread_num()]);
 
-    /* each thread must be initialized with LIKWID_MARKER_THREADINIT */
-    LIKWID_MARKER_THREADINIT;
+    /* LIKWID_MARKER_THREADINIT was required with past versions of likwid but
+     * now is now commonly not needed and, in fact, deprecated with likwid
+     * v5.0.1
+     *
+     * It is only required if the pinning library fails and threads could get
+     * migrated. I am currently unaware of any runtime system that doesn't
+     * work. 
+     */ 
+    // LIKWID_MARKER_THREADINIT;
 
     /* registering regions is optional but strongly recommended, as it reduces
      * overhead of LIKWID_MARKER_START and prevents wrong counts in short
      * regions 
+     *
+     * There must be a barrier between registering a region and starting that
+     * region. Typically these are done in separate parallel blocks, relying on
+     * the implicit barrier at the end of the parallel block. Usually there is
+     * a parallel block for initialization and a parallel block for execution.
      */
     LIKWID_MARKER_REGISTER("Total");
     LIKWID_MARKER_REGISTER("calc_flops");
@@ -131,15 +150,19 @@ int main(int argc, char* argv[])
     double events[MAX_NUM_EVENTS];
     double time = 0;
     int count = 0;
+
+    /* variables for inspecting events */
+    int gid;
+    char * group_name, * event_name;
     
     /* loop iterators */
-    int i, k;
+    int i, k, t;
 
     /* The code that is to be measured will be run multiple times to measure
      * each group specified above. perfmon_getNumberOfGroups makes it easy to
      * run computation once for each group.
      */
-    for (k=0; k<perfmon_getNumberOfGroups(); k++)
+    for (i=0; i<perfmon_getNumberOfGroups(); i++)
     {
         /* barriers are necessary when regions are started or stopped more than
          * once in a region. In this case, put a barrier before each call to
@@ -161,6 +184,62 @@ int main(int argc, char* argv[])
 
         #pragma omp barrier
 
+        /* LIKWID_MARKER_GET can give us some information about what happened
+         * in a region. The values of each event are stored in `events` and
+         * the number of events is stored in `nr_events`. We will inspect and
+         * reset events here, in the middle of computation, but regions may
+         * also be inspected after the marker API has been closed. This is
+         * demonstrated at the end of this file.
+         */
+        LIKWID_MARKER_GET("calc_flops", &nr_events, events, &time, &count);
+
+        /* group ID will let us get group and event names */
+        gid = perfmon_getIdOfActiveGroup();
+
+        /* get group name */
+        group_name = perfmon_getGroupName(gid);
+
+        /*print basic info */
+        printf("calc_flops iteration %d, thread %d finished measuring group "
+            "%s.\n"
+            "Got %d events, runtime %f s, and call count %d\n", 
+            i, omp_get_thread_num(), group_name, nr_events, time, count);
+
+        /* only allow one thread to print so that output is less verbose. The
+         * purpose of the barrier is to prevent garbled output
+         */
+        #pragma omp barrier
+        if(omp_get_thread_num() == 0)
+        {
+            /* uncomment the for loop if you'd like to inspect all threads */
+            t=0;
+            // for (t=0; t<NUM_THREADS; t++)
+            {
+                printf("detailed event results: \n");
+                for(k=0; k<nr_events; k++){
+                    /* get event name */
+                    event_name = perfmon_getEventName(gid, k);
+                    /* print results */
+                    printf("%40s: %30f\n", event_name, 
+                        perfmon_getResult(gid, k, t)
+                    );
+                }
+            }
+            printf("\n");
+        }
+
+        /* "nr_events" must be reset because LIKWID_MARKER_GET uses it to
+         * determine the capacity of "events"
+         */
+        nr_events = MAX_NUM_EVENTS;
+
+        /* regions may be reset during execution. Since we have already
+         * inspected results of the calc_flops region, we will reset it here:
+         */
+        LIKWID_MARKER_RESET("calc_flops");
+
+        #pragma omp barrier
+
         /* this region will measure memory-heavy code */
         LIKWID_MARKER_START("copy");
 
@@ -179,6 +258,9 @@ int main(int argc, char* argv[])
          * called in a parallel region, it must be preceeded by a barrier and
          * run in something like a "#pragma omp single" block to ensure only
          * one thread runs it
+         * 
+         * regions must be switched outside of all regions (e.g. after
+         * "LIKWID_MARKER_STOP" is called for each region)
          */
         #pragma omp single
         {
@@ -186,27 +268,25 @@ int main(int argc, char* argv[])
         }
     }
 
-    /* LIKWID_MARKER_GET can give us some information about what happened in
-     * that region. The values of each event are stored in `events` and may be
-     * inspected here if desired. We choose not to, as we will inspect
-     * everything at the end.
+    /* for demonstration, we will inspect "calc_flops" region again even though
+     * it has been rest.
      */
+    if(omp_get_thread_num() == 0)
+        printf("notice that calc_flops has no calls, since we reset it.\n");
     LIKWID_MARKER_GET("calc_flops", &nr_events, events, &time, &count);
     printf("calc_flops Thread %d got %d events, runtime %f s, call count %d\n", 
         omp_get_thread_num(), nr_events, time, count);
-
-    /* "nr_events" must be reset because LIKWID_MARKER_GET uses it as the size
-     * of "events"
-     */
     nr_events = MAX_NUM_EVENTS;
 
     /* basic info on "copy" region */
+    #pragma omp barrier /* to prevent garbled output */
     LIKWID_MARKER_GET("copy", &nr_events, events, &time, &count);
     printf("copy Thread %d got %d events, runtime %f s, call count %d\n", 
         omp_get_thread_num(), nr_events, time, count);
     nr_events = MAX_NUM_EVENTS;
 
     /* basic info on "Total" region */
+    #pragma omp barrier /* to prevent garbled output */
     LIKWID_MARKER_GET("Total", &nr_events, events, &time, &count);
     printf("Total Thread %d got %d events, runtime %f s, call count %d\n", 
         omp_get_thread_num(), nr_events, time, count);
@@ -238,7 +318,15 @@ int main(int argc, char* argv[])
     /* read file output by likwid so that we can process results */
     perfmon_readMarkerFile(getenv("LIKWID_FILEPATH"));
 
-    /* get information like region name, number of events, number of metrics */
+    /* get information like region name, number of events, number of metrics.
+     * Notice that number of regions printed here is actually
+     * (num_regions*num_groups), because perfmon considers a region to be the
+     * region/group combo. In other words, each time a region is measured with
+     * a different group or event set, perfmon considers it a new region.
+     *
+     * Therefore, if we have two regions and 3 groups measured for each,
+     * perfmon_getNumberOfRegions() will return 6
+     */
     printf("Marker API measured %d regions\n", perfmon_getNumberOfRegions());
     for (i=0;i<perfmon_getNumberOfRegions();i++)
     {
@@ -250,34 +338,39 @@ int main(int argc, char* argv[])
     printf("\n");
 
     /* Print per-thread results. */
-    printf("detailed results for each thread follow:\n");
+    printf("detailed results follow. Notice that the region \"calc_flops\"\n"
+        "will not appear, as it was reset after each time it was measured.\n");
+    printf("\n");
 
     const char * result_header = "%6s : %15s : %10s : %6s : %40s : %30s \n";
     const char * result_format = "%6d : %15s : %10s : %6s : %40s : %30f \n";
     printf(result_header, "thread", "region", "group", "type", 
         "result name", "result value");
 
-    for (t = 0; t < NUM_THREADS; t++) 
+    /* uncomment the for loop if you'd like to inspect all threads */
+    t = 0;
+    // for (t = 0; t < NUM_THREADS; t++) 
     {
-        /* perfmon_getNumberOfRegions actually returns num_regions *
-         * num_groups. This is because this function considers every
-         * combination of region and group its own region.
-         */
         for (i = 0; i < perfmon_getNumberOfRegions(); i++) 
         {
+            /* returns the user-supplied region name */
             regionName = perfmon_getTagOfRegion(i);
 
             /* gid is the group ID independent of region, where as i is the ID
              * of the region/group combo
              */
             gid = perfmon_getGroupOfRegion(i);
+            /* get the name of the group measured, like "FLOPS_DP" or "L2" */
             groupName = perfmon_getGroupName(gid);
 
             /* get info for each event */
             for (k = 0; k < perfmon_getNumberOfEvents(gid); k++) 
             {
+                /* get the event name, like "INSTR_RETIRED_ANY" */
                 event_name = perfmon_getEventName(gid, k);
+                /* get the associated value */
                 event_value = perfmon_getResultOfRegionThread(i, k, t);
+
                 printf(result_format, t, regionName, groupName, "event", 
                     event_name, event_value);
             }
@@ -285,8 +378,11 @@ int main(int argc, char* argv[])
             /* get info for each metric */
             for (k = 0; k < perfmon_getNumberOfMetrics(gid); k++) 
             {
+                /* get the metric name, like "L2 bandwidth [MBytes/s]" */
                 metric_name = perfmon_getMetricName(gid, k);
+                /* get the associated value */
                 metric_value = perfmon_getMetricOfRegionThread(i, k, t);
+
                 printf(result_format, t, regionName, groupName, "metric", 
                     metric_name, metric_value);
             }

--- a/examples/C-internalMarkerAPI.c
+++ b/examples/C-internalMarkerAPI.c
@@ -1,3 +1,43 @@
+/*
+ * ==========================================================================
+ *
+ *      Filename:  C-internalMarkerAPI.c
+ *
+ *      Description:  Example how to use the C/C++ Marker API internally.
+ *                    Avoids the likwid-perfctr CLI for setting environment
+ *                    variables, pinning threads, and inspecting results.
+ *
+ *      Version:   1.0.0
+ *      Released:  2020-07-06
+ *
+ *      Author:   Riley Weber, rileyw13@protonmail.com
+ *      Project:  likwid
+ *
+ *
+ *      This program is free software: you can redistribute it and/or modify it
+ *      under the terms of the GNU General Public License as published by the
+ *      Free Software Foundation, either version 3 of the License, or (at your
+ *      option) any later version.
+ *
+ *      This program is distributed in the hope that it will be useful, but
+ *      WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along
+ *      with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * ==========================================================================
+ *
+ *      Usage: 
+ *
+ *      After installing likwid, change to the `examples` directory. Then, use
+ *      `make C-internalMarkerAPI` to compile and 
+ *      `make C-internalMarkerAPI-run` to run. 
+ *
+ * ==========================================================================
+ */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>

--- a/examples/C-internalMarkerAPI.c
+++ b/examples/C-internalMarkerAPI.c
@@ -83,6 +83,15 @@ int main(int argc, char* argv[])
      * specify environment variables at runtime, be sure to pin threads with 
      * likwid-pin, GOMP_CPU_AFFINITY, or similar.
      */
+    
+    if(getenv("LIKWID_PIN"))
+    {
+        fprintf(stderr, "ERROR: it appears you are running this example with "
+            "likwid-perfctr. This example\n"
+            "is intended to be run alone. Results will be incorrect "
+            "or missing.\n");
+        exit(1);
+    }
 
     /* The first envrionment variable is "LIKWID_EVENTS", which indicates the
      * groups to be measured. In this case, the first 3 are group names

--- a/examples/C-markerAPI.c
+++ b/examples/C-markerAPI.c
@@ -120,9 +120,12 @@ int main(int argc, char* argv[])
             printf("Thread %d wakes up again\n", omp_get_thread_num());
 
             // If you need the performance data inside your application, use
+            // LIKWID_MARKER_GET. events is an array of doubles with
+            // nevents entries, time is a double* and count an int*.
             LIKWID_MARKER_GET("example", &nevents, events, &time, &count);
-            // where events is an array of doubles with nevents entries,
-            // time is a double* and count an int*.
+
+            // this check ensures that nothing will be printed if
+            // -DLIKWID_PERFMON is not included
             if(nevents > 0){
                 printf("Region example measures %d events, total measurement time is %f\n", nevents, time);
                 printf("The region was called %d times\n", count);
@@ -135,7 +138,8 @@ int main(int argc, char* argv[])
 
         // If multiple groups are given, you can switch to the next group. This
         // function has no effect if one group is specified. Notice that this
-        // is called outside the parallel region: this is required.
+        // is called outside the parallel region, as it should only be run by a
+        // single thread
         LIKWID_MARKER_SWITCH;
     }
 

--- a/examples/C-markerAPI.c
+++ b/examples/C-markerAPI.c
@@ -133,7 +133,9 @@ int main(int argc, char* argv[])
             }
         }
 
-        // If multiple groups given, you can switch to the next group
+        // If multiple groups are given, you can switch to the next group. This
+        // function has no effect if one group is specified. Notice that this
+        // is called outside the parallel region: this is required.
         LIKWID_MARKER_SWITCH;
     }
 

--- a/examples/C-markerAPI.c
+++ b/examples/C-markerAPI.c
@@ -8,7 +8,8 @@
  *      Version:   <VERSION>
  *      Released:  <DATE>
  *
- *      Author:  Thomas Gruber (tr), thomas.roehl@googlemail.com
+ *      Authors:  Thomas Gruber (tr), thomas.roehl@googlemail.com
+ *                Riley Weber, rileyw13@protonmail.com
  *      Project:  likwid
  *
  *      Copyright (C) 2015 RRZE, University Erlangen-Nuremberg

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -28,7 +28,7 @@ C-markerAPI:
 	$(CC) -fopenmp $(LIKWID_DEFINES) $(LIKWID_INCLUDE) $(LIKWID_LIBDIR) C-markerAPI.c -o C-markerAPI $(LIKWID_LIB) -lm
 
 C-markerAPI-run: C-markerAPI
-	$(LIKWID_BINDIR)/likwid-perfctr -C 0 -g INSTR_RETIRED_ANY:FIXC0 -m ./C-markerAPI
+	LD_LIBRARY_PATH=$(PREFIX)/lib $(LIKWID_BINDIR)/likwid-perfctr -C 0 -g INSTR_RETIRED_ANY:FIXC0 -m ./C-markerAPI
 
 C-likwidAPI:
 	$(CC) -fopenmp $(LIKWID_INCLUDE) $(LIKWID_LIBDIR) C-likwidAPI.c -o C-likwidAPI $(LIKWID_LIB) -lm

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,7 +40,7 @@ C-internalMarkerAPI:
 	$(CC) -g -fopenmp $(LIKWID_DEFINES) $(LIKWID_INCLUDE) $(LIKWID_LIBDIR) C-internalMarkerAPI.c -o C-internalMarkerAPI $(LIKWID_LIB) -lm
 
 C-internalMarkerAPI-run: C-internalMarkerAPI
-	OMP_NUM_THREADS=3 ./C-internalMarkerAPI
+	LD_LIBRARY_PATH=$(PREFIX)/lib ./C-internalMarkerAPI
 
 monitoring:
 	$(CC) $(LIKWID_INCLUDE) $(LIKWID_LIBDIR) monitoring.c -o monitoring $(LIKWID_LIB) -lm


### PR DESCRIPTION
`C-markerAPI` is a simple example and `C-internalMarkerAPI` is more complete. Examples now work with current version of likwid (v5.0.1) and comments have been dramatically improved.

Mentioned in RRZE-HPC/likwid#292
Part of RRZE-HPC/likwid#297