### PR TITLE
Add Performance Groups for Caches to Intel SapphireRapids

### DIFF
--- a/groups/SPR/L2CACHE.txt
+++ b/groups/SPR/L2CACHE.txt
@@ -1,0 +1,35 @@
+SHORT L2 cache miss rate/ratio
+
+EVENTSET
+FIXC0 INSTR_RETIRED_ANY
+FIXC1 CPU_CLK_UNHALTED_CORE
+FIXC2 CPU_CLK_UNHALTED_REF
+FIXC3 TOPDOWN_SLOTS
+PMC0  L2_REQUEST_ALL
+PMC1  L2_REQUEST_MISS
+
+METRICS
+Runtime (RDTSC) [s] time
+Runtime unhalted [s] FIXC1*inverseClock
+Clock [MHz]  1.E-06*(FIXC1/FIXC2)/inverseClock
+CPI  FIXC1/FIXC0
+L2 request rate PMC0/FIXC0
+L2 miss rate PMC1/FIXC0
+L2 miss ratio PMC1/PMC0
+
+LONG
+Formulas:
+L2 request rate = L2_REQUEST_ALL/INSTR_RETIRED_ANY
+L2 miss rate = L2_REQUEST_MISS/INSTR_RETIRED_ANY
+L2 miss ratio = L2_REQUEST_MISS/L2_REQUEST_ALL
+-
+This group measures the locality of your data accesses with regard to the
+L2 cache. L2 request rate tells you how data intensive your code is
+or how many data accesses you have on average per instruction.
+The L2 miss rate gives a measure how often it was necessary to get
+cache lines from memory. And finally L2 miss ratio tells you how many of your
+memory references required a cache line to be loaded from a higher level.
+While the data cache miss rate might be given by your algorithm you should
+try to get data cache miss ratio as low as possible by increasing your cache reuse.
+
+

--- a/groups/SPR/L3CACHE.txt
+++ b/groups/SPR/L3CACHE.txt
@@ -31,5 +31,6 @@ cache lines from memory. And finally L3 miss ratio tells you how many of your
 memory references required a cache line to be loaded from a higher level.
 While the data cache miss rate might be given by your algorithm you should
 try to get data cache miss ratio as low as possible by increasing your cache reuse.
-
+With Intel SapphireRapids, the retired UOPs cannot be measured anymore.
+Instead, the number of retired instructions are used as a basis for the rates.
 

--- a/groups/SPR/L3CACHE.txt
+++ b/groups/SPR/L3CACHE.txt
@@ -1,0 +1,35 @@
+SHORT L3 cache miss rate/ratio
+
+EVENTSET
+FIXC0 INSTR_RETIRED_ANY
+FIXC1 CPU_CLK_UNHALTED_CORE
+FIXC2 CPU_CLK_UNHALTED_REF
+FIXC3 TOPDOWN_SLOTS
+PMC0  MEM_LOAD_RETIRED_L3_HIT
+PMC1  MEM_LOAD_RETIRED_L3_MISS
+
+METRICS
+Runtime (RDTSC) [s] time
+Runtime unhalted [s] FIXC1*inverseClock
+Clock [MHz]  1.E-06*(FIXC1/FIXC2)/inverseClock
+CPI  FIXC1/FIXC0
+L3 request rate (PMC0+PMC1)/FIXC0
+L3 miss rate PMC1/FIXC0
+L3 miss ratio PMC1/(PMC0+PMC1)
+
+LONG
+Formulas:
+L3 request rate = (MEM_LOAD_RETIRED_L3_HIT+MEM_LOAD_RETIRED_L3_MISS)/INSTR_RETIRED_ANY
+L3 miss rate = MEM_LOAD_RETIRED_L3_MISS/INSTR_RETIRED_ANY
+L3 miss ratio = MEM_LOAD_RETIRED_L3_MISS/(MEM_LOAD_RETIRED_L3_HIT+MEM_LOAD_RETIRED_L3_MISS)
+-
+This group measures the locality of your data accesses with regard to the
+L3 cache. L3 request rate tells you how data intensive your code is
+or how many data accesses you have on average per instruction.
+The L3 miss rate gives a measure how often it was necessary to get
+cache lines from memory. And finally L3 miss ratio tells you how many of your
+memory references required a cache line to be loaded from a higher level.
+While the data cache miss rate might be given by your algorithm you should
+try to get data cache miss ratio as low as possible by increasing your cache reuse.
+
+


### PR DESCRIPTION
Hi @TomTheBear,

This PR adds the two performance groups `L2CACHE` and `L3CACHE` to the Intel SapphireRapids architecture. These groups also exist for previous architectures and were adapted from the existing group files. The following adoptions were made:

- In SapphireRapids, the `L2_TRANS_ALL_REQUESTS` event of the `L2CACHE` group no longer exists and was replaced by the `L2_REQUEST_ALL` event. For consistency within the group file `L2_RQSTS_MISS` was replaced by its alias `L2_REQUEST_MISS`.
- As [this comment](https://github.com/RRZE-HPC/likwid/blob/master/groups/ICL/L3CACHE.txt#L35-L36) ("With Intel Icelake, the retired UOPs cannot be measured anymore but instead, [...]") indicates, SapphireRapids no longer supports the counting of all retired UOPs. Therefore, the `L3CACHE` group uses the event `INSTR_RETIRED_ANY` as a basis for the rates. This matches the calculation in the `L2CACHE` group although it deviates from [the calculation for Icelake](https://github.com/RRZE-HPC/likwid/blob/master/groups/ICL/L3CACHE.txt) which used the `UOPS_RETIRED_SLOTS` event.

The new groups were tested with the `stream` test from the LIKWID benchmark suite. As a sanity check the counter values were compared with enabled and disabled prefetchers as well as on SkylakeX and SapphireRapids. The reported values seemed sensible while the two architectures exhibited the qualitatively same behavior.

Hope this is helpful and can be integrated into LIKWID. Thanks for the consideration 🤓

Greetings

Christian
