### PR TITLE
README: Fix variable assignment in quick install

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ page in the wiki https://github.com/RRZE-HPC/likwid/wiki/Build
 
 For quick install:
 ```bash
-$VERSION=stable
+VERSION=stable
 wget http://ftp.fau.de/pub/likwid/likwid-$VERSION.tar.gz
 tar -xaf likwid-$VERSION.tar.gz
-cd likwid-$VERSION
+cd likwid-*
 vi config.mk # configure build, e.g. change installation prefix and architecture flags
 make
 sudo make install # sudo required to install the access daemon with proper permissions


### PR DESCRIPTION
In bash (and other shells), the leading `$` in `$VERSION=stable` will fail.
The correct variable assignment looks like:

```sh
VERSION=stable
```

Furthermore, if `VERSION` is stable, the directory will not be
called `likwid-stable`  but (at the moment) will be `likwid-5.2.0`.
A workaround is to simply use an `*` as that will be substituted
by the the correct directory, assuming that only one
`likwid-xyz` directory exists.