### PR TITLE
Fix for min. frequency after setting governor. See #404

### DIFF
--- a/src/applications/likwid-setFrequencies.lua
+++ b/src/applications/likwid-setFrequencies.lua
@@ -554,7 +554,7 @@ elseif min_first and min_freq then
             local f = likwid.setCpuClockMax(cpulist[i], max_freq)
         end
     end
-else
+elseif min_freq and max_freq then
     for i=1,#cpulist do
         local f = likwid.setCpuClockMin(cpulist[i], min_freq)
         local f = likwid.setCpuClockMax(cpulist[i], max_freq)


### PR DESCRIPTION
When setting the governor with `likwid-setFrequencies`, the minimal and maximal CPU frequency of all selected HW threads is set to the minimal frequency. This PR fixes this behavior by leaving the CPU frequency untouched.