### PR TITLE
Fix RAPL DRAM energy unit for Sapphire Rapids (SPR)

### DIFF
--- a/src/power.c
+++ b/src/power.c
@@ -404,7 +404,6 @@ power_init(int cpuId)
                 (cpuid_info.model == SKYLAKEX) ||
                 (cpuid_info.model == ICELAKEX1) ||
                 (cpuid_info.model == ICELAKEX2) ||
-                (cpuid_info.model == SAPPHIRERAPIDS) ||
                 (cpuid_info.model == XEON_PHI_KNL) ||
                 (cpuid_info.model == XEON_PHI_KML)))
             {

--- a/src/sysFeatures_intel_rapl.c
+++ b/src/sysFeatures_intel_rapl.c
@@ -502,7 +502,6 @@ static int dram_test_testFunc(uint64_t msrData, void *)
             (info->model == SKYLAKEX) ||
             (info->model == ICELAKEX1) ||
             (info->model == ICELAKEX2) ||
-            (info->model == SAPPHIRERAPIDS) ||
             (info->model == XEON_PHI_KNL) ||
             (info->model == XEON_PHI_KML))
         {


### PR DESCRIPTION
Hi @TomTheBear,

this PR directly addresses the issue reported in #642. Although the implemented changes are really minor, I tested it on our system and the reported numbers are indeed ~4 times higher (new 61 uJ / old 15,3 uJ = 3,9869281).

Greetings

Christian
