### PR TITLE
Fix perfscope when drawing y2title with multi-core

### DIFF
--- a/src/applications/likwid-perfscope.lua
+++ b/src/applications/likwid-perfscope.lua
@@ -479,7 +479,7 @@ for i, group in pairs(group_list) do
     end
     if group["y2title"] ~= nil then
         for c,cpu in pairs(cpulist) do
-            gnucmd = gnucmd .. string.format(" --y2 %d", cpu + (#cpulist * group["y2funcindex"]))
+            gnucmd = gnucmd .. string.format(" --y2 %d", (c-1) + (#cpulist * group["y2funcindex"]))
         end
         table.insert(extracmds, string.format("set y2label %q font \",12\"", group["y2title"]))
     end

--- a/src/applications/likwid-perfscope.lua
+++ b/src/applications/likwid-perfscope.lua
@@ -478,7 +478,9 @@ for i, group in pairs(group_list) do
         table.insert(extracmds, string.format("set ylabel %q font \",12\"", group["ytitle"]))
     end
     if group["y2title"] ~= nil then
-        gnucmd = gnucmd .. string.format(" --y2 %d", group["y2funcindex"])
+        for c,cpu in pairs(cpulist) do
+            gnucmd = gnucmd .. string.format(" --y2 %d", cpu + (#cpulist * group["y2funcindex"]))
+        end
         table.insert(extracmds, string.format("set y2label %q font \",12\"", group["y2title"]))
     end
     if group["formulas"] then
@@ -488,8 +490,8 @@ for i, group in pairs(group_list) do
             end
         else
             local curveID = 0
-            for c,cpu in pairs(cpulist) do
-                for f, fdesc in pairs(group["formulas"]) do
+            for f, fdesc in pairs(group["formulas"]) do
+                for c,cpu in pairs(cpulist) do
                     gnucmd = gnucmd .. string.format(" --legend %d %q", curveID, "C"..cpu..": "..fdesc["name"])
                     curveID = curveID + 1
                 end


### PR DESCRIPTION
Hi, @TomTheBear 

I found there is an issue when likwid-perfscope drawing multi-core events curves
```bash
likwid-perfscope -t 1s -g L3 -c 0,4 likwid-bench -s 5s -t stream_avx -w S0:1MB:2
```
1. Only one curve align to y2
2. Core events are not align to the right core legends

I fixed this issue with the PR

