### PR TITLE
Peakflops armv8

### DIFF
--- a/bench/armv8/peakflops.ptt
+++ b/bench/armv8/peakflops.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, only scalar operations
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 30
+fmov    D1, ARG1
+fmov    D2, ARG1
+fmov    D3, ARG1
+fmov    D4, ARG1
+fmov    D5, ARG1
+fmov    D6, ARG1
+fmov    D7, ARG1
+fmov    D8, ARG1
+fmov    D9, ARG1
+fmov    D10, ARG1
+fmov    D11, ARG1
+fmov    D12, ARG1
+fmov    D13, ARG1
+fmov    D14, ARG1
+fmov    D15, ARG1
+fmov    D16, ARG1
+fmov    D17, ARG1
+fmov    D18, ARG1
+fmov    D19, ARG1
+fmov    D20, ARG1
+fmov    D21, ARG1
+fmov    D22, ARG1
+fmov    D23, ARG1
+fmov    D24, ARG1
+fmov    D25, ARG1
+fmov    D26, ARG1
+fmov    D27, ARG1
+fmov    D28, ARG1
+LOOP 1
+ldr      D16, [STR0], #8
+fadd     D1, D1, D1
+fadd     D2, D2, D2
+fmul     D3, D3, D3
+fmul     D4, D4, D4
+fmul     D5, D5, D5
+fadd     D6, D6, D6
+fadd     D7, D7, D7
+fmul     D8, D8, D8
+fadd     D9, D9, D9
+fadd     D10, D10, D10
+fmul     D11, D11, D11
+fmul     D12, D12, D12
+fmul     D13, D13, D13
+fadd     D14, D14, D14
+fadd     D15, D15, D15
+fmul     D16, D16, D16
+fadd     D17, D17, D17
+fmul     D18, D18, D18
+fadd     D19, D19, D19
+fadd     D20, D20, D20
+fmul     D21, D21, D21
+fmul     D22, D22, D22
+fmul     D23, D23, D23
+fadd     D24, D24, D24
+fadd     D25, D25, D25
+fmul     D26, D26, D26
+fadd     D27, D27, D27
+fmul     D28, D28, D28

--- a/bench/armv8/peakflops.ptt
+++ b/bench/armv8/peakflops.ptt
@@ -7,34 +7,34 @@ LOADS 1
 STORES 0
 INSTR_LOOP 29
 UOPS 29
-fmov    D1, ARG1
-fmov    D2, ARG1
-fmov    D3, ARG1
-fmov    D4, ARG1
-fmov    D5, ARG1
-fmov    D6, ARG1
-fmov    D7, ARG1
-fmov    D8, ARG1
-fmov    D9, ARG1
-fmov    D10, ARG1
-fmov    D11, ARG1
-fmov    D12, ARG1
-fmov    D13, ARG1
-fmov    D14, ARG1
-fmov    D15, ARG1
-fmov    D16, ARG1
-fmov    D17, ARG1
-fmov    D18, ARG1
-fmov    D19, ARG1
-fmov    D20, ARG1
-fmov    D21, ARG1
-fmov    D22, ARG1
-fmov    D23, ARG1
-fmov    D24, ARG1
-fmov    D25, ARG1
-fmov    D26, ARG1
-fmov    D27, ARG1
-fmov    D28, ARG1
+fmov    D1, XZR
+fmov    D2, XZR
+fmov    D3, XZR
+fmov    D4, XZR
+fmov    D5, XZR
+fmov    D6, XZR
+fmov    D7, XZR
+fmov    D8, XZR
+fmov    D9, XZR
+fmov    D10, XZR
+fmov    D11, XZR
+fmov    D12, XZR
+fmov    D13, XZR
+fmov    D14, XZR
+fmov    D15, XZR
+fmov    D16, XZR
+fmov    D17, XZR
+fmov    D18, XZR
+fmov    D19, XZR
+fmov    D20, XZR
+fmov    D21, XZR
+fmov    D22, XZR
+fmov    D23, XZR
+fmov    D24, XZR
+fmov    D25, XZR
+fmov    D26, XZR
+fmov    D27, XZR
+fmov    D28, XZR
 LOOP 1
 ldr      D16, [STR0], #8
 fadd     D1, D1, D1

--- a/bench/armv8/peakflops.ptt
+++ b/bench/armv8/peakflops.ptt
@@ -5,8 +5,8 @@ BYTES 8
 DESC Double-precision multiplications and additions with a single load, only scalar operations
 LOADS 1
 STORES 0
-INSTR_LOOP 28
-UOPS 30
+INSTR_LOOP 29
+UOPS 29
 fmov    D1, ARG1
 fmov    D2, ARG1
 fmov    D3, ARG1

--- a/bench/armv8/peakflops_fma.ptt
+++ b/bench/armv8/peakflops_fma.ptt
@@ -1,12 +1,12 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 28
+FLOPS 56
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, only scalar operations using FMAs
 LOADS 1
 STORES 0
-INSTR_LOOP 28
-UOPS 30
+INSTR_LOOP 29
+UOPS 29
 fmov    D1, ARG1
 fmov    D2, ARG1
 fmov    D3, ARG1
@@ -37,31 +37,31 @@ fmov    D27, ARG1
 fmov    D28, ARG1
 LOOP 1
 ldr      D16, [STR0], #8
-fmadd     D1, D1, D1, D1
-fmadd     D2, D2, D2, D2
-fmadd     D3, D3, D3, D3
-fmadd     D4, D4, D4, D4
-fmadd     D5, D5, D5, D5
-fmadd     D6, D6, D6, D6
-fmadd     D7, D7, D7, D7
-fmadd     D8, D8, D8, D8
-fmadd     D9, D9, D9, D9
-fmadd     D10, D10, D10, D10
-fmadd     D11, D11, D11, D11
-fmadd     D12, D12, D12, D12
-fmadd     D13, D13, D13, D13
-fmadd     D14, D14, D14, D14
-fmadd     D15, D15, D15, D15
-fmadd     D16, D16, D16, D16
-fmadd     D17, D17, D17, D17
-fmadd     D18, D18, D18, D18
-fmadd     D19, D19, D19, D19
-fmadd     D20, D20, D20, D20
-fmadd     D21, D21, D21, D21
-fmadd     D22, D22, D22, D22
-fmadd     D23, D23, D23, D23
-fmadd     D24, D24, D24, D24
-fmadd     D25, D25, D25, D25
-fmadd     D26, D26, D26, D26
-fmadd     D27, D27, D27, D27
-fmadd     D28, D28, D28, D28
+fmadd     D0, D1, D2, D3
+fmadd     D1, D2, D3, D4
+fmadd     D2, D3, D4, D5
+fmadd     D3, D4, D5, D6
+fmadd     D4, D5, D6, D7
+fmadd     D5, D6, D7, D8
+fmadd     D6, D7, D8, D9
+fmadd     D7, D8, D9, D10
+fmadd     D8, D9, D10, D11
+fmadd     D9, D10, D11, D12
+fmadd     D10, D11, D12, D13
+fmadd     D11, D12, D13, D14
+fmadd     D12, D13, D14, D15
+fmadd     D13, D14, D15, D16
+fmadd     D14, D15, D16, D17
+fmadd     D15, D16, D17, D18
+fmadd     D16, D17, D18, D19
+fmadd     D17, D18, D19, D20
+fmadd     D18, D19, D20, D21
+fmadd     D19, D20, D21, D22
+fmadd     D20, D21, D22, D23
+fmadd     D21, D22, D23, D24
+fmadd     D22, D23, D24, D25
+fmadd     D23, D24, D25, D26
+fmadd     D24, D25, D26, D27
+fmadd     D25, D26, D27, D28
+fmadd     D26, D27, D28, D1
+fmadd     D27, D28, D1, D2

--- a/bench/armv8/peakflops_fma.ptt
+++ b/bench/armv8/peakflops_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, only scalar operations using FMAs
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 30
+fmov    D1, ARG1
+fmov    D2, ARG1
+fmov    D3, ARG1
+fmov    D4, ARG1
+fmov    D5, ARG1
+fmov    D6, ARG1
+fmov    D7, ARG1
+fmov    D8, ARG1
+fmov    D9, ARG1
+fmov    D10, ARG1
+fmov    D11, ARG1
+fmov    D12, ARG1
+fmov    D13, ARG1
+fmov    D14, ARG1
+fmov    D15, ARG1
+fmov    D16, ARG1
+fmov    D17, ARG1
+fmov    D18, ARG1
+fmov    D19, ARG1
+fmov    D20, ARG1
+fmov    D21, ARG1
+fmov    D22, ARG1
+fmov    D23, ARG1
+fmov    D24, ARG1
+fmov    D25, ARG1
+fmov    D26, ARG1
+fmov    D27, ARG1
+fmov    D28, ARG1
+LOOP 1
+ldr      D16, [STR0], #8
+fmadd     D1, D1, D1, D1
+fmadd     D2, D2, D2, D2
+fmadd     D3, D3, D3, D3
+fmadd     D4, D4, D4, D4
+fmadd     D5, D5, D5, D5
+fmadd     D6, D6, D6, D6
+fmadd     D7, D7, D7, D7
+fmadd     D8, D8, D8, D8
+fmadd     D9, D9, D9, D9
+fmadd     D10, D10, D10, D10
+fmadd     D11, D11, D11, D11
+fmadd     D12, D12, D12, D12
+fmadd     D13, D13, D13, D13
+fmadd     D14, D14, D14, D14
+fmadd     D15, D15, D15, D15
+fmadd     D16, D16, D16, D16
+fmadd     D17, D17, D17, D17
+fmadd     D18, D18, D18, D18
+fmadd     D19, D19, D19, D19
+fmadd     D20, D20, D20, D20
+fmadd     D21, D21, D21, D21
+fmadd     D22, D22, D22, D22
+fmadd     D23, D23, D23, D23
+fmadd     D24, D24, D24, D24
+fmadd     D25, D25, D25, D25
+fmadd     D26, D26, D26, D26
+fmadd     D27, D27, D27, D27
+fmadd     D28, D28, D28, D28

--- a/bench/armv8/peakflops_fma.ptt
+++ b/bench/armv8/peakflops_fma.ptt
@@ -7,34 +7,35 @@ LOADS 1
 STORES 0
 INSTR_LOOP 29
 UOPS 29
-fmov    D1, ARG1
-fmov    D2, ARG1
-fmov    D3, ARG1
-fmov    D4, ARG1
-fmov    D5, ARG1
-fmov    D6, ARG1
-fmov    D7, ARG1
-fmov    D8, ARG1
-fmov    D9, ARG1
-fmov    D10, ARG1
-fmov    D11, ARG1
-fmov    D12, ARG1
-fmov    D13, ARG1
-fmov    D14, ARG1
-fmov    D15, ARG1
-fmov    D16, ARG1
-fmov    D17, ARG1
-fmov    D18, ARG1
-fmov    D19, ARG1
-fmov    D20, ARG1
-fmov    D21, ARG1
-fmov    D22, ARG1
-fmov    D23, ARG1
-fmov    D24, ARG1
-fmov    D25, ARG1
-fmov    D26, ARG1
-fmov    D27, ARG1
-fmov    D28, ARG1
+fmov	D0, XZR
+fmov    D1, XZR
+fmov    D2, XZR
+fmov    D3, XZR
+fmov    D4, XZR
+fmov    D5, XZR
+fmov    D6, XZR
+fmov    D7, XZR
+fmov    D8, XZR
+fmov    D9, XZR
+fmov    D10, XZR
+fmov    D11, XZR
+fmov    D12, XZR
+fmov    D13, XZR
+fmov    D14, XZR
+fmov    D15, XZR
+fmov    D16, XZR
+fmov    D17, XZR
+fmov    D18, XZR
+fmov    D19, XZR
+fmov    D20, XZR
+fmov    D21, XZR
+fmov    D22, XZR
+fmov    D23, XZR
+fmov    D24, XZR
+fmov    D25, XZR
+fmov    D26, XZR
+fmov    D27, XZR
+fmov    D28, XZR
 LOOP 1
 ldr      D16, [STR0], #8
 fmadd     D0, D1, D2, D3

--- a/bench/armv8/peakflops_sp.ptt
+++ b/bench/armv8/peakflops_sp.ptt
@@ -5,8 +5,8 @@ BYTES 4
 DESC Single-precision multiplications and additions with a single load, only scalar operations
 LOADS 1
 STORES 0
-INSTR_LOOP 28
-UOPS 30
+INSTR_LOOP 29
+UOPS 29
 fmov    S1, WZR
 fmov    S2, WZR
 fmov    S3, WZR

--- a/bench/armv8/peakflops_sp.ptt
+++ b/bench/armv8/peakflops_sp.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 28
+BYTES 4
+DESC Single-precision multiplications and additions with a single load, only scalar operations
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 30
+fmov    S1, WZR
+fmov    S2, WZR
+fmov    S3, WZR
+fmov    S4, WZR
+fmov    S5, WZR
+fmov    S6, WZR
+fmov    S7, WZR
+fmov    S8, WZR
+fmov    S9, WZR
+fmov    S10, WZR
+fmov    S11, WZR
+fmov    S12, WZR
+fmov    S13, WZR
+fmov    S14, WZR
+fmov    S15, WZR
+fmov    S16, WZR
+fmov    S17, WZR
+fmov    S18, WZR
+fmov    S19, WZR
+fmov    S20, WZR
+fmov    S21, WZR
+fmov    S22, WZR
+fmov    S23, WZR
+fmov    S24, WZR
+fmov    S25, WZR
+fmov    S26, WZR
+fmov    S27, WZR
+fmov    S28, WZR
+LOOP 1
+ldr      S16, [STR0], #4
+fadd     S1, S1, S1
+fadd     S2, S2, S2
+fmul     S3, S3, S3
+fmul     S4, S4, S4
+fmul     S5, S5, S5
+fadd     S6, S6, S6
+fadd     S7, S7, S7
+fmul     S8, S8, S8
+fadd     S9, S9, S9
+fadd     S10, S10, S10
+fmul     S11, S11, S11
+fmul     S12, S12, S12
+fmul     S13, S13, S13
+fadd     S14, S14, S14
+fadd     S15, S15, S15
+fmul     S16, S16, S16
+fadd     S17, S17, S17
+fmul     S18, S18, S18
+fadd     S19, S19, S19
+fadd     S20, S20, S20
+fmul     S21, S21, S21
+fmul     S22, S22, S22
+fmul     S23, S23, S23
+fadd     S24, S24, S24
+fadd     S25, S25, S25
+fmul     S26, S26, S26
+fadd     S27, S27, S27
+fmul     S28, S28, S28

--- a/bench/armv8/peakflops_sp_fma.ptt
+++ b/bench/armv8/peakflops_sp_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE
+FLOPS 28
+BYTES 4
+DESC Single-precision multiplications and additions with a single load, only scalar operations using FMAs
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+fmov    S1, WZR
+fmov    S2, WZR
+fmov    S3, WZR
+fmov    S4, WZR
+fmov    S5, WZR
+fmov    S6, WZR
+fmov    S7, WZR
+fmov    S8, WZR
+fmov    S9, WZR
+fmov    S10, WZR
+fmov    S11, WZR
+fmov    S12, WZR
+fmov    S13, WZR
+fmov    S14, WZR
+fmov    S15, WZR
+fmov    S16, WZR
+fmov    S17, WZR
+fmov    S18, WZR
+fmov    S19, WZR
+fmov    S20, WZR
+fmov    S21, WZR
+fmov    S22, WZR
+fmov    S23, WZR
+fmov    S24, WZR
+fmov    S25, WZR
+fmov    S26, WZR
+fmov    S27, WZR
+fmov    S28, WZR
+LOOP 1
+ldr      S16, [STR0], #4
+fmadd     S1, S1, S1, S1
+fmadd     S2, S2, S2, S2
+fmadd     S3, S3, S3, S3
+fmadd     S4, S4, S4, S4
+fmadd     S5, S5, S5, S5
+fmadd     S6, S6, S6, S6
+fmadd     S7, S7, S7, S7
+fmadd     S8, S8, S8, S8
+fmadd     S9, S9, S9, S9
+fmadd     S10, S10, S10, S10
+fmadd     S11, S11, S11, S11
+fmadd     S12, S12, S12, S12
+fmadd     S13, S13, S13, S13
+fmadd     S14, S14, S14, S14
+fmadd     S15, S15, S15, S15
+fmadd     S16, S16, S16, S16
+fmadd     S17, S17, S17, S17
+fmadd     S18, S18, S18, S18
+fmadd     S19, S19, S19, S19
+fmadd     S20, S20, S20, S20
+fmadd     S21, S21, S21, S21
+fmadd     S22, S22, S22, S22
+fmadd     S23, S23, S23, S23
+fmadd     S24, S24, S24, S24
+fmadd     S25, S25, S25, S25
+fmadd     S26, S26, S26, S26
+fmadd     S27, S27, S27, S27
+fmadd     S28, S28, S28, S28

--- a/bench/armv8/peakflops_sp_fma.ptt
+++ b/bench/armv8/peakflops_sp_fma.ptt
@@ -1,11 +1,11 @@
 STREAMS 1
 TYPE SINGLE
-FLOPS 28
+FLOPS 56
 BYTES 4
 DESC Single-precision multiplications and additions with a single load, only scalar operations using FMAs
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
 fmov    S1, WZR
 fmov    S2, WZR

--- a/bench/armv8/peakflops_sp_sve128.ptt
+++ b/bench/armv8/peakflops_sp_sve128.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE 
+FLOPS 28
+BYTES 8
+DESC Single-precision multiplications and additions with a single load, optimized for SVE 
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
+LOOP 2
+ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+fadd     z1.s, p1/m, z1.s, z1.s
+fadd     z2.s, p1/m, z2.s, z2.s
+fmul     z3.s, p1/m, z3.s, z3.s
+fmul     z4.s, p1/m, z4.s, z4.s
+fmul     z5.s, p1/m, z5.s, z5.s
+fadd     z6.s, p1/m, z6.s, z6.s
+fadd     z7.s, p1/m, z7.s, z7.s
+fmul     z8.s, p1/m, z8.s, z8.s
+fadd     z9.s, p1/m, z9.s, z9.s
+fadd     z10.s, p1/m, z10.s, z10.s
+fmul     z11.s, p1/m, z11.s, z11.s
+fmul     z12.s, p1/m, z12.s, z12.s
+fmul     z13.s, p1/m, z13.s, z13.s
+fadd     z14.s, p1/m, z14.s, z14.s
+fadd     z15.s, p1/m, z15.s, z15.s
+fmul     z16.s, p1/m, z16.s, z16.s
+fadd     z17.s, p1/m, z17.s, z17.s
+fmul     z18.s, p1/m, z18.s, z18.s
+fadd     z19.s, p1/m, z19.s, z19.s
+fadd     z20.s, p1/m, z20.s, z20.s
+fmul     z21.s, p1/m, z21.s, z21.s
+fmul     z22.s, p1/m, z22.s, z22.s
+fmul     z23.s, p1/m, z23.s, z23.s
+fadd     z24.s, p1/m, z24.s, z24.s
+fadd     z25.s, p1/m, z25.s, z25.s
+fmul     z26.s, p1/m, z26.s, z26.s
+fadd     z27.s, p1/m, z27.s, z27.s
+fmul     z28.s, p1/m, z28.s, z28.s

--- a/bench/armv8/peakflops_sp_sve128.ptt
+++ b/bench/armv8/peakflops_sp_sve128.ptt
@@ -1,42 +1,42 @@
 STREAMS 1
 TYPE SINGLE 
 FLOPS 28
-BYTES 8
+BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for SVE 
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
-ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
-LOOP 2
-ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1w    z1.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z2.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z3.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z4.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z5.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z6.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z7.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z8.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z9.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z10.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z11.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z12.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z13.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z14.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z15.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z16.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z17.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z18.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z19.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z20.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z21.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z22.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z23.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z24.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z25.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z26.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z27.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z28.s, p0/z, [STR0, GPR6, lsl 2]
+LOOP 4
+ld1w     z16.s, p0/z, [STR0, GPR6, lsl 2]
 fadd     z1.s, p1/m, z1.s, z1.s
 fadd     z2.s, p1/m, z2.s, z2.s
 fmul     z3.s, p1/m, z3.s, z3.s

--- a/bench/armv8/peakflops_sp_sve128_fma.ptt
+++ b/bench/armv8/peakflops_sp_sve128_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE 
+FLOPS 28
+BYTES 8
+DESC Single-precision multiplications and additions with a single load, optimized for SVE FMAs 
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
+LOOP 2
+ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+fmla     z1.s, p1/m, z1.s, z1.s
+fmla     z2.s, p1/m, z2.s, z2.s
+fmla     z3.s, p1/m, z3.s, z3.s
+fmla     z4.s, p1/m, z4.s, z4.s
+fmla     z5.s, p1/m, z5.s, z5.s
+fmla     z6.s, p1/m, z6.s, z6.s
+fmla     z7.s, p1/m, z7.s, z7.s
+fmla     z8.s, p1/m, z8.s, z8.s
+fmla     z9.s, p1/m, z9.s, z9.s
+fmla     z10.s, p1/m, z10.s, z10.s
+fmla     z11.s, p1/m, z11.s, z11.s
+fmla     z12.s, p1/m, z12.s, z12.s
+fmla     z13.s, p1/m, z13.s, z13.s
+fmla     z14.s, p1/m, z14.s, z14.s
+fmla     z15.s, p1/m, z15.s, z15.s
+fmla     z16.s, p1/m, z16.s, z16.s
+fmla     z17.s, p1/m, z17.s, z17.s
+fmla     z18.s, p1/m, z18.s, z18.s
+fmla     z19.s, p1/m, z19.s, z19.s
+fmla     z20.s, p1/m, z20.s, z20.s
+fmla     z21.s, p1/m, z21.s, z21.s
+fmla     z22.s, p1/m, z22.s, z22.s
+fmla     z23.s, p1/m, z23.s, z23.s
+fmla     z24.s, p1/m, z24.s, z24.s
+fmla     z25.s, p1/m, z25.s, z25.s
+fmla     z26.s, p1/m, z26.s, z26.s
+fmla     z27.s, p1/m, z27.s, z27.s
+fmla     z28.s, p1/m, z28.s, z28.s

--- a/bench/armv8/peakflops_sp_sve128_fma.ptt
+++ b/bench/armv8/peakflops_sp_sve128_fma.ptt
@@ -1,42 +1,42 @@
 STREAMS 1
 TYPE SINGLE 
-FLOPS 28
-BYTES 8
+FLOPS 56
+BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for SVE FMAs 
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
-ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
-LOOP 2
-ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1w    z1.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z2.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z3.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z4.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z5.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z6.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z7.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z8.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z9.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z10.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z11.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z12.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z13.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z14.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z15.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z16.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z17.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z18.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z19.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z20.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z21.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z22.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z23.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z24.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z25.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z26.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z27.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z28.s, p0/z, [STR0, GPR6, lsl 2]
+LOOP 4
+ld1w     z16.s, p0/z, [STR0, GPR6, lsl 2]
 fmla     z1.s, p1/m, z1.s, z1.s
 fmla     z2.s, p1/m, z2.s, z2.s
 fmla     z3.s, p1/m, z3.s, z3.s

--- a/bench/armv8/peakflops_sp_sve256.ptt
+++ b/bench/armv8/peakflops_sp_sve256.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE 
+FLOPS 28
+BYTES 8
+DESC Single-precision multiplications and additions with a single load, optimized for SVE 
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
+LOOP 4
+ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+fadd     z1.s, p1/m, z1.s, z1.s
+fadd     z2.s, p1/m, z2.s, z2.s
+fmul     z3.s, p1/m, z3.s, z3.s
+fmul     z4.s, p1/m, z4.s, z4.s
+fmul     z5.s, p1/m, z5.s, z5.s
+fadd     z6.s, p1/m, z6.s, z6.s
+fadd     z7.s, p1/m, z7.s, z7.s
+fmul     z8.s, p1/m, z8.s, z8.s
+fadd     z9.s, p1/m, z9.s, z9.s
+fadd     z10.s, p1/m, z10.s, z10.s
+fmul     z11.s, p1/m, z11.s, z11.s
+fmul     z12.s, p1/m, z12.s, z12.s
+fmul     z13.s, p1/m, z13.s, z13.s
+fadd     z14.s, p1/m, z14.s, z14.s
+fadd     z15.s, p1/m, z15.s, z15.s
+fmul     z16.s, p1/m, z16.s, z16.s
+fadd     z17.s, p1/m, z17.s, z17.s
+fmul     z18.s, p1/m, z18.s, z18.s
+fadd     z19.s, p1/m, z19.s, z19.s
+fadd     z20.s, p1/m, z20.s, z20.s
+fmul     z21.s, p1/m, z21.s, z21.s
+fmul     z22.s, p1/m, z22.s, z22.s
+fmul     z23.s, p1/m, z23.s, z23.s
+fadd     z24.s, p1/m, z24.s, z24.s
+fadd     z25.s, p1/m, z25.s, z25.s
+fmul     z26.s, p1/m, z26.s, z26.s
+fadd     z27.s, p1/m, z27.s, z27.s
+fmul     z28.s, p1/m, z28.s, z28.s

--- a/bench/armv8/peakflops_sp_sve256.ptt
+++ b/bench/armv8/peakflops_sp_sve256.ptt
@@ -1,42 +1,42 @@
 STREAMS 1
 TYPE SINGLE 
 FLOPS 28
-BYTES 8
+BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for SVE 
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
-ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
-LOOP 4
-ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1w    z1.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z2.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z3.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z4.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z5.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z6.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z7.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z8.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z9.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z10.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z11.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z12.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z13.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z14.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z15.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z16.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z17.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z18.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z19.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z20.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z21.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z22.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z23.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z24.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z25.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z26.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z27.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z28.s, p0/z, [STR0, GPR6, lsl 2]
+LOOP 8
+ld1w     z16.s, p0/z, [STR0, GPR6, lsl 2]
 fadd     z1.s, p1/m, z1.s, z1.s
 fadd     z2.s, p1/m, z2.s, z2.s
 fmul     z3.s, p1/m, z3.s, z3.s

--- a/bench/armv8/peakflops_sp_sve256_fma.ptt
+++ b/bench/armv8/peakflops_sp_sve256_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE 
+FLOPS 28
+BYTES 8
+DESC Single-precision multiplications and additions with a single load, optimized for SVE FMAs 
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
+LOOP 4
+ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+fmla     z1.s, p1/m, z1.s, z1.s
+fmla     z2.s, p1/m, z2.s, z2.s
+fmla     z3.s, p1/m, z3.s, z3.s
+fmla     z4.s, p1/m, z4.s, z4.s
+fmla     z5.s, p1/m, z5.s, z5.s
+fmla     z6.s, p1/m, z6.s, z6.s
+fmla     z7.s, p1/m, z7.s, z7.s
+fmla     z8.s, p1/m, z8.s, z8.s
+fmla     z9.s, p1/m, z9.s, z9.s
+fmla     z10.s, p1/m, z10.s, z10.s
+fmla     z11.s, p1/m, z11.s, z11.s
+fmla     z12.s, p1/m, z12.s, z12.s
+fmla     z13.s, p1/m, z13.s, z13.s
+fmla     z14.s, p1/m, z14.s, z14.s
+fmla     z15.s, p1/m, z15.s, z15.s
+fmla     z16.s, p1/m, z16.s, z16.s
+fmla     z17.s, p1/m, z17.s, z17.s
+fmla     z18.s, p1/m, z18.s, z18.s
+fmla     z19.s, p1/m, z19.s, z19.s
+fmla     z20.s, p1/m, z20.s, z20.s
+fmla     z21.s, p1/m, z21.s, z21.s
+fmla     z22.s, p1/m, z22.s, z22.s
+fmla     z23.s, p1/m, z23.s, z23.s
+fmla     z24.s, p1/m, z24.s, z24.s
+fmla     z25.s, p1/m, z25.s, z25.s
+fmla     z26.s, p1/m, z26.s, z26.s
+fmla     z27.s, p1/m, z27.s, z27.s
+fmla     z28.s, p1/m, z28.s, z28.s

--- a/bench/armv8/peakflops_sp_sve256_fma.ptt
+++ b/bench/armv8/peakflops_sp_sve256_fma.ptt
@@ -1,42 +1,42 @@
 STREAMS 1
 TYPE SINGLE 
-FLOPS 28
-BYTES 8
+FLOPS 56
+BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for SVE FMAs 
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
-ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
-LOOP 4
-ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1w    z1.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z2.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z3.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z4.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z5.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z6.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z7.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z8.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z9.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z10.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z11.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z12.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z13.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z14.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z15.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z16.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z17.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z18.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z19.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z20.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z21.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z22.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z23.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z24.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z25.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z26.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z27.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z28.s, p0/z, [STR0, GPR6, lsl 2]
+LOOP 8
+ld1w     z16.s, p0/z, [STR0, GPR6, lsl 2]
 fmla     z1.s, p1/m, z1.s, z1.s
 fmla     z2.s, p1/m, z2.s, z2.s
 fmla     z3.s, p1/m, z3.s, z3.s

--- a/bench/armv8/peakflops_sp_sve512.ptt
+++ b/bench/armv8/peakflops_sp_sve512.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE 
+FLOPS 28
+BYTES 8
+DESC Single-precision multiplications and additions with a single load, optimized for SVE 
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
+LOOP 8
+ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+fadd     z1.s, p1/m, z1.s, z1.s
+fadd     z2.s, p1/m, z2.s, z2.s
+fmul     z3.s, p1/m, z3.s, z3.s
+fmul     z4.s, p1/m, z4.s, z4.s
+fmul     z5.s, p1/m, z5.s, z5.s
+fadd     z6.s, p1/m, z6.s, z6.s
+fadd     z7.s, p1/m, z7.s, z7.s
+fmul     z8.s, p1/m, z8.s, z8.s
+fadd     z9.s, p1/m, z9.s, z9.s
+fadd     z10.s, p1/m, z10.s, z10.s
+fmul     z11.s, p1/m, z11.s, z11.s
+fmul     z12.s, p1/m, z12.s, z12.s
+fmul     z13.s, p1/m, z13.s, z13.s
+fadd     z14.s, p1/m, z14.s, z14.s
+fadd     z15.s, p1/m, z15.s, z15.s
+fmul     z16.s, p1/m, z16.s, z16.s
+fadd     z17.s, p1/m, z17.s, z17.s
+fmul     z18.s, p1/m, z18.s, z18.s
+fadd     z19.s, p1/m, z19.s, z19.s
+fadd     z20.s, p1/m, z20.s, z20.s
+fmul     z21.s, p1/m, z21.s, z21.s
+fmul     z22.s, p1/m, z22.s, z22.s
+fmul     z23.s, p1/m, z23.s, z23.s
+fadd     z24.s, p1/m, z24.s, z24.s
+fadd     z25.s, p1/m, z25.s, z25.s
+fmul     z26.s, p1/m, z26.s, z26.s
+fadd     z27.s, p1/m, z27.s, z27.s
+fmul     z28.s, p1/m, z28.s, z28.s

--- a/bench/armv8/peakflops_sp_sve512.ptt
+++ b/bench/armv8/peakflops_sp_sve512.ptt
@@ -1,42 +1,42 @@
 STREAMS 1
 TYPE SINGLE 
 FLOPS 28
-BYTES 8
+BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for SVE 
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
-ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
-LOOP 8
-ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1w    z1.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z2.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z3.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z4.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z5.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z6.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z7.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z8.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z9.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z10.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z11.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z12.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z13.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z14.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z15.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z16.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z17.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z18.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z19.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z20.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z21.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z22.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z23.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z24.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z25.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z26.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z27.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z28.s, p0/z, [STR0, GPR6, lsl 2]
+LOOP 16
+ld1w     z16.s, p0/z, [STR0, GPR6, lsl 2]
 fadd     z1.s, p1/m, z1.s, z1.s
 fadd     z2.s, p1/m, z2.s, z2.s
 fmul     z3.s, p1/m, z3.s, z3.s

--- a/bench/armv8/peakflops_sp_sve512_fma.ptt
+++ b/bench/armv8/peakflops_sp_sve512_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE SINGLE 
+FLOPS 28
+BYTES 8
+DESC Single-precision multiplications and additions with a single load, optimized for SVE FMAs 
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
+LOOP 8
+ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+fmla     z1.s, p1/m, z1.s, z1.s
+fmla     z2.s, p1/m, z2.s, z2.s
+fmla     z3.s, p1/m, z3.s, z3.s
+fmla     z4.s, p1/m, z4.s, z4.s
+fmla     z5.s, p1/m, z5.s, z5.s
+fmla     z6.s, p1/m, z6.s, z6.s
+fmla     z7.s, p1/m, z7.s, z7.s
+fmla     z8.s, p1/m, z8.s, z8.s
+fmla     z9.s, p1/m, z9.s, z9.s
+fmla     z10.s, p1/m, z10.s, z10.s
+fmla     z11.s, p1/m, z11.s, z11.s
+fmla     z12.s, p1/m, z12.s, z12.s
+fmla     z13.s, p1/m, z13.s, z13.s
+fmla     z14.s, p1/m, z14.s, z14.s
+fmla     z15.s, p1/m, z15.s, z15.s
+fmla     z16.s, p1/m, z16.s, z16.s
+fmla     z17.s, p1/m, z17.s, z17.s
+fmla     z18.s, p1/m, z18.s, z18.s
+fmla     z19.s, p1/m, z19.s, z19.s
+fmla     z20.s, p1/m, z20.s, z20.s
+fmla     z21.s, p1/m, z21.s, z21.s
+fmla     z22.s, p1/m, z22.s, z22.s
+fmla     z23.s, p1/m, z23.s, z23.s
+fmla     z24.s, p1/m, z24.s, z24.s
+fmla     z25.s, p1/m, z25.s, z25.s
+fmla     z26.s, p1/m, z26.s, z26.s
+fmla     z27.s, p1/m, z27.s, z27.s
+fmla     z28.s, p1/m, z28.s, z28.s

--- a/bench/armv8/peakflops_sp_sve512_fma.ptt
+++ b/bench/armv8/peakflops_sp_sve512_fma.ptt
@@ -1,42 +1,42 @@
 STREAMS 1
 TYPE SINGLE 
-FLOPS 28
-BYTES 8
+FLOPS 56
+BYTES 4
 DESC Single-precision multiplications and additions with a single load, optimized for SVE FMAs 
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
-ld1d    z1.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z2.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z3.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z4.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z5.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z6.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z7.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z8.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z9.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z10.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z11.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z12.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z13.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z14.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z15.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z16.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z17.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z18.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z19.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z20.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z21.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z22.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z23.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z24.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z25.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z26.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z27.s, p0/z, [STR0, GPR6, lsl 3]
-ld1d    z28.s, p0/z, [STR0, GPR6, lsl 3]
-LOOP 8
-ld1d     z16.s, p0/z, [STR0, GPR6, lsl 3]
+ld1w    z1.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z2.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z3.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z4.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z5.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z6.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z7.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z8.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z9.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z10.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z11.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z12.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z13.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z14.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z15.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z16.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z17.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z18.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z19.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z20.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z21.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z22.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z23.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z24.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z25.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z26.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z27.s, p0/z, [STR0, GPR6, lsl 2]
+ld1w    z28.s, p0/z, [STR0, GPR6, lsl 2]
+LOOP 16
+ld1w     z16.s, p0/z, [STR0, GPR6, lsl 2]
 fmla     z1.s, p1/m, z1.s, z1.s
 fmla     z2.s, p1/m, z2.s, z2.s
 fmla     z3.s, p1/m, z3.s, z3.s

--- a/bench/armv8/peakflops_sve128.ptt
+++ b/bench/armv8/peakflops_sve128.ptt
@@ -5,7 +5,7 @@ BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for SVE 
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
 ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
 ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]

--- a/bench/armv8/peakflops_sve128.ptt
+++ b/bench/armv8/peakflops_sve128.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for SVE 
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.d, p0/z, [STR0, GPR6, lsl 3]
+LOOP 2
+ld1d     z16.d, p0/z, [STR0, GPR6, lsl 3]
+fadd     z1.d, p1/m, z1.d, z1.d
+fadd     z2.d, p1/m, z2.d, z2.d
+fmul     z3.d, p1/m, z3.d, z3.d
+fmul     z4.d, p1/m, z4.d, z4.d
+fmul     z5.d, p1/m, z5.d, z5.d
+fadd     z6.d, p1/m, z6.d, z6.d
+fadd     z7.d, p1/m, z7.d, z7.d
+fmul     z8.d, p1/m, z8.d, z8.d
+fadd     z9.d, p1/m, z9.d, z9.d
+fadd     z10.d, p1/m, z10.d, z10.d
+fmul     z11.d, p1/m, z11.d, z11.d
+fmul     z12.d, p1/m, z12.d, z12.d
+fmul     z13.d, p1/m, z13.d, z13.d
+fadd     z14.d, p1/m, z14.d, z14.d
+fadd     z15.d, p1/m, z15.d, z15.d
+fmul     z16.d, p1/m, z16.d, z16.d
+fadd     z17.d, p1/m, z17.d, z17.d
+fmul     z18.d, p1/m, z18.d, z18.d
+fadd     z19.d, p1/m, z19.d, z19.d
+fadd     z20.d, p1/m, z20.d, z20.d
+fmul     z21.d, p1/m, z21.d, z21.d
+fmul     z22.d, p1/m, z22.d, z22.d
+fmul     z23.d, p1/m, z23.d, z23.d
+fadd     z24.d, p1/m, z24.d, z24.d
+fadd     z25.d, p1/m, z25.d, z25.d
+fmul     z26.d, p1/m, z26.d, z26.d
+fadd     z27.d, p1/m, z27.d, z27.d
+fmul     z28.d, p1/m, z28.d, z28.d

--- a/bench/armv8/peakflops_sve128_fma.ptt
+++ b/bench/armv8/peakflops_sve128_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for SVE FMAs
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.d, p0/z, [STR0, GPR6, lsl 3]
+LOOP 2
+ld1d     z16.d, p0/z, [STR0, GPR6, lsl 3]
+fmla     z1.d, p1/m, z1.d, z1.d
+fmla     z2.d, p1/m, z2.d, z2.d
+fmla     z3.d, p1/m, z3.d, z3.d
+fmla     z4.d, p1/m, z4.d, z4.d
+fmla     z5.d, p1/m, z5.d, z5.d
+fmla     z6.d, p1/m, z6.d, z6.d
+fmla     z7.d, p1/m, z7.d, z7.d
+fmla     z8.d, p1/m, z8.d, z8.d
+fmla     z9.d, p1/m, z9.d, z9.d
+fmla     z10.d, p1/m, z10.d, z10.d
+fmla     z11.d, p1/m, z11.d, z11.d
+fmla     z12.d, p1/m, z12.d, z12.d
+fmla     z13.d, p1/m, z13.d, z13.d
+fmla     z14.d, p1/m, z14.d, z14.d
+fmla     z15.d, p1/m, z15.d, z15.d
+fmla     z16.d, p1/m, z16.d, z16.d
+fmla     z17.d, p1/m, z17.d, z17.d
+fmla     z18.d, p1/m, z18.d, z18.d
+fmla     z19.d, p1/m, z19.d, z19.d
+fmla     z20.d, p1/m, z20.d, z20.d
+fmla     z21.d, p1/m, z21.d, z21.d
+fmla     z22.d, p1/m, z22.d, z22.d
+fmla     z23.d, p1/m, z23.d, z23.d
+fmla     z24.d, p1/m, z24.d, z24.d
+fmla     z25.d, p1/m, z25.d, z25.d
+fmla     z26.d, p1/m, z26.d, z26.d
+fmla     z27.d, p1/m, z27.d, z27.d
+fmla     z28.d, p1/m, z28.d, z28.d

--- a/bench/armv8/peakflops_sve128_fma.ptt
+++ b/bench/armv8/peakflops_sve128_fma.ptt
@@ -1,11 +1,11 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 28
+FLOPS 56
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for SVE FMAs
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
 ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
 ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]

--- a/bench/armv8/peakflops_sve256.ptt
+++ b/bench/armv8/peakflops_sve256.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for SVE
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.d, p0/z, [STR0, GPR6, lsl 3]
+LOOP 4
+ld1d     z16.d, p0/z, [STR0, GPR6, lsl 3]
+fadd     z1.d, p1/m, z1.d, z1.d
+fadd     z2.d, p1/m, z2.d, z2.d
+fmul     z3.d, p1/m, z3.d, z3.d
+fmul     z4.d, p1/m, z4.d, z4.d
+fmul     z5.d, p1/m, z5.d, z5.d
+fadd     z6.d, p1/m, z6.d, z6.d
+fadd     z7.d, p1/m, z7.d, z7.d
+fmul     z8.d, p1/m, z8.d, z8.d
+fadd     z9.d, p1/m, z9.d, z9.d
+fadd     z10.d, p1/m, z10.d, z10.d
+fmul     z11.d, p1/m, z11.d, z11.d
+fmul     z12.d, p1/m, z12.d, z12.d
+fmul     z13.d, p1/m, z13.d, z13.d
+fadd     z14.d, p1/m, z14.d, z14.d
+fadd     z15.d, p1/m, z15.d, z15.d
+fmul     z16.d, p1/m, z16.d, z16.d
+fadd     z17.d, p1/m, z17.d, z17.d
+fmul     z18.d, p1/m, z18.d, z18.d
+fadd     z19.d, p1/m, z19.d, z19.d
+fadd     z20.d, p1/m, z20.d, z20.d
+fmul     z21.d, p1/m, z21.d, z21.d
+fmul     z22.d, p1/m, z22.d, z22.d
+fmul     z23.d, p1/m, z23.d, z23.d
+fadd     z24.d, p1/m, z24.d, z24.d
+fadd     z25.d, p1/m, z25.d, z25.d
+fmul     z26.d, p1/m, z26.d, z26.d
+fadd     z27.d, p1/m, z27.d, z27.d
+fmul     z28.d, p1/m, z28.d, z28.d

--- a/bench/armv8/peakflops_sve256.ptt
+++ b/bench/armv8/peakflops_sve256.ptt
@@ -5,7 +5,7 @@ BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for SVE
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
 ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
 ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]

--- a/bench/armv8/peakflops_sve256_fma.ptt
+++ b/bench/armv8/peakflops_sve256_fma.ptt
@@ -1,11 +1,11 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 28
+FLOPS 56
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for SVE FMAs
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
 ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
 ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]

--- a/bench/armv8/peakflops_sve256_fma.ptt
+++ b/bench/armv8/peakflops_sve256_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for SVE FMAs
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.d, p0/z, [STR0, GPR6, lsl 3]
+LOOP 4
+ld1d     z16.d, p0/z, [STR0, GPR6, lsl 3]
+fmla     z1.d, p1/m, z1.d, z1.d
+fmla     z2.d, p1/m, z2.d, z2.d
+fmla     z3.d, p1/m, z3.d, z3.d
+fmla     z4.d, p1/m, z4.d, z4.d
+fmla     z5.d, p1/m, z5.d, z5.d
+fmla     z6.d, p1/m, z6.d, z6.d
+fmla     z7.d, p1/m, z7.d, z7.d
+fmla     z8.d, p1/m, z8.d, z8.d
+fmla     z9.d, p1/m, z9.d, z9.d
+fmla     z10.d, p1/m, z10.d, z10.d
+fmla     z11.d, p1/m, z11.d, z11.d
+fmla     z12.d, p1/m, z12.d, z12.d
+fmla     z13.d, p1/m, z13.d, z13.d
+fmla     z14.d, p1/m, z14.d, z14.d
+fmla     z15.d, p1/m, z15.d, z15.d
+fmla     z16.d, p1/m, z16.d, z16.d
+fmla     z17.d, p1/m, z17.d, z17.d
+fmla     z18.d, p1/m, z18.d, z18.d
+fmla     z19.d, p1/m, z19.d, z19.d
+fmla     z20.d, p1/m, z20.d, z20.d
+fmla     z21.d, p1/m, z21.d, z21.d
+fmla     z22.d, p1/m, z22.d, z22.d
+fmla     z23.d, p1/m, z23.d, z23.d
+fmla     z24.d, p1/m, z24.d, z24.d
+fmla     z25.d, p1/m, z25.d, z25.d
+fmla     z26.d, p1/m, z26.d, z26.d
+fmla     z27.d, p1/m, z27.d, z27.d
+fmla     z28.d, p1/m, z28.d, z28.d

--- a/bench/armv8/peakflops_sve512.ptt
+++ b/bench/armv8/peakflops_sve512.ptt
@@ -5,7 +5,7 @@ BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for SVE
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
 ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
 ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]

--- a/bench/armv8/peakflops_sve512.ptt
+++ b/bench/armv8/peakflops_sve512.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for SVE
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.d, p0/z, [STR0, GPR6, lsl 3]
+LOOP 8
+ld1d     z16.d, p0/z, [STR0, GPR6, lsl 3]
+fadd     z1.d, p1/m, z1.d, z1.d
+fadd     z2.d, p1/m, z2.d, z2.d
+fmul     z3.d, p1/m, z3.d, z3.d
+fmul     z4.d, p1/m, z4.d, z4.d
+fmul     z5.d, p1/m, z5.d, z5.d
+fadd     z6.d, p1/m, z6.d, z6.d
+fadd     z7.d, p1/m, z7.d, z7.d
+fmul     z8.d, p1/m, z8.d, z8.d
+fadd     z9.d, p1/m, z9.d, z9.d
+fadd     z10.d, p1/m, z10.d, z10.d
+fmul     z11.d, p1/m, z11.d, z11.d
+fmul     z12.d, p1/m, z12.d, z12.d
+fmul     z13.d, p1/m, z13.d, z13.d
+fadd     z14.d, p1/m, z14.d, z14.d
+fadd     z15.d, p1/m, z15.d, z15.d
+fmul     z16.d, p1/m, z16.d, z16.d
+fadd     z17.d, p1/m, z17.d, z17.d
+fmul     z18.d, p1/m, z18.d, z18.d
+fadd     z19.d, p1/m, z19.d, z19.d
+fadd     z20.d, p1/m, z20.d, z20.d
+fmul     z21.d, p1/m, z21.d, z21.d
+fmul     z22.d, p1/m, z22.d, z22.d
+fmul     z23.d, p1/m, z23.d, z23.d
+fadd     z24.d, p1/m, z24.d, z24.d
+fadd     z25.d, p1/m, z25.d, z25.d
+fmul     z26.d, p1/m, z26.d, z26.d
+fadd     z27.d, p1/m, z27.d, z27.d
+fmul     z28.d, p1/m, z28.d, z28.d

--- a/bench/armv8/peakflops_sve512_fma.ptt
+++ b/bench/armv8/peakflops_sve512_fma.ptt
@@ -1,0 +1,67 @@
+STREAMS 1
+TYPE DOUBLE
+FLOPS 28
+BYTES 8
+DESC Double-precision multiplications and additions with a single load, optimized for SVE FMAs
+LOADS 1
+STORES 0
+INSTR_LOOP 28
+UOPS 29
+ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z3.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z4.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z5.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z6.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z7.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z8.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z9.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z10.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z11.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z12.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z13.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z14.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z15.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z16.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z17.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z18.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z19.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z20.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z21.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z22.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z23.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z24.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z25.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z26.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z27.d, p0/z, [STR0, GPR6, lsl 3]
+ld1d    z28.d, p0/z, [STR0, GPR6, lsl 3]
+LOOP 8
+ld1d     z16.d, p0/z, [STR0, GPR6, lsl 3]
+fmla     z1.d, p1/m, z1.d, z1.d
+fmla     z2.d, p1/m, z2.d, z2.d
+fmla     z3.d, p1/m, z3.d, z3.d
+fmla     z4.d, p1/m, z4.d, z4.d
+fmla     z5.d, p1/m, z5.d, z5.d
+fmla     z6.d, p1/m, z6.d, z6.d
+fmla     z7.d, p1/m, z7.d, z7.d
+fmla     z8.d, p1/m, z8.d, z8.d
+fmla     z9.d, p1/m, z9.d, z9.d
+fmla     z10.d, p1/m, z10.d, z10.d
+fmla     z11.d, p1/m, z11.d, z11.d
+fmla     z12.d, p1/m, z12.d, z12.d
+fmla     z13.d, p1/m, z13.d, z13.d
+fmla     z14.d, p1/m, z14.d, z14.d
+fmla     z15.d, p1/m, z15.d, z15.d
+fmla     z16.d, p1/m, z16.d, z16.d
+fmla     z17.d, p1/m, z17.d, z17.d
+fmla     z18.d, p1/m, z18.d, z18.d
+fmla     z19.d, p1/m, z19.d, z19.d
+fmla     z20.d, p1/m, z20.d, z20.d
+fmla     z21.d, p1/m, z21.d, z21.d
+fmla     z22.d, p1/m, z22.d, z22.d
+fmla     z23.d, p1/m, z23.d, z23.d
+fmla     z24.d, p1/m, z24.d, z24.d
+fmla     z25.d, p1/m, z25.d, z25.d
+fmla     z26.d, p1/m, z26.d, z26.d
+fmla     z27.d, p1/m, z27.d, z27.d
+fmla     z28.d, p1/m, z28.d, z28.d

--- a/bench/armv8/peakflops_sve512_fma.ptt
+++ b/bench/armv8/peakflops_sve512_fma.ptt
@@ -1,11 +1,11 @@
 STREAMS 1
 TYPE DOUBLE
-FLOPS 28
+FLOPS 56
 BYTES 8
 DESC Double-precision multiplications and additions with a single load, optimized for SVE FMAs
 LOADS 1
 STORES 0
-INSTR_LOOP 28
+INSTR_LOOP 29
 UOPS 29
 ld1d    z1.d, p0/z, [STR0, GPR6, lsl 3]
 ld1d    z2.d, p0/z, [STR0, GPR6, lsl 3]


### PR DESCRIPTION
Created peakflops benchmarks for likwid-bench on ARMv8. This includes
- Benchmarks for SP and DP operands
- A combination of MUL and ADD, or pure FMA instructions
- Scalar, SVE128, SVE256, and SVE512 versions

When running those on a single core as `likwid-bench -t BENCHMARK -w S0:40kB:1` and comparing the result with the expected peak performance, all benchmarks reach more than 99% of the theoretical peak performance:

```
benchmark               measured_MFLOPS expected_MFLOPS relative_performance_%
peakflops               3587.83         3600.0          99.66
peakflops_fma           7174.63         7200.0          99.65
peakflops_sve128        7170.39         7200.0          99.59
peakflops_sve128_fma    14340.99        14400.0         99.59
peakflops_sve256        14315.83        14400.0         99.42
peakflops_sve256_fma    28631.60        28800.0         99.42
peakflops_sve512        28527.05        28800.0         99.05
peakflops_sve512_fma    57035.30        57600.0         99.02
peakflops_sp            3589.91         3600.0          99.72
peakflops_sp_fma        7180.22         7200.0          99.73
peakflops_sp_sve128     14341.46        14400.0         99.59
peakflops_sp_sve128_fma 28628.94        28800.0         99.41
peakflops_sp_sve256     28633.55        28800.0         99.42
peakflops_sp_sve256_fma 57045.71        57600.0         99.04
peakflops_sp_sve512     57051.17        57600.0         99.05
peakflops_sp_sve512_fma 114103.75       115200.0        99.05
```
