### PR TITLE
Add support for Intel Comet Lake

### DIFF
--- a/src/access-daemon/accessDaemon.c
+++ b/src/access-daemon/accessDaemon.c
@@ -1931,7 +1931,10 @@ int main(void)
                          (model == SKYLAKE1) ||
                          (model == SKYLAKE2) ||
                          (model == KABYLAKE1) ||
-                         (model == KABYLAKE2))
+                         (model == KABYLAKE2) ||
+                         (model == COMETLAKE1) ||
+                         (model == COMETLAKE2) ||
+                         (model == CANNONLAKE))
                 {
                     allowed = allowed_sandybridge;
                     isClientMem = 1;

--- a/src/cpuFeatures.c
+++ b/src/cpuFeatures.c
@@ -165,7 +165,9 @@ cpuFeatures_update(int cpu)
              (cpuid_info.model == SKYLAKEX) ||
              (cpuid_info.model == KABYLAKE1) ||
              (cpuid_info.model == KABYLAKE2) ||
-             (cpuid_info.model == CANNONLAKE))
+             (cpuid_info.model == CANNONLAKE) ||
+             (cpuid_info.model == COMETLAKE1) ||
+             (cpuid_info.model == COMETLAKE2))
     {
         TEST_FLAG_INV(FEAT_TURBO_MODE,38);
     }
@@ -199,7 +201,9 @@ cpuFeatures_update(int cpu)
             (cpuid_info.model == ICELAKEX1) ||
             (cpuid_info.model == ICELAKEX2) ||
             (cpuid_info.model == ATOM_SILVERMONT_GOLD) ||
-            (cpuid_info.model == CANNONLAKE))
+            (cpuid_info.model == CANNONLAKE) ||
+            (cpuid_info.model == COMETLAKE1) ||
+            (cpuid_info.model == COMETLAKE2))
     {
         ret = HPMread(cpu, MSR_DEV, MSR_PREFETCH_ENABLE, &flags);
         if (ret != 0)
@@ -374,6 +378,8 @@ cpuFeatures_enable(int cpu, CpuFeature type, int print)
             (cpuid_info.model == KABYLAKE1) ||
             (cpuid_info.model == KABYLAKE2) ||
             (cpuid_info.model == CANNONLAKE) ||
+            (cpuid_info.model == COMETLAKE1) ||
+            (cpuid_info.model == COMETLAKE2) ||
             (cpuid_info.model == ICELAKE1) ||
             (cpuid_info.model == ICELAKE2) ||
             (cpuid_info.model == ICELAKEX1) ||
@@ -535,6 +541,8 @@ cpuFeatures_disable(int cpu, CpuFeature type, int print)
             (cpuid_info.model == KABYLAKE1) ||
             (cpuid_info.model == KABYLAKE2) ||
             (cpuid_info.model == CANNONLAKE) ||
+            (cpuid_info.model == COMETLAKE1) ||
+            (cpuid_info.model == COMETLAKE2) ||
             (cpuid_info.model == ICELAKE1) ||
             (cpuid_info.model == ICELAKE2) ||
             (cpuid_info.model == ICELAKEX1) ||

--- a/src/includes/perfmon_skylake.h
+++ b/src/includes/perfmon_skylake.h
@@ -41,6 +41,14 @@
 #include <voltage.h>
 #include <linux/version.h>
 
+#define IS_SKYLAKE_CLIENT(model) ((model) == SKYLAKE1 || \
+                                  (model) == SKYLAKE2 || \
+                                  (model) == KABYLAKE1 || \
+                                  (model) == KABYLAKE2 || \
+                                  (model) == CANNONLAKE || \
+                                  (model) == COMETLAKE1 || \
+                                  (model) == COMETLAKE2)
+
 static int perfmon_numCountersSkylake = NUM_COUNTERS_SKYLAKE;
 static int perfmon_numCoreCountersSkylake = NUM_COUNTERS_CORE_SKYLAKE;
 static int perfmon_numArchEventsSkylake = NUM_ARCH_EVENTS_SKYLAKE;
@@ -85,37 +93,29 @@ int perfmon_init_skylake(int cpu_id)
     }
     if (socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
     {
-        switch (cpuid_info.model)
+        if (skl_did_cbox_check == 0)
         {
-            case SKYLAKEX:
-                if (skl_did_cbox_check == 0)
-                {
-                    skylake_cbox_setup = skx_cbox_setup;
-                    skl_did_cbox_check = 1;
-                }
-                break;
-            case SKYLAKE1:
-            case SKYLAKE2:
-            case KABYLAKE1:
-            case KABYLAKE2:
-            case CANNONLAKE:
-                if (skl_did_cbox_check == 0)
-                {
-                    uint64_t data = 0x0ULL;
-                    ret = HPMwrite(cpu_id, MSR_DEV, MSR_V4_C0_PERF_CTRL0, 0x0ULL);
-                    ret += HPMread(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, &data);
-                    ret += HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL);
-                    ret += HPMread(cpu_id, MSR_DEV, MSR_V4_C0_PERF_CTRL0, &data);
-                    if ((ret == 0) && (data == 0x0ULL))
-                        skylake_cbox_setup = skl_cbox_setup;
-                    else
-                        skylake_cbox_setup = skl_cbox_nosetup;
-                    skl_did_cbox_check = 1;
-                }
-                break;
-            default:
+            if (IS_SKYLAKE_CLIENT(cpuid_info.model))
+            {
+                uint64_t data = 0x0ULL;
+                ret = HPMwrite(cpu_id, MSR_DEV, MSR_V4_C0_PERF_CTRL0, 0x0ULL);
+                ret += HPMread(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, &data);
+                ret += HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL);
+                ret += HPMread(cpu_id, MSR_DEV, MSR_V4_C0_PERF_CTRL0, &data);
+                if ((ret == 0) && (data == 0x0ULL))
+                    skylake_cbox_setup = skl_cbox_setup;
+                else
+                    skylake_cbox_setup = skl_cbox_nosetup;
+            }
+            else if (cpuid_info.model == SKYLAKEX)
+            {
+                skylake_cbox_setup = skx_cbox_setup;
+            }
+            else
+            {
                 skylake_cbox_setup = skl_cbox_nosetup;
-                skl_did_cbox_check = 1;
+            }
+            skl_did_cbox_check = 1;
         }
     }
     return 0;
@@ -749,7 +749,7 @@ int skx_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 #define SKL_UNCORE_FREEZE \
     if (haveLock && MEASURE_UNCORE(eventSet)) \
     { \
-        if (cpuid_info.model == SKYLAKE1 || cpuid_info.model == SKYLAKE2) \
+        if (IS_SKYLAKE_CLIENT(cpuid_info.model)) \
         { \
             VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE) \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL)); \
@@ -765,7 +765,7 @@ int skx_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 #define SKL_UNCORE_UNFREEZE \
     if (haveLock && MEASURE_UNCORE(eventSet)) \
     { \
-        if (cpuid_info.model == SKYLAKE1 || cpuid_info.model == SKYLAKE2) \
+        if (IS_SKYLAKE_CLIENT(cpuid_info.model)) \
         { \
             VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29), UNFREEZE_UNCORE) \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29))); \
@@ -1058,7 +1058,7 @@ int perfmon_startCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet
                 case CBOX25:
                 case CBOX26:
                 case CBOX27:
-                    if (haveLock && (cpuid_info.model == SKYLAKE1 || cpuid_info.model == SKYLAKE2))
+                    if (haveLock && IS_SKYLAKE_CLIENT(cpuid_info.model))
                     {
                         uflags |= (1ULL<<(type-CBOX0));
                     }
@@ -1405,7 +1405,7 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                 case CBOX26:
                 case CBOX27:
                 case WBOX:
-                    if (haveLock && (cpuid_info.model == SKYLAKE1 || cpuid_info.model == SKYLAKE2))
+                    if (haveLock && IS_SKYLAKE_CLIENT(cpuid_info.model))
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         SKL_CHECK_UNCORE_OVERFLOW(box_map[type].ovflOffset);
@@ -1640,7 +1640,7 @@ int perfmon_readCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                 case CBOX25:
                 case CBOX26:
                 case CBOX27:
-                    if (haveLock && (cpuid_info.model == SKYLAKE1 || cpuid_info.model == SKYLAKE2))
+                    if (haveLock && IS_SKYLAKE_CLIENT(cpuid_info.model))
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         SKL_CHECK_UNCORE_OVERFLOW(box_map[type].ovflOffset);

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1079,6 +1079,8 @@ perfmon_init_maps(void)
                 case KABYLAKE1:
                 case KABYLAKE2:
                 case CANNONLAKE:
+                case COMETLAKE1:
+                case COMETLAKE2:
                     box_map = skylake_box_map;
                     eventHash = skylake_arch_events;
                     counter_map = skylake_counter_map;
@@ -1634,6 +1636,8 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                 case KABYLAKE1:
                 case KABYLAKE2:
                 case CANNONLAKE:
+                case COMETLAKE1:
+                case COMETLAKE2:
                     initialize_power = TRUE;
                     initialize_thermal = TRUE;
                     initThreadArch = perfmon_init_skylake;

--- a/src/power.c
+++ b/src/power.c
@@ -125,6 +125,8 @@ power_init(int cpuId)
                 case KABYLAKE1:
                 case KABYLAKE2:
                 case CANNONLAKE:
+                case COMETLAKE1:
+                case COMETLAKE2:
                 case TIGERLAKE1:
                 case TIGERLAKE2:
                 case ICELAKE1:

--- a/src/topology.c
+++ b/src/topology.c
@@ -82,6 +82,7 @@ static char* cascadelakeX_str = "Intel Cascadelake SP processor";
 static char* kabylake_str = "Intel Kabylake processor";
 static char* cannonlake_str = "Intel Cannonlake processor";
 static char* coffeelake_str = "Intel Coffeelake processor";
+static char* cometlake_str = "Intel Cometlake processor";
 static char* nehalem_ex_str = "Intel Nehalem EX processor";
 static char* westmere_ex_str = "Intel Westmere EX processor";
 static char* xeon_mp_string = "Intel Xeon MP processor";
@@ -793,6 +794,13 @@ topology_setName(void)
                     cpuid_info.supportClientmem = 1;
                     cpuid_info.name = cannonlake_str;
                     cpuid_info.short_name = short_cannonlake;
+                    break;
+
+                case COMETLAKE1:
+                case COMETLAKE2:
+                    cpuid_info.supportClientmem = 1;
+                    cpuid_info.name = cometlake_str;
+                    cpuid_info.short_name = short_skylake;
                     break;
 
                 case XEON_PHI_KNL:


### PR DESCRIPTION
Intel Comet Lake in-core support is comparable with Intel Skylake/Kabylake or Cannonlake. It also uses the same event lists.

See issue #359 .