### PR TITLE
Some fixes for ARM7 and ARM8

### DIFF
--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1295,6 +1295,18 @@ perfmon_init_maps(void)
                     perfmon_numCounters = perfmon_numCountersA15;
                     translate_types = a15_translate_types;
                     break;
+                case ARM_CORTEX_A57:
+                case ARM_CORTEX_A72:
+                case ARM_CORTEX_A73:
+                    eventHash = a57_arch_events;
+                    perfmon_numArchEvents = perfmon_numArchEventsA57;
+                    counter_map = a57_counter_map;
+                    box_map = a57_box_map;
+                    perfmon_numCounters = perfmon_numCountersA57;
+                    translate_types = a57_translate_types;
+                    break;
+                default:
+                    ERROR_PLAIN_PRINT(Unsupported ARMv7 Processor);
             }
             break;
 

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1295,6 +1295,15 @@ perfmon_init_maps(void)
                     perfmon_numCounters = perfmon_numCountersA15;
                     translate_types = a15_translate_types;
                     break;
+                case ARM_CORTEX_A35:
+                case ARM_CORTEX_A53:
+                    eventHash = a57_arch_events;
+                    perfmon_numArchEvents = perfmon_numArchEventsA57;
+                    counter_map = a57_counter_map;
+                    box_map = a57_box_map;
+                    perfmon_numCounters = perfmon_numCountersA57;
+                    translate_types = a53_translate_types;
+                    break;
                 case ARM_CORTEX_A57:
                 case ARM_CORTEX_A72:
                 case ARM_CORTEX_A73:
@@ -1307,6 +1316,7 @@ perfmon_init_maps(void)
                     break;
                 default:
                     ERROR_PLAIN_PRINT(Unsupported ARMv7 Processor);
+                    break;
             }
             break;
 
@@ -1344,6 +1354,7 @@ perfmon_init_maps(void)
                             translate_types = neon1_translate_types;
                             break;
                         default:
+                            ERROR_PLAIN_PRINT(Unsupported ARMv8 Processor);
                             break;
                     }
                     break;
@@ -1359,6 +1370,7 @@ perfmon_init_maps(void)
                             translate_types = cav_tx2_translate_types;
                             break;
                         default:
+                            ERROR_PLAIN_PRINT(Unsupported Cavium/Marvell Processor);
                             break;
                     }
                     break;
@@ -1374,6 +1386,7 @@ perfmon_init_maps(void)
                             translate_types = cav_tx2_translate_types;
                             break;
                         default:
+                            ERROR_PLAIN_PRINT(Unsupported Cavium/Marvell Processor);
                             break;
                     }
                     break;
@@ -1389,6 +1402,7 @@ perfmon_init_maps(void)
                             translate_types = a64fx_translate_types;
                             break;
                         default:
+                            ERROR_PLAIN_PRINT(Unsupported Fujitsu Processor);
                             break;
                     }
                     break;

--- a/src/topology.c
+++ b/src/topology.c
@@ -117,8 +117,10 @@ static char* armv7l_str = "ARM 7l architecture";
 static char* armv8_str = "ARM 8 architecture";
 static char* cavium_thunderx2t99_str = "Cavium Thunder X2 (ARMv8)";
 static char* cavium_thunderx_str = "Cavium Thunder X (ARMv8)";
-static char* arm_cortex_a57 = "ARM Cortex A57 (ARMv8)";
-static char* arm_cortex_a53 = "ARM Cortex A53 (ARMv8)";
+static char* arm_cortex_a57 = "ARM Cortex A57";
+static char* arm_cortex_a53 = "ARM Cortex A53";
+static char* arm_cortex_a72 = "ARM Cortex A72";
+static char* arm_cortex_a73 = "ARM Cortex A73";
 static char* arm_neoverse_n1 = "ARM Neoverse N1";
 static char* fujitsu_a64fx = "Fujitsu A64FX";
 static char* power7_str = "POWER7 architecture";
@@ -1109,6 +1111,22 @@ topology_setName(void)
                     cpuid_info.name = armv7l_str;
                     cpuid_info.short_name = short_arm7;
                     break;
+                case ARM_CORTEX_A57:
+                    cpuid_info.name = arm_cortex_a57;
+                    cpuid_info.short_name = short_arm7;
+                    break;
+                case ARM_CORTEX_A53:
+                    cpuid_info.name = arm_cortex_a53;
+                    cpuid_info.short_name = short_arm7;
+                    break;
+                case ARM_CORTEX_A72:
+                    cpuid_info.name = arm_cortex_a72;
+                    cpuid_info.short_name = short_arm7;
+                    break;
+                case ARM_CORTEX_A73:
+                    cpuid_info.name = arm_cortex_a73;
+                    cpuid_info.short_name = short_arm7;
+                    break;
                 default:
                     return EXIT_FAILURE;
                     break;
@@ -1126,6 +1144,14 @@ topology_setName(void)
                             break;
                         case ARM_CORTEX_A53:
                             cpuid_info.name = arm_cortex_a53;
+                            cpuid_info.short_name = short_arm8;
+                            break;
+                        case ARM_CORTEX_A72:
+                            cpuid_info.name = arm_cortex_a72;
+                            cpuid_info.short_name = short_arm8;
+                            break;
+                        case ARM_CORTEX_A73:
+                            cpuid_info.name = arm_cortex_a73;
                             cpuid_info.short_name = short_arm8;
                             break;
                         case ARM_NEOVERSE_N1:


### PR DESCRIPTION
This PR adds all ARM-reference implementation (A35, A53, A72, A73, Neoverse N1) for 32bit (aka ARMv7 in some cases) and 64bit (ARMv8) to the topology module.