### PR TITLE
Adopt shebang lines because of build errors

### DIFF
--- a/filters/json
+++ b/filters/json
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import json
 import sys

--- a/filters/template
+++ b/filters/template
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/filters/xml
+++ b/filters/xml
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 
 use strict;
 use warnings;

--- a/perl/feedGnuplot
+++ b/perl/feedGnuplot
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 
 package feedgnuplot; # for the metacpan indexer
 


### PR DESCRIPTION
The rpm runtime does not like the syntax of some shebang lines in the code. We are receiving error messages:

```
[   63s] likwid.x86_64: E: env-script-interpreter (Badness: 9) /usr/bin/feedGnuplot /usr/bin/env perl
[   63s] likwid.x86_64: E: env-script-interpreter (Badness: 9) /usr/share/likwid/filter/json /usr/bin/env python3
[   63s] likwid.x86_64: E: env-script-interpreter (Badness: 9) /usr/share/likwid/filter/template /usr/bin/env perl
[   63s] likwid.x86_64: E: env-script-interpreter (Badness: 9) /usr/share/likwid/filter/xml /usr/bin/env perl
[   63s] This script uses 'env' as an interpreter. For the rpm runtime dependency
[   63s] detection to work, the shebang #!/usr/bin/env <interpreter>  needs to be
[   63s] patched into #!/usr/bin/<interpreter>  otherwise the package dependency
[   63s] generator merely adds a dependency on /usr/bin/env rather than the actual
[   63s] interpreter /usr/bin/<interpreter>.  Alternatively, if the file should not be
[   63s] executed, then ensure that it is not marked as executable or don't install it
[   63s] in a path that is reserved for executables.
```

Therefore, I have adopted the referenced files as the rpm runtime (in the openSUSE Build Service) is suggesting for more successful builds in the future.