### PR TITLE
Reliable base freq

### DIFF
--- a/src/applications/likwid-setFrequencies.lua
+++ b/src/applications/likwid-setFrequencies.lua
@@ -127,22 +127,8 @@ function get_base_freq()
         out = f:read("*a")
         freq = tonumber(out)
         f:close()
-        return freq
     end
-    f = io.open("/sys/devices/system/cpu/cpu0/cpufreq/bios_limit", "r")
-    if f ~= nil then
-        out = f:read("*a")
-        freq = tonumber(out)
-        f:close()
-        return freq
-    end
-    f = io.open("/proc/cpuinfo", "r")
-    if f ~= nil then
-        out = f:read("*a"):match("cpu MHz%s+:%s+(%d+.%d+)")
-        freq = tonumber(out)
-        f:close()
-    end
-    return freq*1E6
+    return freq
 end
 
 verbosity = 0
@@ -271,17 +257,15 @@ for i, dom in pairs(affinity["domains"]) do
     end
 end
 
-if cpuinfo["clock"] > 0 then
-    base_freq = cpuinfo["clock"] * 1.E-03
-else
-    base_freq = get_base_freq()
-end
-if not base_freq then
-    base_freq = likwid.getCpuClock() * 1.E-03
-end
-
 likwid.initFreq()
 driver = likwid.getFreqDriver(cpulist[1])
+
+base_freq = likwid.getCpuClockBase()
+if base_freq == 0 then
+    if get_base_freq() ~= nil then
+        base_freq = get_base_freq()
+    end
+end
 
 if verbosity == 3 then
     print_stdout(string.format("DEBUG: Given CPU expression expands to %d HW Threads:", numthreads))

--- a/src/applications/likwid-setFrequencies.lua
+++ b/src/applications/likwid-setFrequencies.lua
@@ -260,7 +260,7 @@ end
 likwid.initFreq()
 driver = likwid.getFreqDriver(cpulist[1])
 
-base_freq = likwid.getCpuClockBase()
+base_freq = likwid.getCpuClockBase(cpulist[1])
 if base_freq == 0 then
     if get_base_freq() ~= nil then
         base_freq = get_base_freq()

--- a/src/applications/likwid.lua
+++ b/src/applications/likwid.lua
@@ -154,6 +154,7 @@ likwid.markerRegionCount = likwid_markerRegionCount
 likwid.markerRegionResult = likwid_markerRegionResult
 likwid.markerRegionMetric = likwid_markerRegionMetric
 likwid.initFreq = likwid_initFreq
+likwid.getCpuClockBase = likwid_getCpuClockBase
 likwid.getCpuClockCurrent = likwid_getCpuClockCurrent
 likwid.getCpuClockMin = likwid_getCpuClockMin
 likwid.getConfCpuClockMin = likwid_getConfCpuClockMin

--- a/src/frequency_cpu.c
+++ b/src/frequency_cpu.c
@@ -907,7 +907,8 @@ static int getBaseFreq(const int cpu_id)
         ERROR_PRINT(Cannot read register 0x%x, MSR_PLATFORM_INFO);
         return err;
     }
-    return 100 * extractBitField(tmp,8,8);
+    tmp = extractBitField(tmp,8,8);
+    return 100000 * tmp;
 #endif
 }
 
@@ -1079,7 +1080,9 @@ uint64_t freq_getCpuClockBase(const int cpu_id)
 {
     uint64_t f = getBaseFreq(cpu_id);
     if (f > 0)
+    {
         return f;
+    }
     return 0;
 }
 

--- a/src/frequency_cpu.c
+++ b/src/frequency_cpu.c
@@ -866,6 +866,50 @@ static int getIntelHWP(const int cpu_id)
 #endif
 }
 
+static int getBaseFreq(const int cpu_id)
+{
+    int err = 0;
+
+    if (!lock_check())
+    {
+        fprintf(stderr,"Access to frequency backend is locked.\n");
+        return 0;
+    }
+#ifdef LIKWID_USE_PERFEVENT
+    fprintf(stderr,"Cannot read base frequency with ACCESSMODE=perf_event.\n");
+    return -1;
+#else
+    if (!HPMinitialized())
+    {
+        HPMinit();
+        own_hpm = 1;
+        err = HPMaddThread(cpu_id);
+        if (err != 0)
+        {
+            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            return err;
+        }
+    }
+    else
+    {
+        err = HPMaddThread(cpu_id);
+        if (err != 0)
+        {
+            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            return err;
+        }
+    }
+
+    uint64_t tmp = 0x0ULL;
+    err = HPMread(cpu_id, MSR_DEV, MSR_PLATFORM_INFO, &tmp);
+    if (err)
+    {
+        ERROR_PRINT(Cannot read register 0x%x, MSR_PLATFORM_INFO);
+        return err;
+    }
+    return 100 * extractBitField(tmp,8,8);
+#endif
+}
 
 int
 _freqInit(void)
@@ -1031,6 +1075,13 @@ int freq_setGovernor(const int cpu_id, const char* gov)
     return -EINVAL;
 }
 
+uint64_t freq_getCpuClockBase(const int cpu_id)
+{
+    uint64_t f = getBaseFreq(cpu_id);
+    if (f > 0)
+        return f;
+    return 0;
+}
 
 uint64_t freq_getCpuClockCurrent(const int cpu_id)
 {

--- a/src/includes/likwid.h
+++ b/src/includes/likwid.h
@@ -1654,6 +1654,13 @@ Initialize cpu frequency module
 @return returns 0 if successfull and 1 if invalid accessmode
 */
 extern int freq_init(void) __attribute__ ((visibility ("default") ));
+/*! \brief Get the base clock frequency of a hardware thread
+
+Get the base clock frequency of a hardware thread
+@param [in] cpu_id CPU ID
+@return Frequency or 0 in case of errors
+*/
+uint64_t freq_getCpuClockBase(const int cpu_id) __attribute__ ((visibility ("default") ));
 /*! \brief Get the current clock frequency of a hardware thread
 
 Get the current clock frequency of a hardware thread

--- a/src/luawid.c
+++ b/src/luawid.c
@@ -2588,6 +2588,14 @@ lua_likwid_finalizeFreq(lua_State* L)
 }
 
 static int
+lua_likwid_getCpuClockBase(lua_State* L)
+{
+    const int cpu_id = lua_tointeger(L,-1);
+    lua_pushnumber(L, freq_getCpuClockCurrent(cpu_id));
+    return 1;
+}
+
+static int
 lua_likwid_getCpuClockCurrent(lua_State* L)
 {
     const int cpu_id = lua_tointeger(L,-1);
@@ -3599,6 +3607,7 @@ luaopen_liblikwid(lua_State* L){
     // CPU frequency functions
     lua_register(L, "likwid_initFreq", lua_likwid_initFreq);
     lua_register(L, "likwid_finalizeFreq", lua_likwid_finalizeFreq);
+    lua_register(L, "likwid_getCpuClockBase", lua_likwid_getCpuClockBase);
     lua_register(L, "likwid_getCpuClockCurrent", lua_likwid_getCpuClockCurrent);
     lua_register(L, "likwid_getCpuClockMin", lua_likwid_getCpuClockMin);
     lua_register(L, "likwid_getConfCpuClockMin", lua_likwid_getConfCpuClockMin);

--- a/src/luawid.c
+++ b/src/luawid.c
@@ -2591,7 +2591,7 @@ static int
 lua_likwid_getCpuClockBase(lua_State* L)
 {
     const int cpu_id = lua_tointeger(L,-1);
-    lua_pushnumber(L, freq_getCpuClockCurrent(cpu_id));
+    lua_pushnumber(L, freq_getCpuClockBase(cpu_id));
     return 1;
 }
 


### PR DESCRIPTION
Add a reliable way to get the base frequency from register for Intel and AMD CPUs. This should reduce warnings printed by `likwid-setFrequencies`.