### PR TITLE
Potential fix for likwid-perfctr not working on Cortex A53 when running in ARMv7 mode

### DIFF
--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1284,7 +1284,7 @@ perfmon_init_maps(void)
 #endif
 
         case ARMV7_FAMILY:
-            switch ( cpuid_info.model )
+            switch ( cpuid_info.part )
             {
                 case ARMV7L:
                 case ARM7L:

--- a/src/topology.c
+++ b/src/topology.c
@@ -1134,7 +1134,7 @@ topology_setName(void)
             break;
 
         case ARMV7_FAMILY:
-            switch (cpuid_info.model)
+            switch (cpuid_info.part)
             {
                 case ARM7L:
                 case ARMV7L:

--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -284,21 +284,6 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
         cpuid_info.stepping = atoi(info);
     snprintf(cpuid_info.architecture, 19, "x86_64");
 #endif
-/*
-#ifdef __ARM_ARCH_7A__
-    if ((info = LIKWID_HWLOC_NAME(obj_get_info_by_name)(obj, "CPUArchitecture")))
-       cpuid_info.family = atoi(info);
-    if ((info = LIKWID_HWLOC_NAME(obj_get_info_by_name)(obj, "CPURevision")))
-        cpuid_info.model = atoi(info);
-    if (cpuid_info.family == 0 || cpuid_info.model == 0)
-    {
-        uint32_t part = 0;
-        parse_cpuinfo(&count, &cpuid_info.family, &cpuid_info.model, &cpuid_info.stepping, &cpuid_info.part, &cpuid_info.vendor);
-        parse_cpuname(cpuid_info.osname);
-    }
-    snprintf(cpuid_info.architecture, 19, "armv7");
-#endif
-*/
 #if defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A)
     parse_cpuinfo(&count, &cpuid_info.family, &cpuid_info.model, &cpuid_info.stepping, &cpuid_info.part, &cpuid_info.vendor);
     parse_cpuname(cpuid_info.osname);

--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -300,7 +300,6 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
 #endif
 */
 #if defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A)
-    /* uint32_t part = 0; */
     parse_cpuinfo(&count, &cpuid_info.family, &cpuid_info.model, &cpuid_info.stepping, &cpuid_info.part, &cpuid_info.vendor);
     parse_cpuname(cpuid_info.osname);
 #ifdef __ARM_ARCH_7A__

--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -284,6 +284,7 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
         cpuid_info.stepping = atoi(info);
     snprintf(cpuid_info.architecture, 19, "x86_64");
 #endif
+/*
 #ifdef __ARM_ARCH_7A__
     if ((info = LIKWID_HWLOC_NAME(obj_get_info_by_name)(obj, "CPUArchitecture")))
        cpuid_info.family = atoi(info);
@@ -297,11 +298,17 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
     }
     snprintf(cpuid_info.architecture, 19, "armv7");
 #endif
+*/
 #if defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A)
-    uint32_t part = 0;
+    /* uint32_t part = 0; */
     parse_cpuinfo(&count, &cpuid_info.family, &cpuid_info.model, &cpuid_info.stepping, &cpuid_info.part, &cpuid_info.vendor);
     parse_cpuname(cpuid_info.osname);
+#ifdef __ARM_ARCH_7A__
+    snprintf(cpuid_info.architecture, 19, "armv7");
+#endif
+#ifdef __ARM_ARCH_8A
     snprintf(cpuid_info.architecture, 19, "armv8");
+#endif
 #endif
 
 #ifndef _ARCH_PPC


### PR DESCRIPTION
Potential fix for the issue as described in #483.