### PR TITLE
Fugaku topology fix

### DIFF
--- a/src/includes/topology.h
+++ b/src/includes/topology.h
@@ -197,6 +197,7 @@ struct topology_functions {
 
 extern int cpu_count(cpu_set_t* set);
 extern int likwid_cpu_online(int cpu_id);
+extern int likwid_sysfs_list_len(char* sysfsfile);
 
 static inline int cpuid_hasFeature(FeatureBit bit)
 {

--- a/src/topology.c
+++ b/src/topology.c
@@ -650,6 +650,38 @@ likwid_cpu_online(int cpu_id)
     return state;
 }
 
+int likwid_sysfs_list_len(char* sysfsfile)
+{
+    int i = 0;
+    int len = 0;
+    FILE* fp;
+    if (NULL != (fp = fopen (sysfsfile, "r")))
+    {
+        bstring src = bread ((bNread) fread, fp);
+        struct bstrList* first = bsplit(src, ',');
+        for (i = 0; i < first->qty; i++)
+        {
+            struct bstrList* second = bsplit(first->entry[i], '-');
+            if (second->qty == 1)
+            {
+                len++;
+            }
+            else
+            {
+                int s = atoi(bdata(second->entry[0]));
+                int e = atoi(bdata(second->entry[1]));
+                len += e - s + 1;
+            }
+            bstrListDestroy(second);
+        }
+        bstrListDestroy(first);
+        bdestroy(src);
+        fclose(fp);
+    }
+    return len;
+}
+
+
 
 int
 topology_setName(void)
@@ -1257,6 +1289,14 @@ standard_init:
         topology_setName();
         funcs.init_cpuFeatures();
         funcs.init_nodeTopology(cpuSet);
+        int activeCount = 0;
+        for (int i = 0; i < cpuid_topology.numHWThreads; i++)
+        {
+            if (cpuid_topology.threadPool[i].inCpuSet)
+                activeCount++;
+        }
+        if (activeCount > cpuid_topology.activeHWThreads)
+            cpuid_topology.activeHWThreads = activeCount;
         funcs.init_cacheTopology();
         if (cpuid_topology.numCacheLevels == 0)
         {

--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -345,6 +345,9 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
     if (count > cpuid_topology.numHWThreads)
         cpuid_topology.numHWThreads = count;
 #endif
+    count = likwid_sysfs_list_len("/sys/devices/system/cpu/present");
+    if (count > cpuid_topology.numHWThreads)
+        cpuid_topology.numHWThreads = count;
     if (cpuid_topology.activeHWThreads > cpuid_topology.numHWThreads)
         cpuid_topology.numHWThreads = cpuid_topology.activeHWThreads;
     DEBUG_PRINT(DEBUGLEV_DEVELOP, HWLOC CpuInfo Family %d Model %d Stepping %d Vendor 0x%X Part 0x%X isIntel %d numHWThreads %d activeHWThreads %d,

--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -237,6 +237,7 @@ void
 hwloc_init_cpuInfo(cpu_set_t cpuSet)
 {
     int i;
+    uint32_t count = 0;
     hwloc_obj_t obj;
     if (perfmon_verbosity <= 1)
     {
@@ -288,7 +289,6 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
     if (cpuid_info.family == 0 || cpuid_info.model == 0)
     {
         uint32_t part = 0;
-        uint32_t count = 0;
         parse_cpuinfo(&count, &cpuid_info.family, &cpuid_info.model, &cpuid_info.stepping, &cpuid_info.part, &cpuid_info.vendor);
         parse_cpuname(cpuid_info.osname);
     }
@@ -296,7 +296,6 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
 #endif
 #if defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A)
     uint32_t part = 0;
-    uint32_t count = 0;
     parse_cpuinfo(&count, &cpuid_info.family, &cpuid_info.model, &cpuid_info.stepping, &cpuid_info.part, &cpuid_info.vendor);
     parse_cpuname(cpuid_info.osname);
     snprintf(cpuid_info.architecture, 19, "armv8");


### PR DESCRIPTION
This PR fixes topology issues on the Fugaku nodes. I'm not sure what the difference between the FX1000 I used before is.

One problem is the naming of affinity domains. The first 4 packages and NUMA domains do not contain any usable hardware thread (just management cores). If we name the affinity domains as normal, they would be called `S4`-`S7` (and `M4`-`M7`). This PR uses zero-based numbering, so although the socket has e.g. the ID 4, the affinity domain is called `S0`.