### PR TITLE
fixing two bugs which result in crashes on a 24-core a64fx (related to issue #599)

### DIFF
--- a/src/affinity.c
+++ b/src/affinity.c
@@ -553,7 +553,7 @@ affinity_init()
         numberOfCoresPerCache = numberOfProcessorsPerCache / cputopo->numThreadsPerCore;
         DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: CPU cores per LLC %d, numberOfCoresPerCache);
         int numCachesPerSocket = cputopo->numCoresPerSocket / numberOfCoresPerCache;
-        numberOfCacheDomains = cputopo->numSockets * numCachesPerSocket;
+        numberOfCacheDomains = cputopo->numSockets * MAX(numCachesPerSocket, 1);
         DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: Cache domains %d, numberOfCacheDomains);
         numberOfDomains += numberOfCacheDomains;
     }

--- a/src/topology_proc.c
+++ b/src/topology_proc.c
@@ -602,6 +602,7 @@ proc_init_nodeTopology(cpu_set_t cpuSet)
     int (*ownatoi)(const char*);
     ownatoi = &atoi;
     int last_socket = -1;
+    int last_coreid = -1;
     int num_sockets = 0;
     int num_cores_per_socket = 0;
     int num_threads_per_core = 0;
@@ -631,6 +632,7 @@ proc_init_nodeTopology(cpu_set_t cpuSet)
             {
                 num_sockets++;
                 last_socket = packageId;
+                last_coreid = -1;
             }
             fclose(fp);
         }
@@ -639,7 +641,7 @@ proc_init_nodeTopology(cpu_set_t cpuSet)
         if (NULL != (fp = fopen (bdata(file), "r")))
         {
             bstring src = bread ((bNread) fread, fp);
-            hwThreadPool[i].coreId = ownatoi(bdata(src));
+            hwThreadPool[i].coreId = (++last_coreid);
             if (hwThreadPool[i].packageId == 0)
             {
                 num_cores_per_socket++;


### PR DESCRIPTION
bug 1: numCachesPerSocket is 0 and numberOfDomains is therefore calculated incorrectly resulting in writes to not allocated mem

bug 2: 24-core version of a64fx is essentiually a 48 core with some cores being disabled, but the core IDs are not numbered consecutively by the kernel resulting in segfaults in likwid