### PR TITLE
Fix a bug due to the unrelased lock before the method returns (the issue#416)

### DIFF
--- a/src/libperfctr.c
+++ b/src/libperfctr.c
@@ -608,6 +608,10 @@ likwid_markerStopRegion(const char* regionTag)
     if (results->state != MARKER_STATE_START)
     {
         fprintf(stderr, "WARN: Stopping an unknown/not-started region %s\n", regionTag);
+        if (use_locks == 1)
+        {
+            pthread_mutex_unlock(&threadLocks[myCPU]);
+        }
         return -EFAULT;
     }
     results->groupID = groupSet->activeGroup;


### PR DESCRIPTION
Fix a bug due to the unreleased lock before the method likwid_markerStopRegion returns. Insert the unlock statement before returning.