### PR TITLE
Fix likwid-perfctr filter and enable timeline mode to output file

### DIFF
--- a/filters/json
+++ b/filters/json
@@ -140,7 +140,7 @@ if filetype == "perfctr" or filetype == "topology":
 
         for elems in tables[groups[0]]["Raw"]:
             for k in elems:
-                m = re.match("Core (\d+)", k)
+                m = re.match("HWThread (\d+)", k)
                 if m:
                     cpulist.append(int(m.group(1)))
                 m = re.match("GPU (\d+)", k)

--- a/filters/xml
+++ b/filters/xml
@@ -174,7 +174,7 @@ if ($fileType eq 'topology') {
                 if (not $header) {
                     @cpus = split(',',$1);
                     foreach (@cpus) {
-                        s/Core //g;
+                        s/HWThread //g;
                         s/[ ]//g;
                     }
                     $header = 1;
@@ -193,7 +193,7 @@ if ($fileType eq 'topology') {
                 print OUTFILE '</event>'.$NL;
             }
         } elsif ($region eq 'metric') {
-            if ((!/Metric,Core/) and (!/TABLE/)) {
+            if ((!/Metric,HWThread/) and (!/TABLE/)) {
                 @col = split(',',$_);
                 print OUTFILE '<metric>'.$NL;
                 my $name = "";


### PR DESCRIPTION
- Fixes parsing of `likwid-topology` and `likwid-perfctr`
- Simplifies filter code
- Enable output file with timeline mode
- CLI Option (not in help output yet) to add output prefix to timeline mode lines. This is required to implement timeline mode for `likwid-mpirun`