### PR TITLE
docs: fix simple typo, sccess -> access

### DIFF
--- a/src/includes/likwid.h
+++ b/src/includes/likwid.h
@@ -205,7 +205,7 @@ extern void HPMmode(int mode) __attribute__ ((visibility ("default") ));
 /*! \brief Initialize access module
 
 Initialize the module internals to either the MSR/PCI files or the access daemon
-@return error code (0 for sccess)
+@return error code (0 for access)
 */
 extern int HPMinit() __attribute__ ((visibility ("default") ));
 /*! \brief Add CPU to access module


### PR DESCRIPTION
There is a small typo in bench/includes/likwid.h, src/includes/likwid.h.

Should read `access` rather than `sccess`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md