### PR TITLE
Support spaces in marker API labels

### DIFF
--- a/src/nvmon.c
+++ b/src/nvmon.c
@@ -866,7 +866,7 @@ double nvmon_getMetric(int groupId, int metricId, int gpuId)
     {
         return NAN;
     }
-    
+
     char* f = ginfo->metricformulas[metricId];
     NvmonDevice_t device = &nvGroupSet->gpus[gpuId];
     if (groupId < 0 || groupId >= device->numNvEventSets)
@@ -1062,14 +1062,22 @@ nvmon_readMarkerFile(const char* filename)
             char regiontag[100];
             char* ptr = NULL;
             char* colonptr = NULL;
-            regiontag[0] = '\0';
-            ret = sscanf(buf, "%d:%s", &regionid, regiontag);
+            // zero out ALL of regiontag due to replacing %s with %Nc
+            memset(regiontag, 0, sizeof(regiontag) * sizeof(char));
+            char fmt[64];
+            // using %d:%s for sscanf doesn't support spaces so replace %s with %Nc where N is one minus
+            // the size of regiontag, thus to avoid hardcoding N, compose fmt from the size of regiontag, e.g.:
+            //      regiontag[50]  --> %d:%50c
+            //      regiontag[100] --> %d:%100c
+            snprintf(fmt, 60, "%s:%s%ic", "%d", "%", (int) (sizeof(regiontag) - 1));
+            // use fmt (%d:%Nc) in lieu of %d:%s to support spaces
+            ret = sscanf(buf, fmt, &regionid, regiontag);
 
             ptr = strrchr(regiontag,'-');
             colonptr = strchr(buf,':');
             if (ret != 2 || ptr == NULL || colonptr == NULL)
             {
-                fprintf(stderr, "Line %s not a valid region description\n", buf);
+                fprintf(stderr, "Line %s not a valid region description: %s\n", buf, regiontag);
                 continue;
             }
             groupid = atoi(ptr+1);
@@ -1378,5 +1386,3 @@ double nvmon_getMetricOfRegionGpu(int region, int metricId, int gpuId)
     destroy_clist(&clist);
     return result;
 }
-
-

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1845,7 +1845,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
     *init_temp = initialize_thermal;
 }
 
-char** 
+char**
 getArchRegisterTypeNames()
 {
     return archRegisterTypeNames;
@@ -3792,14 +3792,22 @@ perfmon_readMarkerFile(const char* filename)
             char regiontag[100];
             char* ptr = NULL;
             char* colonptr = NULL;
-            regiontag[0] = '\0';
-            ret = sscanf(buf, "%d:%s", &regionid, regiontag);
+            // zero out ALL of regiontag due to replacing %s with %Nc
+            memset(regiontag, 0, sizeof(regiontag) * sizeof(char));
+            char fmt[64];
+            // using %d:%s for sscanf doesn't support spaces so replace %s with %Nc where N is one minus
+            // the size of regiontag, thus to avoid hardcoding N, compose fmt from the size of regiontag, e.g.:
+            //      regiontag[50]  --> %d:%50c
+            //      regiontag[100] --> %d:%100c
+            snprintf(fmt, 60, "%s:%s%ic", "%d", "%", (int) (sizeof(regiontag) - 1));
+            // use fmt (%d:%Nc) in lieu of %d:%s to support spaces
+            ret = sscanf(buf, fmt, &regionid, regiontag);
 
             ptr = strrchr(regiontag,'-');
             colonptr = strchr(buf,':');
             if (ret != 2 || ptr == NULL || colonptr == NULL)
             {
-                fprintf(stderr, "Line %s not a valid region description\n", buf);
+                fprintf(stderr, "Line %s not a valid region description: %s\n", buf, regiontag);
                 continue;
             }
             groupid = atoi(ptr+1);


### PR DESCRIPTION
- replaces "%s" with "%Nc" where N is set to one minus
  the size of the zeroed out.
- added printout of regiontag to not valid region description msg

Hey @TomTheBear I was using the marker API and was generating some strings dynamically in timemory along the lines of: `"run/ex_cxx_overhead.cpp:314 [with timing = mode::manual]"` and was getting errors + a segfault at the end of the application like so:

```console
Line 1:run/ex_cxx_overhead.cpp:314 [with timing = mode::none]-0
 not a valid region description
Line 2:run/ex_cxx_overhead.cpp:314 [with timing = mode::manual]-0
 not a valid region description
Line 3:run/ex_cxx_overhead.cpp:314 [with timing = mode::single]-0
 not a valid region description
Line 4:run/ex_cxx_overhead.cpp:314 [with timing = mode::blank]-0
 not a valid region description
Line 5:run/ex_cxx_overhead.cpp:314 [with timing = mode::blank_pointer]-0
 not a valid region description
Line 6:run/ex_cxx_overhead.cpp:314 [with timing = mode::chained]-0
 not a valid region description
Line 7:run/ex_cxx_overhead.cpp:314 [with timing = mode::basic]-0
 not a valid region description
Line 8:run/ex_cxx_overhead.cpp:314 [with timing = mode::basic_pointer]-0
 not a valid region description
Line 9:run/ex_cxx_overhead.cpp:314 [with timing = mode::invoke]-0
 not a valid region description
Segmentation fault (core dumped)
```

Which was a bit opaque since the string looked correct. But then I added `regiontag` to the "not a valid region description" message and realized what has happening with the spaces so I patched `perfmon.c` and `nvmon.c` to support spaces and I included that diagnostic as part of this PR since it was helpful.

If I were you, I'd verify my implementation... my C string manipulation skills are fairly rusty due to my predilection for C++ strings.



