### PR TITLE
Fix memory measurements for AMD Zen2

### DIFF
--- a/groups/zen2/MEM.txt
+++ b/groups/zen2/MEM.txt
@@ -13,27 +13,27 @@ Runtime (RDTSC) [s] time
 Runtime unhalted [s] FIXC1*inverseClock
 Clock [MHz]  1.E-06*(FIXC1/FIXC2)/inverseClock
 CPI  PMC1/PMC0
-Memory read bandwidth [MBytes/s] 1.0E-06*(DFC0)*(4.0/num_numadomains)*64.0/time
-Memory read data volume [GBytes] 1.0E-09*(DFC0)*(4.0/num_numadomains)*64.0
-Memory write bandwidth [MBytes/s] 1.0E-06*(DFC1)*(4.0/num_numadomains)*64.0/time
-Memory write data volume [GBytes] 1.0E-09*(DFC1)*(4.0/num_numadomains)*64.0
-Memory bandwidth [MBytes/s] 1.0E-06*(DFC0+DFC1)*(4.0/num_numadomains)*64.0/time
-Memory data volume [GBytes] 1.0E-09*(DFC0+DFC1)*(4.0/num_numadomains)*64.0
+Memory read bandwidth [MBytes/s] 1.0E-06*(DFC0)*(4.0/(num_numadomains/num_sockets))*64.0/time
+Memory read data volume [GBytes] 1.0E-09*(DFC0)*(4.0/(num_numadomains/num_sockets))*64.0
+Memory write bandwidth [MBytes/s] 1.0E-06*(DFC1)*(4.0/(num_numadomains/num_sockets))*64.0/time
+Memory write data volume [GBytes] 1.0E-09*(DFC1)*(4.0/(num_numadomains/num_sockets))*64.0
+Memory bandwidth [MBytes/s] 1.0E-06*(DFC0+DFC1)*(4.0/(num_numadomains/num_sockets))*64.0/time
+Memory data volume [GBytes] 1.0E-09*(DFC0+DFC1)*(4.0/(num_numadomains/num_sockets))*64.0
 
 LONG
 Formulas:
-Memory read bandwidth [MBytes/s] = 4.0E-06*(DATA_FROM_LOCAL_DRAM_CHANNEL)*(4.0/num_numadomains)*64.0/runtime
-Memory read data volume [GBytes] = 4.0E-09*(DATA_FROM_LOCAL_DRAM_CHANNEL)*(4.0/num_numadomains)*64.0
-Memory write bandwidth [MBytes/s] = 4.0E-06*(DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/num_numadomains)*64.0/runtime
-Memory write data volume [GBytes] = 4.0E-09*(DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/num_numadomains)*64.0
-Memory bandwidth [MBytes/s] = 4.0E-06*(DATA_FROM_LOCAL_DRAM_CHANNEL+DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/num_numadomains)*64.0/runtime
-Memory data volume [GBytes] = 4.0E-09*(DATA_FROM_LOCAL_DRAM_CHANNEL+DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/num_numadomains)*64.0
+Memory read bandwidth [MBytes/s] = 4.0E-06*(DATA_FROM_LOCAL_DRAM_CHANNEL)*(4.0/(num_numadomains/num_sockets))*64.0/runtime
+Memory read data volume [GBytes] = 4.0E-09*(DATA_FROM_LOCAL_DRAM_CHANNEL)*(4.0/(num_numadomains/num_sockets))*64.0
+Memory write bandwidth [MBytes/s] = 4.0E-06*(DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/(num_numadomains/num_sockets))*64.0/runtime
+Memory write data volume [GBytes] = 4.0E-09*(DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/(num_numadomains/num_sockets))*64.0
+Memory bandwidth [MBytes/s] = 4.0E-06*(DATA_FROM_LOCAL_DRAM_CHANNEL+DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/(num_numadomains/num_sockets))*64.0/runtime
+Memory data volume [GBytes] = 4.0E-09*(DATA_FROM_LOCAL_DRAM_CHANNEL+DATA_TO_LOCAL_DRAM_CHANNEL)*(4.0/(num_numadomains/num_sockets))*64.0
 -
 Profiling group to measure memory bandwidth drawn by all cores of a socket.
 Since this group is based on Uncore events it is only possible to measure on a
 per socket base.
 Even though the group provides almost accurate results for the total bandwidth
 and data volume, the read and write bandwidths and data volumes seem off.
-The metric formulas contain a correction factor of (4.0/num_numadomains) to
+The metric formulas contain a correction factor of (4.0/(num_numadomains/num_sockets)) to
 return the value for all 4 memory controllers in NPS1 mode. This is probably
 a work-around. Requested info from AMD.

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -2864,7 +2864,7 @@ perfmon_getMetric(int groupId, int metricId, int threadId)
     add_to_clist(&clist, "inverseClock", 1.0/timer_getCycleClock());
     add_to_clist(&clist, "true", 1);
     add_to_clist(&clist, "false", 0);
-    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes);
+    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes/cpuid_topology.numSockets);
     int cpu = 0, sock_cpu = 0, err = 0;
     for (e=0; e<groupSet->numberOfThreads; e++)
     {
@@ -2947,7 +2947,7 @@ perfmon_getLastMetric(int groupId, int metricId, int threadId)
     add_to_clist(&clist, "inverseClock", 1.0/timer_getCycleClock());
     add_to_clist(&clist, "true", 1);
     add_to_clist(&clist, "false", 0);
-    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes);
+    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes/cpuid_topology.numSockets);
     int cpu = 0, sock_cpu = 0, err = 0;
     for (e=0; e<groupSet->numberOfThreads; e++)
     {
@@ -3613,7 +3613,7 @@ perfmon_getMetricOfRegionThread(int region, int metricId, int threadId)
     add_to_clist(&clist, "inverseClock", 1.0/timer_getCycleClock());
     add_to_clist(&clist, "true", 1);
     add_to_clist(&clist, "false", 0);
-    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes);
+    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes/cpuid_topology.numSockets);
     int cpu = 0, sock_cpu = 0;
     for (e=0; e<groupSet->numberOfThreads; e++)
     {

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -2864,7 +2864,8 @@ perfmon_getMetric(int groupId, int metricId, int threadId)
     add_to_clist(&clist, "inverseClock", 1.0/timer_getCycleClock());
     add_to_clist(&clist, "true", 1);
     add_to_clist(&clist, "false", 0);
-    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes/cpuid_topology.numSockets);
+    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes);
+    add_to_clist(&clist, "num_sockets", cpuid_topology.numSockets);
     int cpu = 0, sock_cpu = 0, err = 0;
     for (e=0; e<groupSet->numberOfThreads; e++)
     {
@@ -2947,7 +2948,8 @@ perfmon_getLastMetric(int groupId, int metricId, int threadId)
     add_to_clist(&clist, "inverseClock", 1.0/timer_getCycleClock());
     add_to_clist(&clist, "true", 1);
     add_to_clist(&clist, "false", 0);
-    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes/cpuid_topology.numSockets);
+    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes);
+    add_to_clist(&clist, "num_sockets", cpuid_topology.numSockets);
     int cpu = 0, sock_cpu = 0, err = 0;
     for (e=0; e<groupSet->numberOfThreads; e++)
     {
@@ -3613,7 +3615,8 @@ perfmon_getMetricOfRegionThread(int region, int metricId, int threadId)
     add_to_clist(&clist, "inverseClock", 1.0/timer_getCycleClock());
     add_to_clist(&clist, "true", 1);
     add_to_clist(&clist, "false", 0);
-    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes/cpuid_topology.numSockets);
+    add_to_clist(&clist, "num_numadomains", numa_info.numberOfNodes);
+    add_to_clist(&clist, "num_sockets", cpuid_topology.numSockets);
     int cpu = 0, sock_cpu = 0;
     for (e=0; e<groupSet->numberOfThreads; e++)
     {


### PR DESCRIPTION
Memory measurements on AMD Zen2 need to be scaled dependent on the NPS mode (`4.0/num_numadomains`). This works well for single-socket servers but for multi-socket systems, the divisor needs to be the number of NUMA domains per socket. This patch fixes this by including the number of CPU sockets in the scaling factor: `4.0/(num_numadomains/num_sockets)`.