### PR TITLE
Fix cpuinfo path used in topology_hwloc.c on ARM devices

### DIFF
--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -70,7 +70,7 @@ int parse_cpuinfo(uint32_t* count, uint32_t* family, uint32_t* variant, uint32_t
     struct tagbstring vendString = bsStatic("CPU implementer");
     struct tagbstring procString = bsStatic("processor");
 
-    if (NULL != (fp = fopen ("cpuinfo", "r")))
+    if (NULL != (fp = fopen ("/proc/cpuinfo", "r")))
     {
         bstring src = bread ((bNread) fread, fp);
         struct bstrList* tokens = bsplit(src,(char) '\n');


### PR DESCRIPTION
In a previous commit, the path to the `cpuinfo` file was changed to just `"cpuinfo"` instead of `"/proc/cpuinfo"`. This causes ARM processors to not be recognized.

This commit simply changes that path back to `/proc/cpuinfo`.