### PR TITLE
Add missing build requirement for rpm specfile

### DIFF
--- a/packaging/rpm/likwid.spec
+++ b/packaging/rpm/likwid.spec
@@ -44,6 +44,7 @@ BuildRequires: liblua5_1 lua5_1-devel
 %endif
 %endif
 BuildRequires: perl
+BuildRequires: perl-Data-Dumper
 
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig


### PR DESCRIPTION
This commit, add the perl-Data-Dumper package as rpm build requirement.
Otherwise an rpmbuild with the provided specfile will fail.