### PR TITLE
Check perf device path for ARM8 A72 with fallback. Fixes #425

### DIFF
--- a/src/includes/perfmon_a57_counters.h
+++ b/src/includes/perfmon_a57_counters.h
@@ -48,6 +48,10 @@ static char* a57_translate_types[NUM_UNITS] = {
     [PMC] = "/sys/bus/event_source/devices/armv8_pmuv3",
 };
 
+static char* a72_translate_types[NUM_UNITS] = {
+    [PMC] = "/sys/bus/event_source/devices/armv8_cortex_a72",
+};
+
 static char* a53_translate_types[NUM_UNITS] = {
     [PMC] = "/sys/bus/event_source/devices/cpu",
 };

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1316,6 +1316,10 @@ perfmon_init_maps(void)
                     box_map = a57_box_map;
                     perfmon_numCounters = perfmon_numCountersA57;
                     translate_types = a57_translate_types;
+                    if (access(translate_types[PMC], F_OK) != 0)
+                    {
+                        translate_types = a72_translate_types;
+                    }
                     break;
                 default:
                     ERROR_PLAIN_PRINT(Unsupported ARMv7 Processor);
@@ -1338,6 +1342,10 @@ perfmon_init_maps(void)
                             box_map = a57_box_map;
                             perfmon_numCounters = perfmon_numCountersA57;
                             translate_types = a57_translate_types;
+                            if (access(translate_types[PMC], F_OK) != 0)
+                            {
+                                translate_types = a72_translate_types;
+                            }
                             break;
                         case ARM_CORTEX_A35:
                         case ARM_CORTEX_A53:


### PR DESCRIPTION
If `/sys/bus/event_source/devices/armv8_pmuv3` does not exist, use `/sys/bus/event_source/devices/armv8_cortex_a72`.