### PR TITLE
Add support for AMD Zen3 (Ryzen and probably Milan). 

### DIFF
--- a/src/access-daemon/accessDaemon.c
+++ b/src/access-daemon/accessDaemon.c
@@ -2005,6 +2005,12 @@ int main(void)
                     allowed = allowed_amd17;
                 }
                 break;
+            case ZEN3_FAMILY:
+                if (model == ZEN3_RYZEN || model == ZEN3_RYZEN2)
+                {
+                    allowed = allowed_amd17_zen2;
+                }
+                break;
             default:
                 syslog(LOG_ERR, "ERROR - [%s:%d] - Unsupported processor. Exiting!  \n",
                         __FILE__, __LINE__);

--- a/src/includes/perfmon_types.h
+++ b/src/includes/perfmon_types.h
@@ -65,8 +65,10 @@ typedef enum {
     EVENT_OPTION_MASK1, /*!< \brief Mask1 register */
     EVENT_OPTION_MASK2, /*!< \brief Mask2 register */
     EVENT_OPTION_MASK3, /*!< \brief Mask3 register */
-    EVENT_OPTION_NID, /*!< \brief Set NUMA node ID */
-    EVENT_OPTION_TID, /*!< \brief Set Thread ID */
+    EVENT_OPTION_NID, /*!< \brief Set NUMA node IDs */
+    EVENT_OPTION_TID, /*!< \brief Set Thread IDs */
+    EVENT_OPTION_CID, /*!< \brief Set Core IDs */
+    EVENT_OPTION_SLICE, /*!< \brief Set Slice IDs, often when the L3 is assembled with different sections */
     EVENT_OPTION_STATE, /*!< \brief Match for state */
     EVENT_OPTION_EDGE, /*!< \brief Increment counter at each edge */
     EVENT_OPTION_THRESHOLD, /*!< \brief Increment only if exceeding threshold */
@@ -129,6 +131,8 @@ extern char* eventOptionTypeName[NUM_EVENT_OPTIONS];
 #define EVENT_OPTION_MASK3_MASK (1ULL<<EVENT_OPTION_MASK3)
 #define EVENT_OPTION_NID_MASK (1ULL<<EVENT_OPTION_NID)
 #define EVENT_OPTION_TID_MASK (1ULL<<EVENT_OPTION_TID)
+#define EVENT_OPTION_CID_MASK (1ULL<<EVENT_OPTION_CID)
+#define EVENT_OPTION_SLICE_MASK (1ULL<<EVENT_OPTION_SLICE)
 #define EVENT_OPTION_STATE_MASK (1ULL<<EVENT_OPTION_STATE)
 #define EVENT_OPTION_EDGE_MASK (1ULL<<EVENT_OPTION_EDGE)
 #define EVENT_OPTION_THRESHOLD_MASK (1ULL<<EVENT_OPTION_THRESHOLD)

--- a/src/includes/perfmon_zen3.h
+++ b/src/includes/perfmon_zen3.h
@@ -1,0 +1,544 @@
+/*
+ * =======================================================================================
+ *
+ *      Filename:  perfmon_zen3.h
+ *
+ *      Description:  Header file of perfmon module for AMD Family 19 (ZEN3)
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Gruber (tg), thomas.roehl@googlemail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2017 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
+
+#include <perfmon_zen3_events.h>
+#include <perfmon_zen3_counters.h>
+#include <error.h>
+#include <affinity.h>
+
+
+
+static int perfmon_numCountersZen3 = NUM_COUNTERS_ZEN3;
+static int perfmon_numArchEventsZen3 = NUM_ARCH_EVENTS_ZEN3;
+
+int perfmon_init_zen3(int cpu_id)
+{
+    lock_acquire((int*) &socket_lock[affinity_thread2socket_lookup[cpu_id]], cpu_id);
+    lock_acquire((int*) &core_lock[affinity_thread2core_lookup[cpu_id]], cpu_id);
+    lock_acquire((int*) &sharedl3_lock[affinity_thread2sharedl3_lookup[cpu_id]], cpu_id);
+    lock_acquire((int*) &numa_lock[affinity_thread2numa_lookup[cpu_id]], cpu_id);
+    return 0;
+}
+
+int zen3_fixed_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
+{
+    uint64_t flags = 0x0ULL;
+    cpu_id++;
+    index++;
+    switch (event->eventId)
+    {
+        case 0x1:
+            flags |= (1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT);
+            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, SETUP_FIXC0);
+            break;
+        case 0x2:
+        case 0x3:
+            break;
+        default:
+            fprintf(stderr, "Unknown fixed event 0x%X\n", event->eventId);
+            break;
+    }
+    return flags;
+}
+
+int zen3_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
+{
+    uint64_t flags = 0x0ULL;
+
+    // per default LIKWID counts in user-space
+    flags |= (1ULL<<AMD_K17_PMC_USER_BIT);
+    flags |= ((event->umask & AMD_K17_PMC_UNIT_MASK) << AMD_K17_PMC_UNIT_SHIFT);
+    flags |= ((event->eventId & AMD_K17_PMC_EVSEL_MASK) << AMD_K17_PMC_EVSEL_SHIFT);
+    flags |= (((event->eventId >> 8) & AMD_K17_PMC_EVSEL_MASK2) << AMD_K17_PMC_EVSEL_SHIFT2);
+
+    if (event->numberOfOptions > 0)
+    {
+        for(int j=0;j<event->numberOfOptions;j++)
+        {
+            switch (event->options[j].type)
+            {
+                case EVENT_OPTION_EDGE:
+                    flags |= (1ULL<<AMD_K17_PMC_EDGE_BIT);
+                    break;
+                case EVENT_OPTION_COUNT_KERNEL:
+                    flags |= (1ULL<<AMD_K17_PMC_KERNEL_BIT);
+                    break;
+                case EVENT_OPTION_INVERT:
+                    flags |= (1ULL<<AMD_K17_PMC_INVERT_BIT);
+                    break;
+                case EVENT_OPTION_THRESHOLD:
+                    flags |= (event->options[j].value & AMD_K17_PMC_THRES_MASK) << AMD_K17_PMC_THRES_SHIFT;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    if (flags != currentConfig[cpu_id][index])
+    {
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
+        currentConfig[cpu_id][index] = flags;
+    }
+    return 0;
+}
+
+int zen3_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
+{
+    uint64_t flags = 0x0ULL;
+    int has_tid = 0;
+    int has_cid = 0;
+    int has_slice = 0;
+
+    if (sharedl3_lock[affinity_thread2sharedl3_lookup[cpu_id]] != cpu_id)
+    {
+        return 0;
+    }
+
+    flags |= ((event->umask & AMD_K17_L3_UNIT_MASK) << AMD_K17_L3_UNIT_SHIFT);
+    flags |= ((event->eventId & AMD_K17_L3_EVSEL_MASK) << AMD_K17_L3_EVSEL_SHIFT);
+    if (event->numberOfOptions > 0)
+    {
+        for(int j=0;j<event->numberOfOptions;j++)
+        {
+            switch (event->options[j].type)
+            {
+                case EVENT_OPTION_TID:
+                    flags |= ((uint64_t)(event->options[j].value & AMD_K17_L3_TID_MASK)) << AMD_K17_L3_TID_SHIFT;
+                    has_tid = 1;
+                    break;
+                case EVENT_OPTION_CID:
+                    flags |= ((uint64_t)(event->options[j].value & AMD_K17_L3_CID_MASK)) << AMD_K17_L3_CID_SHIFT;
+                    has_cid = 1;
+                    break;
+                case EVENT_OPTION_SLICE:
+                    flags |= ((uint64_t)(event->options[j].value & AMD_K17_L3_SLICE_MASK)) << AMD_K17_L3_SLICE_SHIFT;
+                    has_slice = 1;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+    if (!has_tid)
+        flags |= 0x3ULL << AMD_K17_L3_TID_SHIFT;
+    if (!has_slice)
+        flags |= 0x1ULL << AMD_K17_L3_ALL_SLICES_BIT;
+    if (!has_cid)
+        flags |= 0x1ULL << AMD_K17_L3_ALL_CORES_BIT;
+
+    if (flags != currentConfig[cpu_id][index])
+    {
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
+        currentConfig[cpu_id][index] = flags;
+    }
+    return 0;
+}
+
+int zen3_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
+{
+    uint64_t flags = 0x0ULL;
+
+    if (socket_lock[affinity_thread2socket_lookup[cpu_id]] != cpu_id)
+    {
+        return 0;
+    }
+
+    flags |= ((event->eventId & AMD_K17_DF_EVSEL_MASK) << AMD_K17_DF_EVSEL_SHIFT);
+    flags |= (((event->eventId >> 8) & AMD_K17_DF_EVSEL_MASK1) << AMD_K17_DF_EVSEL_SHIFT1);
+    flags |= (((event->eventId >> 12) & AMD_K17_DF_EVSEL_MASK2) << AMD_K17_DF_EVSEL_SHIFT2);
+
+    flags |= ((event->umask & AMD_K17_DF_UNIT_MASK) << AMD_K17_DF_UNIT_SHIFT);
+
+
+    if (flags != currentConfig[cpu_id][index])
+    {
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_DF);
+        CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
+        currentConfig[cpu_id][index] = flags;
+    }
+    return 0;
+}
+
+int perfmon_setupCounterThread_zen3(int thread_id, PerfmonEventSet* eventSet)
+{
+    int cpu_id = groupSet->threads[thread_id].processorId;
+    uint64_t fixed_flags = 0x0ULL;
+
+    for (int i=0;i < eventSet->numberOfEvents;i++)
+    {
+        RegisterType type = eventSet->events[i].type;
+        if (!TESTTYPE(eventSet, type))
+        {
+            continue;
+        }
+        RegisterIndex index = eventSet->events[i].index;
+        PerfmonEvent *event = &(eventSet->events[i].event);
+        switch (type)
+        {
+            case PMC:
+                zen2_pmc_setup(cpu_id, index, event);
+                break;
+            case CBOX0:
+                zen2_cache_setup(cpu_id, index, event);
+                break;
+            case POWER:
+                break;
+            case FIXED:
+                fixed_flags |= zen2_fixed_setup(cpu_id, index, event);
+                break;
+            case MBOX0:
+                zen2_uncore_setup(cpu_id, index, event);
+                break;
+            default:
+                break;
+        }
+        eventSet->events[i].threadCounter[thread_id].init = TRUE;
+    }
+    if ((fixed_flags > 0x0ULL))
+    {
+        uint64_t tmp = 0x0ULL;
+        CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, &tmp));
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, READ_HW_CONFIG);
+        tmp |= fixed_flags;
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, WRITE_HW_CONFIG)
+        CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, tmp));
+    }
+    return 0;
+}
+
+
+int perfmon_startCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
+{
+    int haveSLock = 0;
+    int haveL3Lock = 0;
+    int haveCLock = 0;
+    int haveMLock = 0;
+    uint64_t flags = 0x0ULL;
+    int cpu_id = groupSet->threads[thread_id].processorId;
+
+    if (socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
+    {
+        haveSLock = 1;
+    }
+    if (sharedl3_lock[affinity_thread2sharedl3_lookup[cpu_id]] == cpu_id)
+    {
+        haveL3Lock = 1;
+    }
+    if (core_lock[affinity_thread2core_lookup[cpu_id]] == cpu_id)
+    {
+        haveCLock = 1;
+    }
+    if (numa_lock[affinity_thread2numa_lookup[cpu_id]] == cpu_id)
+    {
+        haveMLock = 1;
+    }
+
+    for (int i=0;i < eventSet->numberOfEvents;i++)
+    {
+        if (eventSet->events[i].threadCounter[thread_id].init == TRUE)
+        {
+            RegisterType type = eventSet->events[i].type;
+            if (!TESTTYPE(eventSet, type))
+            {
+                continue;
+            }
+            flags = 0x0ULL;
+            RegisterIndex index = eventSet->events[i].index;
+            uint32_t reg = counter_map[index].configRegister;
+            uint32_t counter = counter_map[index].counterRegister;
+            eventSet->events[i].threadCounter[thread_id].startData = 0;
+            eventSet->events[i].threadCounter[thread_id].counterData = 0;
+            if ((type == PMC) ||
+                ((type == MBOX0) && (haveSLock)) ||
+                ((type == CBOX0) && (haveL3Lock)))
+            {
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, RESET_CTR);
+                CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter, 0x0ULL));
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, READ_CTRL);
+                flags |= (1ULL << AMD_K17_ENABLE_BIT);  /* enable flag */
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, START_CTRL);
+                CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
+            }
+            else if (type == POWER)
+            {
+                if (counter == MSR_AMD17_RAPL_PKG_STATUS && (!haveSLock))
+                    continue;
+                if (counter == MSR_AMD17_RAPL_CORE_STATUS && (!haveCLock))
+                    continue;
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
+                eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_POWER);
+            }
+            else if (type == FIXED)
+            {
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
+                eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_FIXED);
+            }
+            eventSet->events[i].threadCounter[thread_id].counterData = eventSet->events[i].threadCounter[thread_id].startData;
+        }
+    }
+    return 0;
+}
+
+int perfmon_stopCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
+{
+    uint64_t flags = 0x0ULL;
+    int haveSLock = 0;
+    int haveL3Lock = 0;
+    int haveCLock = 0;
+    int haveMLock = 0;
+    uint64_t counter_result = 0x0ULL;
+    int cpu_id = groupSet->threads[thread_id].processorId;
+
+    if (socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
+    {
+        haveSLock = 1;
+    }
+    if (sharedl3_lock[affinity_thread2sharedl3_lookup[cpu_id]] == cpu_id)
+    {
+        haveL3Lock = 1;
+    }
+    if (core_lock[affinity_thread2core_lookup[cpu_id]] == cpu_id)
+    {
+        haveCLock = 1;
+    }
+    if (numa_lock[affinity_thread2numa_lookup[cpu_id]] == cpu_id)
+    {
+        haveMLock = 1;
+    }
+
+    for (int i=0;i < eventSet->numberOfEvents;i++)
+    {
+        if (eventSet->events[i].threadCounter[thread_id].init == TRUE)
+        {
+            RegisterType type = eventSet->events[i].type;
+            if (!TESTTYPE(eventSet, type))
+            {
+                continue;
+            }
+            counter_result = 0x0ULL;
+            RegisterIndex index = eventSet->events[i].index;
+            uint32_t reg = counter_map[index].configRegister;
+            uint32_t counter = counter_map[index].counterRegister;
+            if ((type == PMC) ||
+                ((type == MBOX0) && (haveSLock)) ||
+                ((type == CBOX0) && (haveL3Lock)))
+            {
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
+                flags &= ~(1ULL<<AMD_K17_ENABLE_BIT);  /* clear enable flag */
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, STOP_CTRL);
+                CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, READ_CTR);
+                if (field64(counter_result, 0, box_map[type].regWidth) < eventSet->events[i].threadCounter[thread_id].counterData)
+                {
+                    eventSet->events[i].threadCounter[thread_id].overflows++;
+                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, OVERFLOW);
+                }
+            }
+            else if (type == POWER)
+            {
+                if (counter == MSR_AMD17_RAPL_PKG_STATUS && (!haveSLock))
+                    continue;
+                if (counter == MSR_AMD17_RAPL_CORE_STATUS && (!haveCLock))
+                    continue;
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
+                counter_result = field64(counter_result, 0, box_map[type].regWidth);
+                if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
+                {
+                    eventSet->events[i].threadCounter[thread_id].overflows++;
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                }
+
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_POWER);
+            }
+            else if (type == FIXED)
+            {
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
+                counter_result = field64(counter_result, 0, box_map[type].regWidth);
+                if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
+                {
+                    eventSet->events[i].threadCounter[thread_id].overflows++;
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                }
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_FIXED);
+            }
+            eventSet->events[i].threadCounter[thread_id].counterData = counter_result;
+        }
+    }
+    return 0;
+}
+
+
+int perfmon_readCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
+{
+    int haveSLock = 0;
+    int haveL3Lock = 0;
+    int haveCLock = 0;
+    int haveMLock = 0;
+    uint64_t counter_result = 0x0ULL;
+    int cpu_id = groupSet->threads[thread_id].processorId;
+
+    if (socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
+    {
+        haveSLock = 1;
+    }
+    if (sharedl3_lock[affinity_thread2sharedl3_lookup[cpu_id]] == cpu_id)
+    {
+        haveL3Lock = 1;
+    }
+    if (core_lock[affinity_thread2core_lookup[cpu_id]] == cpu_id)
+    {
+        haveCLock = 1;
+    }
+    if (numa_lock[affinity_thread2numa_lookup[cpu_id]] == cpu_id)
+    {
+        haveMLock = 1;
+    }
+
+    for (int i=0;i < eventSet->numberOfEvents;i++)
+    {
+        if (eventSet->events[i].threadCounter[thread_id].init == TRUE)
+        {
+            RegisterType type = eventSet->events[i].type;
+            if (!TESTTYPE(eventSet, type))
+            {
+                continue;
+            }
+            counter_result = 0x0ULL;
+            RegisterIndex index = eventSet->events[i].index;
+            uint32_t counter = counter_map[index].counterRegister;
+            uint64_t* current = &(eventSet->events[i].threadCounter[thread_id].counterData);
+            if ((type == PMC) ||
+                ((type == MBOX0) && (haveSLock)) ||
+                ((type == CBOX0) && (haveL3Lock)))
+            {
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
+                VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_CTR);
+                if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
+                {
+                    eventSet->events[i].threadCounter[thread_id].overflows++;
+                }
+                *current = field64(counter_result, 0, box_map[type].regWidth);
+            }
+            else if (type == POWER)
+            {
+                if (counter == MSR_AMD17_RAPL_PKG_STATUS && (!haveSLock))
+                    continue;
+                if (counter == MSR_AMD17_RAPL_CORE_STATUS && (!haveCLock))
+                    continue;
+                CHECK_POWER_READ_ERROR(power_read(cpu_id, counter, (uint32_t*)&counter_result));
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_POWER)
+                if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
+                {
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    eventSet->events[i].threadCounter[thread_id].overflows++;
+                }
+                *current = field64(counter_result, 0, box_map[type].regWidth);
+            }
+            else if (type == FIXED)
+            {
+                CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
+                {
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    eventSet->events[i].threadCounter[thread_id].overflows++;
+                }
+                *current = field64(counter_result, 0, box_map[type].regWidth);
+            }
+        }
+    }
+    return 0;
+}
+
+
+int perfmon_finalizeCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
+{
+    int haveSLock = 0;
+    int haveMLock = 0;
+    int haveL3Lock = 0;
+    int cpu_id = groupSet->threads[thread_id].processorId;
+
+    if (socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
+    {
+        haveSLock = 1;
+    }
+    if (sharedl3_lock[affinity_thread2sharedl3_lookup[cpu_id]] == cpu_id)
+    {
+        haveL3Lock = 1;
+    }
+    if (numa_lock[affinity_thread2numa_lookup[cpu_id]] == cpu_id)
+    {
+        haveMLock = 1;
+    }
+
+
+    for (int i=0;i < eventSet->numberOfEvents;i++)
+    {
+        RegisterType type = eventSet->events[i].type;
+        if (!TESTTYPE(eventSet, type))
+        {
+            continue;
+        }
+        RegisterIndex index = eventSet->events[i].index;
+        if ((type == PMC) ||
+            ((type == MBOX0) && (haveSLock)) ||
+            ((type == CBOX0) && (haveL3Lock)))
+        {
+            if (counter_map[index].configRegister != 0x0)
+            {
+                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, CLEAR_CTRL);
+                CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, 0x0ULL));
+            }
+            if (counter_map[index].counterRegister != 0x0)
+            {
+                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+                CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
+            }
+            eventSet->events[i].threadCounter[thread_id].init = FALSE;
+        }
+        else if (type == FIXED)
+        {
+            uint64_t tmp = 0x0ULL;
+            CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, &tmp));
+            if (tmp & (1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT))
+            {
+                tmp &= ~(1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT);
+            }
+            CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, tmp));
+        }
+    }
+    return 0;
+}

--- a/src/includes/perfmon_zen3_counters.h
+++ b/src/includes/perfmon_zen3_counters.h
@@ -1,0 +1,94 @@
+/*
+ * =======================================================================================
+ *
+ *      Filename:  perfmon_zen3_counters.h
+ *
+ *      Description:  Counter Header File of perfmon module for AMD Family 19 (Zen3)
+ *
+ *      Version:   <VERSION>
+ *      Released:  <DATE>
+ *
+ *      Author:   Thomas Gruber (tr), thomas.roehl@googlemail.com
+ *      Project:  likwid
+ *
+ *      Copyright (C) 2017 RRZE, University Erlangen-Nuremberg
+ *
+ *      This program is free software: you can redistribute it and/or modify it under
+ *      the terms of the GNU General Public License as published by the Free Software
+ *      Foundation, either version 3 of the License, or (at your option) any later
+ *      version.
+ *
+ *      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ *      You should have received a copy of the GNU General Public License along with
+ *      this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * =======================================================================================
+ */
+
+#define NUM_COUNTERS_ZEN3 21
+#define NUM_COUNTERS_CORE_ZEN3 9
+
+#define AMD_K17_DF_EVSEL_SHIFT  0
+#define AMD_K17_DF_EVSEL_MASK   0xFFULL
+#define AMD_K17_DF_EVSEL_SHIFT1 32
+#define AMD_K17_DF_EVSEL_MASK1  0xFULL
+#define AMD_K17_DF_EVSEL_SHIFT2 59
+#define AMD_K17_DF_EVSEL_MASK2  0x3ULL
+#define AMD_K17_DF_UNIT_SHIFT   8
+#define AMD_K17_DF_UNIT_MASK    0xFFULL
+
+#define AMD_K17_L3_CID_SHIFT 42
+#define AMD_K17_L3_CID_MASK 0x7ULL
+#define AMD_K17_L3_ALL_SLICES_BIT 46
+#define AMD_K17_L3_ALL_CORES_BIT 47
+
+#define ZEN3_VALID_OPTIONS_PMC EVENT_OPTION_EDGE_MASK|EVENT_OPTION_COUNT_KERNEL_MASK|EVENT_OPTION_INVERT_MASK|EVENT_OPTION_THRESHOLD_MASK
+#define ZEN3_VALID_OPTIONS_L3 EVENT_OPTION_TID_MASK|EVENT_OPTION_CID_MASK|EVENT_OPTION_SLICE_MASK
+
+static RegisterMap zen3_counter_map[NUM_COUNTERS_ZEN2] = {
+    /* Fixed counters */
+    {"FIXC0", PMC0, FIXED, MSR_AMD17_HW_CONFIG, MSR_AMD17_RO_INST_RETIRED_CTR, 0, 0, 0},
+    {"FIXC1", PMC1, FIXED, 0, MSR_AMD17_RO_APERF, 0, 0, 0},
+    {"FIXC2", PMC2, FIXED, 0, MSR_AMD17_RO_MPERF, 0, 0, 0},
+    /* Core counters */
+    {"PMC0",PMC3, PMC, MSR_AMD17_PERFEVTSEL0, MSR_AMD17_PMC0, 0, 0, ZEN3_VALID_OPTIONS_PMC},
+    {"PMC1",PMC4, PMC, MSR_AMD17_PERFEVTSEL1, MSR_AMD17_PMC1, 0, 0, ZEN3_VALID_OPTIONS_PMC},
+    {"PMC2",PMC5, PMC, MSR_AMD17_PERFEVTSEL2, MSR_AMD17_PMC2, 0, 0, ZEN3_VALID_OPTIONS_PMC},
+    {"PMC3",PMC6, PMC, MSR_AMD17_PERFEVTSEL3, MSR_AMD17_PMC3, 0, 0, ZEN3_VALID_OPTIONS_PMC},
+    {"PMC4",PMC7, PMC, MSR_AMD17_2_PERFEVTSEL4, MSR_AMD17_2_PMC4, 0, 0, ZEN3_VALID_OPTIONS_PMC},
+    {"PMC5",PMC8, PMC, MSR_AMD17_2_PERFEVTSEL5, MSR_AMD17_2_PMC5, 0, 0, ZEN3_VALID_OPTIONS_PMC},
+    /* L3 cache counters */
+    {"CPMC0",PMC9, CBOX0, MSR_AMD17_L3_PERFEVTSEL0, MSR_AMD17_L3_PMC0, 0, 0, ZEN3_VALID_OPTIONS_L3},
+    {"CPMC1",PMC10, CBOX0, MSR_AMD17_L3_PERFEVTSEL1, MSR_AMD17_L3_PMC1, 0, 0, ZEN3_VALID_OPTIONS_L3},
+    {"CPMC2",PMC11, CBOX0, MSR_AMD17_L3_PERFEVTSEL2, MSR_AMD17_L3_PMC2, 0, 0, ZEN3_VALID_OPTIONS_L3},
+    {"CPMC3",PMC12, CBOX0, MSR_AMD17_L3_PERFEVTSEL3, MSR_AMD17_L3_PMC3, 0, 0, ZEN3_VALID_OPTIONS_L3},
+    {"CPMC4",PMC13, CBOX0, MSR_AMD17_L3_PERFEVTSEL4, MSR_AMD17_L3_PMC4, 0, 0, ZEN3_VALID_OPTIONS_L3},
+    {"CPMC5",PMC14, CBOX0, MSR_AMD17_L3_PERFEVTSEL5, MSR_AMD17_L3_PMC5, 0, 0, ZEN3_VALID_OPTIONS_L3},
+    /* Energy counters */
+    {"PWR0", PMC15, POWER, 0, MSR_AMD17_RAPL_CORE_STATUS, 0, 0},
+    {"PWR1", PMC16, POWER, 0, MSR_AMD17_RAPL_PKG_STATUS, 0, 0},
+    /* Data fabric counters */
+    {"DFC0",PMC17, MBOX0, MSR_AMD17_2_DF_PERFEVTSEL0, MSR_AMD17_2_DF_PMC0, 0, 0},
+    {"DFC1",PMC18, MBOX0, MSR_AMD17_2_DF_PERFEVTSEL1, MSR_AMD17_2_DF_PMC1, 0, 0},
+    {"DFC2",PMC19, MBOX0, MSR_AMD17_2_DF_PERFEVTSEL2, MSR_AMD17_2_DF_PMC2, 0, 0},
+    {"DFC3",PMC20, MBOX0, MSR_AMD17_2_DF_PERFEVTSEL3, MSR_AMD17_2_DF_PMC3, 0, 0},
+};
+
+static BoxMap zen3_box_map[NUM_UNITS] = {
+    [FIXED] = {0, 0, 0, 0, 0, 0, 64},
+    [PMC] = {0, 0, 0, 0, 0, 0, 48},
+    [CBOX0] = {0, 0, 0, 0, 0, 0, 48},
+    [MBOX0] = {0, 0, 0, 0, 0, 0, 48},
+    [POWER] = {0, 0, 0, 0, 0, 0, 32},
+};
+
+static char* zen3_translate_types[NUM_UNITS] = {
+    [FIXED] = "/sys/bus/event_source/devices/msr",
+    [PMC] = "/sys/bus/event_source/devices/cpu",
+    [POWER] = "/sys/bus/event_source/devices/power",
+    [CBOX0] = "/sys/bus/event_source/devices/amd_l3",
+    [MBOX0] = "/sys/bus/event_source/devices/amd_nb",
+};

--- a/src/includes/perfmon_zen3_events.txt
+++ b/src/includes/perfmon_zen3_events.txt
@@ -1,0 +1,31 @@
+# =======================================================================================
+#
+#      Filename:  perfmon_zen3_events.txt
+#
+#      Description:  Event list for AMD Zen (Gen3)
+#
+#      Version:   <VERSION>
+#      Released:  <DATE>
+#
+#      Author:   Thomas Gruber (tr), thomas.roehl@googlemail.com
+#      Project:  likwid
+#
+#      Copyright (C) 2017 RRZE, University Erlangen-Nuremberg
+#
+#      This program is free software: you can redistribute it and/or modify it under
+#      the terms of the GNU General Public License as published by the Free Software
+#      Foundation, either version 3 of the License, or (at your option) any later
+#      version.
+#
+#      This program is distributed in the hope that it will be useful, but WITHOUT ANY
+#      WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+#      PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+#      You should have received a copy of the GNU General Public License along with
+#      this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# =======================================================================================
+
+
+
+

--- a/src/includes/topology.h
+++ b/src/includes/topology.h
@@ -138,9 +138,11 @@ struct topology_functions {
 #define ATHLON64_G2     0x7FU
 #define ZEN_RYZEN       0x01
 #define ZENPLUS_RYZEN   0x08
-#define ZENPLUS_RYZEN2   0x18
+#define ZENPLUS_RYZEN2  0x18
 #define ZEN2_RYZEN      0x31
-#define ZEN2_RYZEN2      0x71
+#define ZEN2_RYZEN2     0x71
+#define ZEN3_RYZEN      0x01
+#define ZEN3_RYZEN2     0x21
 
 /* ARM */
 #define  ARM7L          0x3U
@@ -183,7 +185,8 @@ struct topology_functions {
 #define  P6_FAMILY        0x6U
 #define  MIC_FAMILY       0xBU
 #define  NETBURST_FAMILY  0xFFU
-#define  ZEN_FAMILY       0x17
+#define  ZEN_FAMILY       0x17U
+#define  ZEN3_FAMILY      0x19U
 #define  K15_FAMILY       0x15U
 #define  K16_FAMILY       0x16U
 #define  K10_FAMILY       0x10U

--- a/src/power.c
+++ b/src/power.c
@@ -148,11 +148,14 @@ power_init(int cpuId)
             }
             break;
         case ZEN_FAMILY:
+        case ZEN3_FAMILY:
             if (cpuid_info.model == ZEN_RYZEN ||
                 cpuid_info.model == ZENPLUS_RYZEN ||
                 cpuid_info.model == ZENPLUS_RYZEN2 ||
                 cpuid_info.model == ZEN2_RYZEN ||
-                cpuid_info.model == ZEN2_RYZEN2)
+                cpuid_info.model == ZEN2_RYZEN2 ||
+                cpuid_info.model == ZEN3_RYZEN ||
+                cpuid_info.model == ZEN3_RYZEN2)
             {
                 cpuid_info.turbo = 0;
                 power_info.hasRAPL = 1;
@@ -171,6 +174,7 @@ power_init(int cpuId)
                     info_regs[i] = 0x0;
                 }
             }
+            break;
     }
 
     perfmon_init_maps();

--- a/src/topology.c
+++ b/src/topology.c
@@ -111,6 +111,7 @@ static char* amd_k8_str = "AMD K8 architecture";
 static char* amd_zen_str = "AMD K17 (Zen) architecture";
 static char* amd_zenplus_str = "AMD K17 (Zen+) architecture";
 static char* amd_zen2_str = "AMD K17 (Zen2) architecture";
+static char* amd_zen3_str = "AMD K19 (Zen3) architecture";
 static char* armv7l_str = "ARM 7l architecture";
 static char* armv8_str = "ARM 8 architecture";
 static char* cavium_thunderx2t99_str = "Cavium Thunder X2 (ARMv8)";
@@ -164,6 +165,7 @@ static char* short_k15 = "interlagos";
 static char* short_k16 = "kabini";
 static char* short_zen = "zen";
 static char* short_zen2 = "zen2";
+static char* short_zen3 = "zen3";
 
 static char* short_arm7 = "arm7";
 static char* short_arm8 = "arm8";
@@ -1038,6 +1040,19 @@ topology_setName(void)
                     break;
             }
             break;
+        case ZEN3_FAMILY:
+            switch (cpuid_info.model)
+            {
+                case ZEN3_RYZEN:
+                    cpuid_info.name = amd_zen3_str;
+                    cpuid_info.short_name = short_zen3;
+                    break;
+                case ZEN3_RYZEN2:
+                    cpuid_info.name = amd_zen3_str;
+                    cpuid_info.short_name = short_zen3;
+                    break;
+            }
+            break;
 
         case ARMV7_FAMILY:
             switch (cpuid_info.model)
@@ -1434,6 +1449,7 @@ print_supportedCPUs (void)
     printf("\t%s\n",kabini_str);
     printf("\t%s\n",amd_zen_str);
     printf("\t%s\n",amd_zen2_str);
+    printf("\t%s\n",amd_zen3_str);
     printf("\n");
     printf("Supported ARMv8 processors:\n");
     printf("\t%s\n",arm_cortex_a53);


### PR DESCRIPTION
Counter logic included for:
- Fixed-purpose counters
- General-purpose counters
- RAPL counters
- L3 counters
- Data fabric counters

Event list is currently empty but updated as soon as it is public