### PR TITLE
Use _exit() instead of exit() when checking for RDPMC support

### DIFF
--- a/src/access_x86_rdpmc.c
+++ b/src/access_x86_rdpmc.c
@@ -89,7 +89,7 @@ __rdpmc(int cpu_id, int counter, uint64_t* value)
 void
 segfault_sigaction_rdpmc(int signal, siginfo_t *si, void *arg)
 {
-    exit(1);
+    _exit(1);
 }
 
 static int
@@ -106,6 +106,10 @@ test_rdpmc(int cpu_id, uint64_t value, int flag)
     }
     if (!pid)
     {
+        // Note: when exiting the child process we use _exit() instead of exit()
+        // to avoid calling exit handlers registered by the parent process
+        // (e.g. libuv functions from Julia), which can cause crashes.
+
         uint64_t tmp;
         struct sigaction sa;
         memset(&sa, 0, sizeof(struct sigaction));
@@ -118,7 +122,7 @@ test_rdpmc(int cpu_id, uint64_t value, int flag)
             __rdpmc(cpu_id, value, &tmp);
             usleep(100);
         }
-        exit(0);
+        _exit(0);
     }
     else
     {


### PR DESCRIPTION
Checking for RDPMC support is done in a `fork()`'ed child process, and when the parent is a Julia process there can be exit handlers registered that will crash in the child process. We can get around that by using `_exit()` instead, which doesn't run exit handlers.

Fixes https://github.com/JuliaPerf/LIKWID.jl/issues/51 for me. AFAIK it's safe to use `_exit()` here, according to the [docs](https://man7.org/linux/man-pages/man2/_exit.2.html) the only things to be wary of are stdio streams not being flushed (but we don't print anything in the child) and open file descriptors being closed (I can't see any file descriptors used in the child). I can't see any difference in signal handling either.

CC @carstenbauer 