### PR TITLE
Fix for perf_event multiplexing

### DIFF
--- a/src/includes/perfmon_perfevent.h
+++ b/src/includes/perfmon_perfevent.h
@@ -56,6 +56,7 @@ static int running_group = -1;
 static int perf_event_num_cpus = 0;
 static int perf_disable_uncore = 0;
 static int perf_event_paranoid = -1;
+static int printed_multiplex_info = 0;
 
 static long
 perf_event_open(struct perf_event_attr *hw_event, pid_t pid,
@@ -894,6 +895,11 @@ int perfmon_startCountersThread_perfevent(int thread_id, PerfmonEventSet* eventS
                         value *= (enabled/running);
                         res.value = (uint64_t)value;
                         VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], res.value, SCALE_POWER);
+                        if (printed_multiplex_info == 0)
+                        {
+                            fprintf(stderr, "WARN: Perf_event uses multiplexing. Raw event results are scaled to an estimated value.");
+                            printed_multiplex_info = 1;
+                        }
                     }
                     eventSet->events[i].threadCounter[thread_id].startData = res.value;
                 }
@@ -941,6 +947,11 @@ int perfmon_stopCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
                     value *= (enabled/running);
                     res.value = (uint64_t)value;
                     VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], res.value, SCALE_COUNTER);
+                    if (printed_multiplex_info == 0)
+                    {
+                        fprintf(stderr, "WARN: Perf_event uses multiplexing. Raw event results are scaled to an estimated value.");
+                        printed_multiplex_info = 1;
+                    }
                 }
                 eventSet->events[i].threadCounter[thread_id].counterData = res.value;
             }
@@ -986,6 +997,11 @@ int perfmon_readCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
                     value *= (enabled/running);
                     res.value = (uint64_t)value;
                     VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], res.value, SCALE_COUNTER);
+                    if (printed_multiplex_info == 0)
+                    {
+                        fprintf(stderr, "WARN: Perf_event uses multiplexing. Raw event results are scaled to an estimated value.");
+                        printed_multiplex_info = 1;
+                    }
                 }
                 eventSet->events[i].threadCounter[thread_id].counterData = res.value;
             }

--- a/src/includes/perfmon_perfevent.h
+++ b/src/includes/perfmon_perfevent.h
@@ -878,12 +878,20 @@ int perfmon_startCountersThread_perfevent(int thread_id, PerfmonEventSet* eventS
                 ret = read(cpu_event_fds[cpu_id][index],
                         tmp,
                         3*sizeof(long long));
-                if (tmp[1] != tmp[2])
+                VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp[0], START_POWER);
+                if (ret == 3*sizeof(long long))
                 {
-                    double f = ((double)tmp[1]) / tmp[2];
-                    tmp[0] = (long long)(tmp[0] * f);
+                    if (tmp[2] > 0 && tmp[1] != tmp[2])
+                    {
+                        double t0 = (double)tmp[0];
+                        double t1 = (double)tmp[1];
+                        double t2 = (double)tmp[2];
+                        double f = t0 * (t1/t2);
+                        tmp[0] = (long long)f;
+                        VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp[0], SCALE_POWER);
+                    }
+                    eventSet->events[i].threadCounter[thread_id].startData = tmp[0];
                 }
-                eventSet->events[i].threadCounter[thread_id].startData = tmp[0];
             }
             VERBOSEPRINTREG(cpu_id, 0x0,
                             eventSet->events[i].threadCounter[thread_id].startData,
@@ -913,14 +921,18 @@ int perfmon_stopCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
             VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, FREEZE_COUNTER);
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_DISABLE, 0);
             tmp[0] = tmp[1] = tmp[2] = 0;
-            ret = read(cpu_event_fds[cpu_id][index], &tmp, 3*sizeof(long long));
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp, READ_COUNTER);
+            ret = read(cpu_event_fds[cpu_id][index], tmp, 3*sizeof(long long));
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp[0], READ_COUNTER);
             if (ret == 3*sizeof(long long))
             {
-                if (tmp[1] != tmp[2])
+                if (tmp[2] > 0 && tmp[1] != tmp[2])
                 {
-                    double f = ((double)tmp[1]) / tmp[2];
-                    tmp[0] = (long long)(tmp[0] * f);
+                    double t0 = (double)tmp[0];
+                    double t1 = (double)tmp[1];
+                    double t2 = (double)tmp[2];
+                    double f = t0 * (t1/t2);
+                    tmp[0] = (long long)f;
+                    VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp[0], SCALE_COUNTER);
                 }
                 eventSet->events[i].threadCounter[thread_id].counterData = tmp[0];
             }
@@ -950,14 +962,18 @@ int perfmon_readCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
             VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, FREEZE_COUNTER);
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_DISABLE, 0);
             tmp[0] = tmp[1] = tmp[2] = 0;
-            ret = read(cpu_event_fds[cpu_id][index], &tmp, 3*sizeof(long long));
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp, READ_COUNTER);
+            ret = read(cpu_event_fds[cpu_id][index], tmp, 3*sizeof(long long));
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp[0], READ_COUNTER);
             if (ret == 3*sizeof(long long))
             {
-                if (tmp[1] != tmp[2])
+                if (tmp[2] > 0 && tmp[1] != tmp[2])
                 {
-                    double f = ((double)tmp[1]) / tmp[2];
-                    tmp[0] = (long long)(tmp[0] * f);
+                    double t0 = (double)tmp[0];
+                    double t1 = (double)tmp[1];
+                    double t2 = (double)tmp[2];
+                    double f = t0 * (t1/t2);
+                    tmp[0] = (long long)f;
+                    VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp[0], SCALE_COUNTER);
                 }
                 eventSet->events[i].threadCounter[thread_id].counterData = tmp[0];
             }

--- a/src/includes/perfmon_perfevent.h
+++ b/src/includes/perfmon_perfevent.h
@@ -970,7 +970,6 @@ int perfmon_readCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
 {
     int ret;
     int cpu_id = groupSet->threads[thread_id].processorId;
-    long long tmp[3] = {0};
     if (!perf_event_initialized)
     {
         return -(thread_id+1);


### PR DESCRIPTION
In most cases it is not required to do multiplexing because LIKWID never uses more events than there are physical counter registers for CPUs. The Intel Skylake SP architecture (and maybe Cascadelake SP) has a bug in the `PMC3` if transactional memory is enabled (see #224 or [likwid-users mailing list post](https://groups.google.com/g/likwid-users/c/VlllTO0qv-c)). This causes that perf_event multiplexes on the remaining 3 counters and LIKWID has to evaluate the multiplexing information to calculate the real counter value.