### PR TITLE
Export list of hwthreads to wrapped application

### DIFF
--- a/src/applications/likwid-perfctr.lua
+++ b/src/applications/likwid-perfctr.lua
@@ -839,6 +839,11 @@ if use_marker == true then
         likwid.setenv("LIKWID_GPUFILEPATH", nvMarkerFile)
     end
 end
+local likwid_hwthreads = {}
+for i=1,#cpulist do
+    table.insert(likwid_hwthreads, tostring(math.tointeger(cpulist[i])))
+end
+likwid.setenv("LIKWID_HWTHREADS", table.concat(likwid_hwthreads, ","))
 
 --[[for i, event_string in pairs(event_string_list) do
     local groupdata = likwid.get_groupdata(event_string)

--- a/src/applications/likwid-pin.lua
+++ b/src/applications/likwid-pin.lua
@@ -252,6 +252,11 @@ if omp_threads and tonumber(omp_threads) < num_threads then
 end
 
 likwid.setenv("KMP_AFFINITY","disabled")
+local likwid_hwthreads = {}
+for i=1,#cpu_list do
+    table.insert(likwid_hwthreads, tostring(math.tointeger(cpu_list[i])))
+end
+likwid.setenv("LIKWID_HWTHREADS", table.concat(likwid_hwthreads, ","))
 
 if os.getenv("CILK_NWORKERS") == nil then
     likwid.setenv("CILK_NWORKERS", tostring(math.tointeger(num_threads)))


### PR DESCRIPTION
This PR adds the export of the used HW threads through the environment variable `LIKWID_HWTHREADS` so that applications can use this knowledge. There is already an environment variable `LIKWID_THREADS` but it only exported by `likwid-perfctr` in MarkerAPI mode. In some cases, you need the knowledge also in non-instrumented applications.