### PR TITLE
Update Nvidia GPU support

### DIFF
--- a/src/applications/likwid-perfctr.lua
+++ b/src/applications/likwid-perfctr.lua
@@ -385,7 +385,7 @@ io.stdout:setvbuf("no")
 cpuinfo = likwid.getCpuInfo()
 cputopo = likwid.getCpuTopology()
 ---------------------------
-if gpusSupported then
+if gpusSupported and (#gpu_event_string_list > 0 or print_events or print_event ~= nil) then
     gputopo = likwid.getGpuTopology()
 end
 ---------------------------
@@ -859,7 +859,7 @@ elseif not ldpath:match(libpath) then
     likwid.setenv("LD_LIBRARY_PATH", libpath..":"..ldpath)
 end
 ---------------------------
-if gpusSupported then
+if gpusSupported  and #gpu_event_string_list > 0 then
     local cudahome = os.getenv("CUDA_HOME")
     if cudahome then
         ldpath = os.getenv("LD_LIBRARY_PATH")
@@ -914,7 +914,7 @@ for i, event_string in pairs(event_string_list) do
         table.insert(group_ids, gid)
     end
 end
-if gpusSupported then
+if gpusSupported  and #gpu_event_string_list > 0 then
     for i, event_string in pairs(gpu_event_string_list) do
         if event_string:len() > 0 then
             local gid = likwid.nvAddEventSet(event_string)

--- a/src/includes/nvmon_perfworks.h
+++ b/src/includes/nvmon_perfworks.h
@@ -54,7 +54,7 @@ static void *dl_perfworks_libcudart = NULL;
     do {                                                                \
         CUresult _status = (call);                                      \
         if (_status != CUDA_SUCCESS) {                                  \
-            fprintf(stderr, "Error: function %s failed with error %d.\n", #call, _status); \
+            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
             handleerror;                                                \
         }                                                               \
     } while (0)
@@ -65,7 +65,7 @@ static void *dl_perfworks_libcudart = NULL;
         NVPA_Status _status = (call);                                                          \
         if(_status != NVPA_STATUS_SUCCESS)                                                \
         {                                                                                \
-            fprintf(stderr, "Error: function %s failed with error %d.\n", #call, _status); \
+            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
             handleerror;                                                               \
         }                                                                                \
     } while(0)
@@ -74,7 +74,7 @@ static void *dl_perfworks_libcudart = NULL;
     do {                                                                           \
         CUptiResult _status = (call);                                         \
         if (_status != CUPTI_SUCCESS) {                                            \
-            fprintf(stderr, "Error: function %s failed with error %d.\n", #call, _status);                    \
+            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
             handleerror;                                                             \
         }                                                                          \
     } while (0)
@@ -83,7 +83,7 @@ static void *dl_perfworks_libcudart = NULL;
     do {                                                                \
         cudaError_t _status = (call);                                   \
         if (_status != cudaSuccess) {                                   \
-            fprintf(stderr, "Error: function %s failed with error %d.\n", #call, _status); \
+            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
             handleerror;                                                \
         }                                                               \
     } while (0)
@@ -377,7 +377,7 @@ link_perfworks_libraries(void)
     dl_perfworks_libcuda = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
     if (!dl_perfworks_libcuda || dlerror() != NULL)
     {
-        fprintf(stderr, "CUDA library libcuda.so not found.");
+        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcuda.so not found);
         return -1;
     }
     cuCtxGetCurrentPtr = DLSYM_AND_CHECK(dl_perfworks_libcuda, "cuCtxGetCurrent");
@@ -397,7 +397,7 @@ link_perfworks_libraries(void)
     dl_perfworks_libcudart = dlopen(libcudartpath, RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
     if ((!dl_perfworks_libcudart) || (dlerror() != NULL))
     {
-        fprintf(stderr, "CUDA runtime library libcudart.so not found.\n");
+        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcudart.so not found);
         return -1;
     }
     cudaGetDevicePtr = DLSYM_AND_CHECK(dl_perfworks_libcudart, "cudaGetDevice");
@@ -414,7 +414,7 @@ link_perfworks_libraries(void)
         dl_libhost = dlopen("libnvperf_host.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
         if ((!dl_libhost) || (dlerror() != NULL))
         {
-            fprintf(stderr, "CUpti library libnvperf_host.so not found.\n");
+            DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libnvperf_host.so not found);
             return -1;
         }
     }
@@ -463,7 +463,7 @@ link_perfworks_libraries(void)
         dl_cupti = dlopen("libcupti.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
         if ((!dl_cupti) || (dlerror() != NULL))
         {
-            fprintf(stderr, "CUpti library libcupti.so not found.\n");
+            DEBUG_PRINT(DEBUGLEV_INFO, CUpti library libcupti.so not found);
             return -1;
         }
     }

--- a/src/includes/nvmon_types.h
+++ b/src/includes/nvmon_types.h
@@ -49,8 +49,10 @@ typedef enum {
 } NvmonEventType;
 
 typedef enum {
-    ENTITY_EVENT_TYPE_MONOTONIC = 0,
-    ENTITY_TYPE_INSTANT,
+    ENTITY_TYPE_INSTANT = 0,
+    ENTITY_TYPE_SUM,
+    ENTITY_TYPE_MIN,
+    ENTITY_TYPE_MAX,
 } NvmonEventResultType;
 
 typedef struct {
@@ -74,6 +76,7 @@ typedef struct {
     char description[NVMON_DEFAULT_STR_LEN];
     int active;
     NvmonEventType type;
+    NvmonEventResultType rtype;
 } NvmonEvent;
 typedef NvmonEvent* NvmonEvent_t;
 

--- a/src/libnvctr.c
+++ b/src/libnvctr.c
@@ -394,8 +394,8 @@ likwid_gpuMarkerStartRegion(const char* regionTag)
             if (device->backend == LIKWID_NVMON_CUPTI_BACKEND)
                 results->StartPMcounters[j] = nvmon_getLastResult(results->groupID, j, i);
             else if (device->backend == LIKWID_NVMON_PERFWORKS_BACKEND)
-                results->StartPMcounters[j] = 0.0;
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, START Device %d Event %d: %f - %f, i, j, results->StartPMcounters[j], results->PMcounters[j]);
+                results->StartPMcounters[j] = nvmon_getResult(results->groupID, j, i);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, START Device %d Event %d: %f, i, j, results->StartPMcounters[j]);
         }
         results->state = GPUMARKER_STATE_START;
         timer_start(&(results->startTime));
@@ -440,13 +440,16 @@ likwid_gpuMarkerStopRegion(const char* regionTag)
         results->count++;
         for (int j = 0; j < results->nevents; j++)
         {
-            double end = nvmon_getLastResult(results->groupID, j, i);
+            double end = nvmon_getResult(results->groupID, j, i);
             NvmonDevice_t device = &nvGroupSet->gpus[i];
-            if (device->backend == LIKWID_NVMON_CUPTI_BACKEND)
-                results->PMcounters[j] += end - results->StartPMcounters[j];
-            else if (device->backend == LIKWID_NVMON_PERFWORKS_BACKEND)
-                results->PMcounters[j] += end;
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, STOP Device %d Event %d: %f - %f, i, j, end, results->PMcounters[j]);
+/*            if (device->backend == LIKWID_NVMON_CUPTI_BACKEND)*/
+/*                results->PMcounters[j] += end - results->StartPMcounters[j];*/
+/*            else if (device->backend == LIKWID_NVMON_PERFWORKS_BACKEND)*/
+/*            {*/
+/*                */
+/*            }*/
+            results->PMcounters[j] += end - results->StartPMcounters[j];
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, STOP Device %d Event %d: %f - %f, i, j, end, results->StartPMcounters[j]);
         }
         results->state = GPUMARKER_STATE_STOP;
     }

--- a/src/topology_gpu.c
+++ b/src/topology_gpu.c
@@ -50,7 +50,7 @@
     do {                                                                \
         CUresult _status = (call);                                      \
         if (_status != CUDA_SUCCESS) {                                  \
-            fprintf(stderr, "Error: function %s failed with error %d.\n", #call, _status); \
+            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
             handleerror;                                                \
         }                                                               \
     } while (0)
@@ -63,7 +63,7 @@
     do {                                                                \
         cudaError_t _status = (call);                                   \
         if (_status != cudaSuccess) {                                   \
-            fprintf(stderr, "Error: function %s failed with error %d.\n", #call, _status); \
+            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
             handleerror;                                                \
         }                                                               \
     } while (0)
@@ -111,13 +111,13 @@ topo_link_libraries(void)
     topo_dl_libcuda = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
     if (!topo_dl_libcuda)
     {
-        fprintf(stderr, "CUDA library libcuda.so not found.\n");
+        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcuda.so not found);
         return -1;
     }
     topo_dl_libcudart = dlopen("libcudart.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
     if (!topo_dl_libcudart)
     {
-        fprintf(stderr, "CUDA runtime library libcudart.so not found.");
+        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcudart.so not found);
         return -1;
     }
     cuDeviceGetTopoPtr = DLSYM_AND_CHECK(topo_dl_libcuda, "cuDeviceGet");
@@ -145,7 +145,7 @@ topo_init_cuda(void)
     CUresult cuErr = (*cuInitTopoPtr)(0);
     if (cuErr != CUDA_SUCCESS)
     {
-        fprintf(stderr, "CUDA cannot be found and initialized (cuInit failed).\n");
+        DEBUG_PRINT(DEBUGLEV_INFO, CUDA cannot be found and initialized (cuInit failed));
         return -ENODEV;
     }
     return 0;
@@ -223,13 +223,11 @@ topology_gpu_init()
     ret = topo_link_libraries();
     if (ret != 0)
     {
-        ERROR_PLAIN_PRINT(Cannot open CUDA library to fill GPU topology);
         return EXIT_FAILURE;
     }
     int num_devs = topo_get_numDevices();
     if (num_devs < 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get number of devices from CUDA library);
         return EXIT_FAILURE;
     }
     CUDA_CALL((*cudaDriverGetVersionTopoPtr)(&cuda_version), ret = -1; goto topology_gpu_init_error;);


### PR DESCRIPTION
This PR contains different updates:
- Ability for the perfworks backend to use min,max,sum and spot values
- Don't use `fprintf` in the code but the debug/error macros provided by LIKWID
- `likwid-perfctr`: Initialize the Nvidia GPU modules only if needed (user wants to measure, print or search events). See #427 