### PR TITLE
New environment variable `LIKWID_IGNORE_CPUSET` to ignore the current cpuset

### DIFF
--- a/src/numa.c
+++ b/src/numa.c
@@ -255,9 +255,9 @@ numa_init(void)
     }
     else
     {
-        cpu_set_t cpuSet;
-        CPU_ZERO(&cpuSet);
-        sched_getaffinity(0,sizeof(cpu_set_t), &cpuSet);
+/*        cpu_set_t cpuSet;*/
+/*        CPU_ZERO(&cpuSet);*/
+/*        sched_getaffinity(0,sizeof(cpu_set_t), &cpuSet);*/
         if (cpuid_topology.activeHWThreads < cpuid_topology.numHWThreads &&
             getenv("HWLOC_FSROOT") == NULL)
         {

--- a/src/topology.c
+++ b/src/topology.c
@@ -1276,7 +1276,20 @@ topology_init(void)
     {
 standard_init:
         CPU_ZERO(&cpuSet);
-        sched_getaffinity(0,sizeof(cpu_set_t), &cpuSet);
+        if (getenv("LIKWID_IGNORE_CPUSET") == NULL)
+        {
+            sched_getaffinity(0,sizeof(cpu_set_t), &cpuSet);
+        }
+        else
+        {
+            for (int i = 0; i < sysconf(_SC_NPROCESSORS_CONF); i++)
+            {
+                if (likwid_cpu_online(i))
+                {
+                    CPU_SET(i, &cpuSet);
+                }
+            }
+        }
         if (cpu_count(&cpuSet) < sysconf(_SC_NPROCESSORS_CONF))
         {
 #if !defined(__ARM_ARCH_7A__) && !defined(__ARM_ARCH_8A)
@@ -1389,7 +1402,20 @@ standard_init:
     else
     {
         CPU_ZERO(&cpuSet);
-        sched_getaffinity(0, sizeof(cpu_set_t), &cpuSet);
+        if (getenv("LIKWID_IGNORE_CPUSET") == NULL)
+        {
+            sched_getaffinity(0, sizeof(cpu_set_t), &cpuSet);
+        }
+        else
+        {
+            for (int i = 0; i < sysconf(_SC_NPROCESSORS_CONF); i++)
+            {
+                if (likwid_cpu_online(i))
+                {
+                    CPU_SET(i, &cpuSet);
+                }
+            }
+        }
         DEBUG_PRINT(DEBUGLEV_INFO, Reading topology information from %s, config.topologyCfgFileName);
         ret = readTopologyFile(config.topologyCfgFileName, cpuSet);
         if (ret < 0)


### PR DESCRIPTION
New environment variable `LIKWID_IGNORE_CPUSET`. The variable affects all tools and the library. Maybe fixes #358, not tested `isolcpus` explicitly. 

```
System with 8 hardware threads (SMT active)
$ taskset -c -p $$
pid's current affinity list: 0-2
$ likwid-pin -c 0,1 -p
INFO: You are running LIKWID in a cpuset with 3 CPUs. Taking given IDs as logical ID in cpuset
0,1
$ likwid-pin -c 3,4 -p
INFO: You are running LIKWID in a cpuset with 3 CPUs. Taking given IDs as logical ID in cpuset
0,1
$ LIKWID_IGNORE_CPUSET=1 ./likwid-pin -c 3,4 -p
3,4
```

It does not ignore the CPUset but creates an own CPUset containing `X` **online** CPUs where `X=sysconf(_SC_NPROCESSORS_CONF)`. This should be fine for almost all use-cases.