### PR TITLE
Add support for AMD mobile Zen 4 (Phoenix)

### DIFF
--- a/src/includes/topology.h
+++ b/src/includes/topology.h
@@ -154,6 +154,7 @@ struct topology_functions {
 #define ZEN3_RYZEN3     0x50
 #define ZEN3_EPYC_TRENTO 0x30
 #define ZEN4_RYZEN      0x61
+#define ZEN4_RYZEN2     0x74
 #define ZEN4_EPYC       0x11
 
 /* ARM */

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1282,6 +1282,7 @@ perfmon_init_maps(void)
                     translate_types = zen3_translate_types;
                     break;
                 case ZEN4_RYZEN:
+                case ZEN4_RYZEN2:
                 case ZEN4_EPYC:
                     eventHash = zen4_arch_events;
                     perfmon_numArchEvents = perfmon_numArchEventsZen4;
@@ -1925,6 +1926,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     perfmon_finalizeCountersThread = perfmon_finalizeCountersThread_zen3;
                     break;
                 case ZEN4_RYZEN:
+                case ZEN4_RYZEN2:
                 case ZEN4_EPYC:
                     initThreadArch = perfmon_init_zen4;
                     initialize_power = TRUE;

--- a/src/topology.c
+++ b/src/topology.c
@@ -1138,6 +1138,7 @@ topology_setName(void)
                     cpuid_info.short_name = short_zen3;
                     break;
                 case ZEN4_RYZEN:
+                case ZEN4_RYZEN2:
                 case ZEN4_EPYC:
                     cpuid_info.name = amd_zen4_str;
                     cpuid_info.short_name = short_zen4;


### PR DESCRIPTION
This PR adds (experimental) support for the AMD Zen 4 mobile architecture (codenamed Phoenix):
```
CPU name:	AMD Ryzen 7 PRO 7840U w/ Radeon 780M Graphics  
CPU type:	AMD K19 (Zen4) architecture
CPU clock:	3.29 GHz
```
This is just a very rough setting to get the architecture running (looking at what `ZEN3_RYZEN2` did), I am happy to add additional settings if I get some guidance, as I see several warnings in some of the other Zen 4 groups.