### PR TITLE
Proper handling of `CORE` RAPL domain in `likwid-powermeter` for AMD Zen

### DIFF
--- a/src/luawid.c
+++ b/src/luawid.c
@@ -1537,11 +1537,11 @@ lua_likwid_getPowerInfo(lua_State* L)
         power_hasRAPL = power_init(0);
         if (power_hasRAPL > 0)
         {
-            for(i=0;i<affinity->numberOfAffinityDomains;i++)
+            for (i = 0; i < cputopo->numHWThreads; i++)
             {
-                if (bstrchrp(affinity->domains[i].tag, 'S', 0) != BSTR_ERR)
+                if (cputopo->threadPool[i].inCpuSet)
                 {
-                    HPMaddThread(affinity->domains[i].processorList[0]);
+                    HPMaddThread(cputopo->threadPool[i].apicId);
                 }
             }
             power_isInitialized = 1;


### PR DESCRIPTION
For the `CORE` RAPL domain of AMD Zen1/2/3 chips, `likwid-powermeter` reads the data of all cores and sum it up.

Without this PR, only the first hwthread of each socket is measured. 