### PR TITLE
Add support for ARM Cortex A76 reusing Neon N1 counters and events

### DIFF
--- a/src/includes/perfmon_neon1_counters.h
+++ b/src/includes/perfmon_neon1_counters.h
@@ -48,3 +48,7 @@ static char* neon1_translate_types[NUM_UNITS] = {
     [PMC] = "/sys/bus/event_source/devices/armv8_pmuv3_0",
 };
 
+static char* a76_translate_types[NUM_UNITS] = {
+    [PMC] = "/sys/bus/event_source/devices/armv8_cortex_a76",
+};
+

--- a/src/includes/topology.h
+++ b/src/includes/topology.h
@@ -164,6 +164,7 @@ struct topology_functions {
 #define  ARM_CORTEX_A57     0xD07U
 #define  ARM_CORTEX_A72     0xD08U
 #define  ARM_CORTEX_A73     0xD09U
+#define  ARM_CORTEX_A76     0xD0BU
 #define  CAV_THUNDERX	0x0A0U
 #define  CAV_THUNDERX88	0x0A1U
 #define  CAV_THUNDERX81	0x0A2U

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -1402,12 +1402,17 @@ perfmon_init_maps(void)
                             translate_types = a53_translate_types;
                             break;
                         case ARM_NEOVERSE_N1:
+                        case ARM_CORTEX_A76:
                             eventHash = neon1_arch_events;
                             perfmon_numArchEvents = perfmon_numArchEventsNeoN1;
                             counter_map = neon1_counter_map;
                             box_map = neon1_box_map;
                             perfmon_numCounters = perfmon_numCountersNeoN1;
                             translate_types = neon1_translate_types;
+                            if (access(translate_types[PMC], F_OK) != 0)
+                            {
+                                translate_types = a76_translate_types;
+                            }
                             break;
                         case AWS_GRAVITON3:
                             eventHash = graviton3_arch_events;

--- a/src/topology.c
+++ b/src/topology.c
@@ -124,6 +124,7 @@ static char* arm_cortex_a57 = "ARM Cortex A57";
 static char* arm_cortex_a53 = "ARM Cortex A53";
 static char* arm_cortex_a72 = "ARM Cortex A72";
 static char* arm_cortex_a73 = "ARM Cortex A73";
+static char* arm_cortex_a76 = "ARM Cortex A76";
 static char* arm_neoverse_n1 = "ARM Neoverse N1";
 static char* arm_neoverse_v1 = "ARM Neoverse V1";
 static char* arm_huawei_tsv110 = "Huawei TSV110 (ARMv8)";
@@ -1201,6 +1202,10 @@ topology_setName(void)
                             cpuid_info.name = arm_cortex_a73;
                             cpuid_info.short_name = short_arm8;
                             break;
+                        case ARM_CORTEX_A76:
+                            cpuid_info.name = arm_cortex_a76;
+                            cpuid_info.short_name = short_arm8;
+                            break;
                         case ARM_NEOVERSE_N1:
                             cpuid_info.name = arm_neoverse_n1;
                             cpuid_info.short_name = short_arm8_neo_n1;
@@ -1690,6 +1695,7 @@ print_supportedCPUs (void)
     printf("Supported ARMv8 processors:\n");
     printf("\t%s\n",arm_cortex_a53);
     printf("\t%s\n",arm_cortex_a57);
+    printf("\t%s\n",arm_cortex_a76);
     printf("\t%s\n",cavium_thunderx_str);
     printf("\t%s\n",cavium_thunderx2t99_str);
     printf("\t%s\n",fujitsu_a64fx);


### PR DESCRIPTION
Since I am currently trying to use Likwid on a Raspberry Pi 5 which features an ARM Cortex A76 that is not supported yet, I added the topology definitions to `topology.h` and `topology.c` and also the counter + event definitions. Since they look to be identical, I reused the Neon 1 counter and event setup like was done for the Cortex A72 which uses the Cortex A57 definitions.