### PR TITLE
Update arm64fx MEM groups bandwidth metrics

### DIFF
--- a/groups/arm64fx/MEM.txt
+++ b/groups/arm64fx/MEM.txt
@@ -3,27 +3,28 @@ SHORT Main memory bandwidth in MBytes/s
 EVENTSET
 PMC0  INST_RETIRED
 PMC1  CPU_CYCLES
-PMC2  BUS_READ_TOTAL_MEM
-PMC3  BUS_WRITE_TOTAL_MEM
-
+PMC2  L2D_CACHE_REFILL
+PMC3  L2D_CACHE_WB
+PMC4  L2D_SWAP_DM
+PMC5  L2D_CACHE_MIBMCH_PRF
 
 METRICS
 Runtime (RDTSC) [s] time
 CPI  PMC1/PMC0
-Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2)*256.0/time
-Memory read data volume [GBytes] 1.0E-09*(PMC2)*256.0
+Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2-(PMC4+PMC5))*256.0/time
+Memory read data volume [GBytes] 1.0E-09*(PMC2-(PMC4+PMC5))*256.0
 Memory write bandwidth [MBytes/s] 1.0E-06*(PMC3)*256.0/time
 Memory write data volume [GBytes] 1.0E-09*(PMC3)*256.0
-Memory bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*256.0/time
-Memory data volume [GBytes] 1.0E-09*(PMC2+PMC3)*256.0
+Memory bandwidth [MBytes/s] 1.0E-06*((PMC2-(PMC4+PMC5))+PMC3)*256.0/time
+Memory data volume [GBytes] 1.0E-09*((PMC2-(PMC4+PMC5))+PMC3)*256.0
 
 LONG
 Formulas:
-Memory read bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM)*256.0/runtime
-Memory read data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM)*256.0
-Memory write bandwidth [MBytes/s] = 1.0E-06*(BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory write data volume [GBytes] = 1.0E-09*(BUS_WRITE_TOTAL_MEM)*256.0
-Memory bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0
+Memory read bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0/runtime
+Memory read data volume [GBytes] = 1.0E-09*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0
+Memory write bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_WB)*256.0/runtime
+Memory write data volume [GBytes] = 1.0E-09*(L2D_CACHE_WB)*256.0
+Memory bandwidth [MBytes/s] = 1.0E-06*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0/runtime
+Memory data volume [GBytes] = 1.0E-09*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0
 -
 Profiling group to measure memory bandwidth. The cache line size is 256 Byte.

--- a/groups/arm64fx/MEM_DP.txt
+++ b/groups/arm64fx/MEM_DP.txt
@@ -1,31 +1,30 @@
 SHORT Overview of arithmetic and main memory performance
 
 EVENTSET
-PMC0  INST_RETIRED
-PMC1  CPU_CYCLES
-PMC2  BUS_READ_TOTAL_MEM
-PMC3  BUS_WRITE_TOTAL_MEM
-PMC4  FP_DP_FIXED_OPS_SPEC
-PMC5  FP_DP_SCALE_OPS_SPEC
+PMC0  FP_DP_FIXED_OPS_SPEC
+PMC1  FP_DP_SCALE_OPS_SPEC
+PMC2  L2D_CACHE_REFILL
+PMC3  L2D_CACHE_WB
+PMC4  L2D_SWAP_DM
+PMC5  L2D_CACHE_MIBMCH_PRF
 
 
 METRICS
 Runtime (RDTSC) [s] time
-CPI  PMC1/PMC0
-DP (FP) [MFLOP/s] 1E-06*(PMC4)/time
-DP (FP+SVE128) [MFLOP/s] 1E-06*(((PMC5*128.0)/128.0)+PMC4)/time
-DP (FP+SVE256) [MFLOP/s] 1E-06*(((PMC5*256.0)/128.0)+PMC4)/time
-DP (FP+SVE512) [MFLOP/s] 1E-06*(((PMC5*512.0)/128.0)+PMC4)/time
-Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2)*256.0/time
-Memory read data volume [GBytes] 1.0E-09*(PMC2)*256.0
+DP (FP) [MFLOP/s] 1E-06*(PMC0)/time
+DP (FP+SVE128) [MFLOP/s] 1E-06*(((PMC1*128.0)/128.0)+PMC0)/time
+DP (FP+SVE256) [MFLOP/s] 1E-06*(((PMC1*256.0)/128.0)+PMC0)/time
+DP (FP+SVE512) [MFLOP/s] 1E-06*(((PMC1*512.0)/128.0)+PMC0)/time
+Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2-(PMC4+PMC5))*256.0/time
+Memory read data volume [GBytes] 1.0E-09*(PMC2-(PMC4+PMC5))*256.0
 Memory write bandwidth [MBytes/s] 1.0E-06*(PMC3)*256.0/time
 Memory write data volume [GBytes] 1.0E-09*(PMC3)*256.0
-Memory bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*256.0/time
-Memory data volume [GBytes] 1.0E-09*(PMC2+PMC3)*256.0
-Operational intensity (FP) PMC4/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE128) (((PMC5*128.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE256) (((PMC5*256.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE512) (((PMC5*512.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
+Memory bandwidth [MBytes/s] 1.0E-06*((PMC2-(PMC4+PMC5))+PMC3)*256.0/time
+Memory data volume [GBytes] 1.0E-09*((PMC2-(PMC4+PMC5))+PMC3)*256.0
+Operational intensity (FP) PMC0/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE128) (((PMC1*128.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE256) (((PMC1*256.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE512) (((PMC1*512.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
 
 
 LONG
@@ -34,16 +33,16 @@ DP (FP) [MFLOP/s] = 1E-06*FP_DP_FIXED_OPS_SPEC/time
 DP (FP+SVE128) [MFLOP/s] = 1.0E-06*(FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*128)/128))/time
 DP (FP+SVE256) [MFLOP/s] = 1.0E-06*(FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*256)/128))/time
 DP (FP+SVE512) [MFLOP/s] = 1.0E-06*(FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*512)/128))/time
-Memory read bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM)*256.0/runtime
-Memory read data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM)*256.0
-Memory write bandwidth [MBytes/s] = 1.0E-06*(BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory write data volume [GBytes] = 1.0E-09*(BUS_WRITE_TOTAL_MEM)*256.0
-Memory bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0
-Operational intensity (FP) = FP_DP_FIXED_OPS_SPEC/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE128) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*128)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE256) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*256)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE512) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*512)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
+Memory read bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0/runtime
+Memory read data volume [GBytes] = 1.0E-09*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0
+Memory write bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_WB)*256.0/runtime
+Memory write data volume [GBytes] = 1.0E-09*(L2D_CACHE_WB)*256.0
+Memory bandwidth [MBytes/s] = 1.0E-06*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0/runtime
+Memory data volume [GBytes] = 1.0E-09*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0
+Operational intensity (FP) = FP_DP_FIXED_OPS_SPEC/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE128) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*128)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE256) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*256)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE512) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*512)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
 -
 Profiling group to measure memory bandwidth and double-precision FP rate for scalar and SVE vector
 operations with different widths. The events for the SVE metrics assumes that all vector elements

--- a/groups/arm64fx/MEM_HP.txt
+++ b/groups/arm64fx/MEM_HP.txt
@@ -1,31 +1,30 @@
 SHORT Overview of arithmetic and main memory performance
 
 EVENTSET
-PMC0  INST_RETIRED
-PMC1  CPU_CYCLES
-PMC2  BUS_READ_TOTAL_MEM
-PMC3  BUS_WRITE_TOTAL_MEM
-PMC4  FP_HP_FIXED_OPS_HPEC
-PMC5  FP_HP_SCALE_OPS_HPEC
+PMC0  FP_HP_FIXED_OPS_HPEC
+PMC1  FP_HP_SCALE_OPS_HPEC
+PMC2  L2D_CACHE_REFILL
+PMC3  L2D_CACHE_WB
+PMC4  L2D_SWAP_DM
+PMC5  L2D_CACHE_MIBMCH_PRF
 
 
 METRICS
 Runtime (RDTSC) [s] time
-CPI  PMC1/PMC0
-HP (FP) [MFLOP/s] 1E-06*(PMC4)/time
-HP (FP+SVE128) [MFLOP/s] 1E-06*(((PMC5*128.0)/128.0)+PMC4)/time
-HP (FP+SVE256) [MFLOP/s] 1E-06*(((PMC5*256.0)/128.0)+PMC4)/time
-HP (FP+SVE512) [MFLOP/s] 1E-06*(((PMC5*512.0)/128.0)+PMC4)/time
-Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2)*256.0/time
-Memory read data volume [GBytes] 1.0E-09*(PMC2)*256.0
+HP (FP) [MFLOP/s] 1E-06*(PMC0)/time
+HP (FP+SVE128) [MFLOP/s] 1E-06*(((PMC1*128.0)/128.0)+PMC0)/time
+HP (FP+SVE256) [MFLOP/s] 1E-06*(((PMC1*256.0)/128.0)+PMC0)/time
+HP (FP+SVE512) [MFLOP/s] 1E-06*(((PMC1*512.0)/128.0)+PMC0)/time
+Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2-(PMC4+PMC5))*256.0/time
+Memory read data volume [GBytes] 1.0E-09*(PMC2-(PMC4+PMC5))*256.0
 Memory write bandwidth [MBytes/s] 1.0E-06*(PMC3)*256.0/time
 Memory write data volume [GBytes] 1.0E-09*(PMC3)*256.0
-Memory bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*256.0/time
-Memory data volume [GBytes] 1.0E-09*(PMC2+PMC3)*256.0
-Operational intensity (FP) PMC4/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE128) (((PMC5*128.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE256) (((PMC5*256.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE512) (((PMC5*512.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
+Memory bandwidth [MBytes/s] 1.0E-06*((PMC2-(PMC4+PMC5))+PMC3)*256.0/time
+Memory data volume [GBytes] 1.0E-09*((PMC2-(PMC4+PMC5))+PMC3)*256.0
+Operational intensity (FP) PMC0/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE128) (((PMC1*128.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE256) (((PMC1*256.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE512) (((PMC1*512.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
 
 
 LONG
@@ -34,16 +33,16 @@ HP (FP) [MFLOP/s] = 1E-06*FP_HP_FIXED_OPS_HPEC/time
 HP (FP+SVE128) [MFLOP/s] = 1.0E-06*(FP_HP_FIXED_OPS_HPEC+((FP_HP_SCALE_OPS_HPEC*128)/128))/time
 HP (FP+SVE256) [MFLOP/s] = 1.0E-06*(FP_HP_FIXED_OPS_HPEC+((FP_HP_SCALE_OPS_HPEC*256)/128))/time
 HP (FP+SVE512) [MFLOP/s] = 1.0E-06*(FP_HP_FIXED_OPS_HPEC+((FP_HP_SCALE_OPS_HPEC*512)/128))/time
-Memory read bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM)*256.0/runtime
-Memory read data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM)*256.0
-Memory write bandwidth [MBytes/s] = 1.0E-06*(BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory write data volume [GBytes] = 1.0E-09*(BUS_WRITE_TOTAL_MEM)*256.0
-Memory bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0
-Operational intensity (FP) = FP_HP_FIXED_OPS_HPEC/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE128) = (FP_HP_FIXED_OPS_HPEC+((FP_HP_SCALE_OPS_HPEC*128)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE256) = (FP_HP_FIXED_OPS_HPEC+((FP_HP_SCALE_OPS_HPEC*256)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE512) = (FP_HP_FIXED_OPS_HPEC+((FP_HP_SCALE_OPS_HPEC*512)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
+Memory read bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0/runtime
+Memory read data volume [GBytes] = 1.0E-09*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0
+Memory write bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_WB)*256.0/runtime
+Memory write data volume [GBytes] = 1.0E-09*(L2D_CACHE_WB)*256.0
+Memory bandwidth [MBytes/s] = 1.0E-06*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0/runtime
+Memory data volume [GBytes] = 1.0E-09*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0
+Operational intensity (FP) = FP_DP_FIXED_OPS_SPEC/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE128) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*128)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE256) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*256)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE512) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*512)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
 -
 Profiling group to measure memory bandwidth and half-precision FP rate for scalar and SVE vector
 operations with different widths. The events for the SVE metrics assumes that all vector elements

--- a/groups/arm64fx/MEM_SP.txt
+++ b/groups/arm64fx/MEM_SP.txt
@@ -1,31 +1,30 @@
 SHORT Overview of arithmetic and main memory performance
 
 EVENTSET
-PMC0  INST_RETIRED
-PMC1  CPU_CYCLES
-PMC2  BUS_READ_TOTAL_MEM
-PMC3  BUS_WRITE_TOTAL_MEM
-PMC4  FP_SP_FIXED_OPS_SPEC
-PMC5  FP_SP_SCALE_OPS_SPEC
+PMC0  FP_SP_FIXED_OPS_SPEC
+PMC1  FP_SP_SCALE_OPS_SPEC
+PMC2  L2D_CACHE_REFILL
+PMC3  L2D_CACHE_WB
+PMC4  L2D_SWAP_DM
+PMC5  L2D_CACHE_MIBMCH_PRF
 
 
 METRICS
 Runtime (RDTSC) [s] time
-CPI  PMC1/PMC0
-SP (FP) [MFLOP/s] 1E-06*(PMC4)/time
-SP (FP+SVE128) [MFLOP/s] 1E-06*(((PMC5*128.0)/128.0)+PMC4)/time
-SP (FP+SVE256) [MFLOP/s] 1E-06*(((PMC5*256.0)/128.0)+PMC4)/time
-SP (FP+SVE512) [MFLOP/s] 1E-06*(((PMC5*512.0)/128.0)+PMC4)/time
-Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2)*256.0/time
-Memory read data volume [GBytes] 1.0E-09*(PMC2)*256.0
+SP (FP) [MFLOP/s] 1E-06*(PMC0)/time
+SP (FP+SVE128) [MFLOP/s] 1E-06*(((PMC1*128.0)/128.0)+PMC0)/time
+SP (FP+SVE256) [MFLOP/s] 1E-06*(((PMC1*256.0)/128.0)+PMC0)/time
+SP (FP+SVE512) [MFLOP/s] 1E-06*(((PMC1*512.0)/128.0)+PMC0)/time
+Memory read bandwidth [MBytes/s] 1.0E-06*(PMC2-(PMC4+PMC5))*256.0/time
+Memory read data volume [GBytes] 1.0E-09*(PMC2-(PMC4+PMC5))*256.0
 Memory write bandwidth [MBytes/s] 1.0E-06*(PMC3)*256.0/time
 Memory write data volume [GBytes] 1.0E-09*(PMC3)*256.0
-Memory bandwidth [MBytes/s] 1.0E-06*(PMC2+PMC3)*256.0/time
-Memory data volume [GBytes] 1.0E-09*(PMC2+PMC3)*256.0
-Operational intensity (FP) PMC4/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE128) (((PMC5*128.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE256) (((PMC5*256.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
-Operational intensity (FP+SVE512) (((PMC5*512.0)/128.0)+PMC4)/((PMC2+PMC3)*256.0)
+Memory bandwidth [MBytes/s] 1.0E-06*((PMC2-(PMC4+PMC5))+PMC3)*256.0/time
+Memory data volume [GBytes] 1.0E-09*((PMC2-(PMC4+PMC5))+PMC3)*256.0
+Operational intensity (FP) PMC0/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE128) (((PMC1*128.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE256) (((PMC1*256.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
+Operational intensity (FP+SVE512) (((PMC1*512.0)/128.0)+PMC0)/(((PMC2-(PMC4+PMC5))+PMC3)*256.0)
 
 
 LONG
@@ -34,16 +33,16 @@ SP (FP) [MFLOP/s] = 1E-06*FP_SP_FIXED_OPS_SPEC/time
 SP (FP+SVE128) [MFLOP/s] = 1.0E-06*(FP_SP_FIXED_OPS_SPEC+((FP_SP_SCALE_OPS_SPEC*128)/128))/time
 SP (FP+SVE256) [MFLOP/s] = 1.0E-06*(FP_SP_FIXED_OPS_SPEC+((FP_SP_SCALE_OPS_SPEC*256)/128))/time
 SP (FP+SVE512) [MFLOP/s] = 1.0E-06*(FP_SP_FIXED_OPS_SPEC+((FP_SP_SCALE_OPS_SPEC*512)/128))/time
-Memory read bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM)*256.0/runtime
-Memory read data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM)*256.0
-Memory write bandwidth [MBytes/s] = 1.0E-06*(BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory write data volume [GBytes] = 1.0E-09*(BUS_WRITE_TOTAL_MEM)*256.0
-Memory bandwidth [MBytes/s] = 1.0E-06*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0/runtime
-Memory data volume [GBytes] = 1.0E-09*(BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0
-Operational intensity (FP) = FP_SP_FIXED_OPS_SPEC/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE128) = (FP_SP_FIXED_OPS_SPEC+((FP_SP_SCALE_OPS_SPEC*128)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE256) = (FP_SP_FIXED_OPS_SPEC+((FP_SP_SCALE_OPS_SPEC*256)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
-Operational intensity (FP+SVE512) = (FP_SP_FIXED_OPS_SPEC+((FP_SP_SCALE_OPS_SPEC*512)/128)/((BUS_READ_TOTAL_MEM+BUS_WRITE_TOTAL_MEM)*256.0)
+Memory read bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0/runtime
+Memory read data volume [GBytes] = 1.0E-09*(L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))*256.0
+Memory write bandwidth [MBytes/s] = 1.0E-06*(L2D_CACHE_WB)*256.0/runtime
+Memory write data volume [GBytes] = 1.0E-09*(L2D_CACHE_WB)*256.0
+Memory bandwidth [MBytes/s] = 1.0E-06*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0/runtime
+Memory data volume [GBytes] = 1.0E-09*((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0
+Operational intensity (FP) = FP_DP_FIXED_OPS_SPEC/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE128) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*128)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE256) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*256)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
+Operational intensity (FP+SVE512) = (FP_DP_FIXED_OPS_SPEC+((FP_DP_SCALE_OPS_SPEC*512)/128)/(((L2D_CACHE_REFILL-(L2D_SWAP_DM+L2D_CACHE_MIBMCH_PRF))+L2D_CACHE_WB)*256.0)
 -
 Profiling group to measure memory bandwidth and single-precision FP rate for scalar and SVE vector
 operations with different widths. The events for the SVE metrics assumes that all vector elements


### PR DESCRIPTION
Metrics and correction terms taken from the fujitsu a64fx microarchitectural manual v1.4 page 85 and the a64fx pmu events errata v1.0.

```
L2D_CACHE_REFILL (corrected) = L2D_CACHE_REFILL - L2D_SWAP_DM - L2D_CACHE_MIBMCH_PRF
Bandwidth (corrected) = (L2D_CACHE_REFILL - (L2D_SWAP_DM + L2D_CACHE_MIBMCH_PRF) + L2D_CACHE_WB) * 256 / time
```

- https://github.com/fujitsu/A64FX/blob/master/doc/A64FX_Microarchitecture_Manual_en_1.4.pdf
- https://github.com/fujitsu/A64FX/blob/master/doc/A64FX_PMU_Events_Errata_1.0.pdf