### PR TITLE
likwid-bridge: a helper tool to run likwid in containers like Apptainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ likwid-pin
 likwid-powermeter
 likwid-setFrequencies
 likwid-topology
+likwid-bridge
 likwid.lua
 
 # generated doc files

--- a/config.mk
+++ b/config.mk
@@ -37,6 +37,9 @@ ROCM_INTERFACE = false#NO SPACE
 # Build experimental sysfeatures interface and Lua CLI application
 BUILD_SYSFEATURES = false#NO SPACE
 
+# Build container helper
+CONTAINER_HELPER = true#NO SPACE
+
 #################################################################
 #################################################################
 # Advanced configuration options                                #
@@ -86,6 +89,10 @@ INSTALLED_FREQDAEMON = $(INSTALLED_SBINPREFIX)/likwid-setFreq#NO SPACE
 BUILDAPPDAEMON=true
 APPDAEMON = $(PREFIX)/lib/likwid-appDaemon.so#NO SPACE
 INSTALLED_APPDAEMON = $(INSTALLED_PREFIX)/lib/likwid-appDaemon.so#NO SPACE
+
+# Build the container helper.
+TMP_CONTAINER_HELPER = $(PREFIX)/sbin/likwid-bridge
+INSTALLED_CONTAINER_HELPER = $(INSTALLED_PREFIX)/sbin/likwid-bridge
 
 # chown installed tools to this user/group
 # if you change anything here, make sure that the user/group can access

--- a/make/config_defines.mk
+++ b/make/config_defines.mk
@@ -302,6 +302,10 @@ DEFINES += -DLIKWID_WITH_ROCMON -D__HIP_PLATFORM_HCC__
 BUILDAPPDAEMON = true
 endif
 
+ifeq ($(CONTAINER_HELPER),true)
+	C_APPS += likwid-bridge
+	CONTAINER_HELPER_TARGET = likwid-bridge
+endif
 ifeq ($(strip $(BUILDDAEMON)),true)
 ifneq ($(strip $(COMPILER)),MIC)
     DAEMON_TARGET = likwid-accessD

--- a/src/access_client.c
+++ b/src/access_client.c
@@ -185,8 +185,7 @@ access_client_startDaemon_direct(int cpu_id, struct sockaddr_un *address)
 }
 
 static int
-access_client_startDaemon_bridge(int cpu_id, const char *bridge_pid_str, struct sockaddr_un *daemon_address) {
-    int bridge_pid;
+access_client_startDaemon_bridge(int cpu_id, const char *bridge_path, struct sockaddr_un *daemon_address) {
     struct sockaddr_un bridge_address;
     int socket_fd = -1;
     int address_length;
@@ -197,10 +196,8 @@ access_client_startDaemon_bridge(int cpu_id, const char *bridge_pid_str, struct 
     long io_count;
     int daemon_pid;
 
-    bridge_pid = atoi(bridge_pid_str);
-
     bridge_address.sun_family = AF_LOCAL;
-    snprintf(bridge_address.sun_path, sizeof(bridge_address.sun_path), "/tmp/likwid-bridge-%d", bridge_pid);
+    snprintf(bridge_address.sun_path, sizeof(bridge_address.sun_path), "%s", bridge_path);
 
     socket_fd = socket(AF_LOCAL, SOCK_STREAM, 0);
     if (socket_fd < 0)
@@ -342,17 +339,17 @@ access_client_daemon_connect(int cpu_id, struct sockaddr_un *address) {
 
 static int
 access_client_startDaemon(int cpu_id) {
-    const char *likwid_bridge_pid_val;
+    const char *bridge_path;
     struct sockaddr_un address;
     int daemon_ret_code;
     int socket_fd;
 
-    likwid_bridge_pid_val = getenv("LIKWID_BRIDGE_PID");
+    bridge_path = getenv("LIKWID_BRIDGE_PATH");
 
-    if (!likwid_bridge_pid_val) {
+    if (!bridge_path) {
         daemon_ret_code = access_client_startDaemon_direct(cpu_id, &address);
     } else {
-        daemon_ret_code = access_client_startDaemon_bridge(cpu_id, likwid_bridge_pid_val, &address);
+        daemon_ret_code = access_client_startDaemon_bridge(cpu_id, bridge_path, &address);
     }
 
     if (daemon_ret_code < 0) {

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -1,0 +1,128 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+[[noreturn]] void access_daemon_main() {
+    char *argv[1] = {NULL};
+    int ret = execvp("likwid-accessD", argv);
+    if (ret < 0) {
+        printf("Failed to start likwid-accessD daemon\n", ret);
+    }
+    exit(ret);
+}
+
+int create_access_daemon() {
+    int pid = fork();
+    if (pid == 0) access_daemon_main();
+    else return pid;
+}
+
+int create_bridge_socket(int id) {
+    struct sockaddr_un sock_addr;
+
+    sock_addr.sun_family = AF_LOCAL;
+    snprintf(sock_addr.sun_path, sizeof(sock_addr.sun_path), "/tmp/likwid-bridge-%d", id);
+
+    int socket_fd = socket(AF_LOCAL, SOCK_STREAM, 0);
+    if (socket_fd < 0) {
+        printf("Failed to start the bridge socket\n");
+        return -1;
+    }
+
+    int ret = bind(socket_fd, (const struct sockaddr *) &sock_addr, sizeof(sock_addr));
+    if (ret < 0) {
+        printf("Failed to bind() to the bridge socket\n");
+        return -1;
+    }
+
+    ret = listen(socket_fd, 128);
+    if (ret < 0) {
+        printf("Failed to listen() on the bridge socket\n");
+        return -1;
+    }
+
+    return socket_fd;
+}
+
+[[noreturn]] void bridge_daemon_main(int socket_fd) {
+    int io_buf;
+    while (1) {
+        int conn_fd = accept(socket_fd, NULL, NULL);
+
+        if (conn_fd < 0) {
+            printf("Failed to accept a bridge connection\n");
+            exit(-1);
+        }
+
+        long io_count = recv(conn_fd, (char *) &io_buf, sizeof(io_buf), 0);
+        if (io_count != sizeof(io_buf)) {
+            printf("Failed to recv from the bridge socket\n");
+            exit(-1);
+        }
+
+        switch (io_buf) {
+            case 1: {
+                int daemon_pid = create_access_daemon();
+
+                io_buf = daemon_pid;
+                io_count = send(conn_fd, (char *) &io_buf, sizeof(io_buf), 0);
+                if (io_count != sizeof(io_buf)) {
+                    printf("Failed to send from the bridge socket\n");
+                    close(conn_fd);
+                    close(socket_fd);
+                    exit(-1);
+                }
+
+                break;
+            }
+            default: {
+                printf("Unknown bridge command: %d. Ignoring.\n", io_buf);
+                close(conn_fd);
+                break;
+            }
+        }
+    }
+}
+
+int create_bridge_daemon(int id) {
+    int socket_fd = create_bridge_socket(id);
+    if (socket_fd < 0) return socket_fd;
+
+    int pid = fork();
+    if (pid == 0) {
+        bridge_daemon_main(socket_fd);
+    } else return pid;
+}
+
+int main(int argc, char *const *argv) {
+    int id = getpid();
+    int bridge_pid = create_bridge_daemon(id);
+    if (bridge_pid < 0) return bridge_pid;
+
+    char env_var[128];
+    snprintf(env_var, sizeof(env_var), "LIKWID_BRIDGE_PATH=/tmp/likwid-bridge-%d", id);
+    char *envp[2] = {env_var, NULL};
+
+    int child_pid = fork();
+    if (child_pid == 0) {
+        if (argc == 1) {
+            char *child_argv[2] = {"-i", NULL};
+            int ret = execve("/bin/bash", child_argv, envp);
+            if (ret < 0) printf("Failed to invoke bash\n");
+        } else {
+            const char *child_path = argv[1];
+            char *const *child_argv = argv + 1;
+            int ret = execvpe(child_path, child_argv, envp);
+            if (ret < 0) printf("Failed to invoke %s\n", child_path);
+        }
+    } else {
+        waitpid(child_pid, NULL, 0);
+    }
+
+    kill(bridge_pid, SIGKILL);
+}

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -1,4 +1,6 @@
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -7,7 +9,14 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-[[noreturn]] void access_daemon_main() {
+#ifdef __GNUC__
+#define NORETURN_ATTR  __attribute__((noreturn))
+#endif
+#ifdef __GNUG__
+#define NORETURN_ATTR  [[noreturn]]
+#endif
+
+NORETURN_ATTR void access_daemon_main() {
     char *argv[1] = {NULL};
     int ret = execvp("likwid-accessD", argv);
     if (ret < 0) {
@@ -49,7 +58,7 @@ int create_bridge_socket(int id) {
     return socket_fd;
 }
 
-[[noreturn]] void bridge_daemon_main(int socket_fd) {
+NORETURN_ATTR void bridge_daemon_main(int socket_fd) {
     int io_buf;
     while (1) {
         int conn_fd = accept(socket_fd, NULL, NULL);


### PR DESCRIPTION
Hi,

### Introduction

Most HPC systems grant only a basic set of permissions (i.e. no sudo, no CAP_SYS_ADMIN). This means that only non-sudo container technologies are ready available to the end users. 

Using likwid in unprivileged containers like Apptainer can be problematic. The `perf_event` method does work provided that the `per_event_paranoid` setting is low enough, but the data is often limited (the clusters I've tested had all `perf_event_paranoid=2`). Setuid binaries don't get any additional privileges when executed inside an unprivileged container, so spawning access daemons inside the container isn't an option either.

### Idea

This PR demonstrates how we can utilise the power of the access daemon installed on the host machine inside Apptainer. The general idea is to have a process on the host that listens for requests from within Apptainer, spawns the access daemon processes on the host, and communicates back the paths of the newly spawned access deamons, so that likwid can use them from within Apptainer.

This is possible because the /tmp filesystem is shared between host and Apptainer, and so any socket-based communication over /tmp mounted sockets works as expected.

### Implementation

This PR consists of two changes, a new cmd utility that I call `likwid-bridge` in `src/bridge/bridge.c`, and a change to the `src/access_client.c` file.

The new cmd utility listens on the host side and spawns access daemons on demand. It should be invoked as follows:

`> likwid-bridge apptainer exec mycontainer.sif likwid-perfctr args...`

The bridge binary acts as a wrapper - it starts listening for requests, and executes whatever arguments we give it in a child process. When the child process finishes, it stops listening for new requests, cleans up, and exits.

When `likwid-bridge` starts listening for requests, it exposes a new environment variable `LIKWID_BRIDGE_PATH` which is then used by `likwid-perfctr` to decide how to spawn the access daemons (either directly via `execve()` or via the bridge). All the necessary changes to likwid-perfctr are confined in the `src/access_client.c` file.

### Code state

The changes to the `src/access_client.c` mimic the style of the file. I think minor changes may be required.

The new file `src/bridge/bridge.c` is at the moment a completely standalone file. It does not use many parts of the project that it perhaps should be (i.e. logging). Furthermore, it's not hooked into the project build system. I expect that if you are willing to incorporate these changes, some potentially major work will be needed to make this new utility a first-class citizen of this project.

### Summary

This PR introduces changes that allow me to use likwid inside Apptainer. If you're interested in incorporating them in, I'm willing to put in the effort to make the changes that are needed to achieve this.  
