### PR TITLE
Fix segfault when invalid affinity domain is specified

### DIFF
--- a/bench/src/strUtil.c
+++ b/bench/src/strUtil.c
@@ -154,7 +154,7 @@ parse_workgroup(Workgroup* group, const_bstring str, DataType type)
         }
         else
         {
-            fprintf(stderr, "Unknown affinity domain %s\n", bdata(tokens->entry[2]));
+            fprintf(stderr, "Unknown affinity domain %s\n", bdata(tokens->entry[0]));
             bstrListDestroy(tokens);
             return NULL;
         }


### PR DESCRIPTION
There is an issue in the workgroup parsing code that causes a segfault (also with latest master commit):

```
$ ./likwid-bench -t store -w S0:1GB  # works
Allocate: Process running [...] 
$ ./likwid-bench -t store -w X0:1GB # does not work 
Segmentation fault (core dumped)
```
The current code checks for two elements to be presents in the token list, but accesses the non-existing third element which is fixed by this PR. The outcome then is:

``` 
$ ./likwid-bench -t store -w X0:1GB
Unknown affinity domain X0
```