### PR TITLE
use 'top' instead of 'threads' in executeSlurm as 'threads' is not de…

### DIFF
--- a/src/applications/likwid-mpirun.lua
+++ b/src/applications/likwid-mpirun.lua
@@ -655,7 +655,7 @@ local function executeSlurm(wrapperscript, hostfile, env, nrNodes)
         opts["ntasks-per-node"] = string.format("%d", ppn)
     end
     opts["cpu_bind"] = "none"
-    opts["cpus-per-task"] = string.format("%d", threads)
+    opts["cpus-per-task"] = string.format("%d", tpp)
     supported_types = _srun_get_mpi_types()
     if supported_types["pmi2"] then
         opts["mpi"] = "pmi2"


### PR DESCRIPTION
likwid-mpirun with SLURM throws an error since variable 'threads' is not defined at this point. Using 'top' instead