### PR TITLE
Add stream_sp_mem kernel

### DIFF
--- a/bench/x86-64/stream_sp_mem.ptt
+++ b/bench/x86-64/stream_sp_mem.ptt
@@ -1,0 +1,44 @@
+STREAMS 3
+TYPE SINGLE
+FLOPS 2
+BYTES 12
+DESC Single-precision stream triad A(i) = B(i)*c + C(i), uses scalar arithmetic and SSE non-temporal stores
+LOADS 2
+STORES 1
+INSTR_CONST 17
+INSTR_LOOP 35
+UOPS 44
+movss FPR9, [rip+SCALAR]
+LOOP 8
+movss    FPR1, [STR1 + GPR1*4]
+movss    FPR2, [STR1 + GPR1*4+4]
+movss    FPR3, [STR1 + GPR1*4+8]
+movss    FPR4, [STR1 + GPR1*4+12]
+movss    FPR5, [STR1 + GPR1*4+16]
+movss    FPR6, [STR1 + GPR1*4+20]
+movss    FPR7, [STR1 + GPR1*4+24]
+movss    FPR8, [STR1 + GPR1*4+28]
+mulss    FPR1, FPR9
+addss    FPR1, [STR2 + GPR1*4]
+mulss    FPR2, FPR9
+addss    FPR2, [STR2 + GPR1*4+4]
+mulss    FPR3, FPR9
+addss    FPR3, [STR2 + GPR1*4+8]
+mulss    FPR4, FPR9
+addss    FPR4, [STR2 + GPR1*4+12]
+mulss    FPR5, FPR9
+addss    FPR5, [STR2 + GPR1*4+16]
+mulss    FPR6, FPR9
+addss    FPR6, [STR2 + GPR1*4+20]
+mulss    FPR7, FPR9
+addss    FPR7, [STR2 + GPR1*4+24]
+mulss    FPR8, FPR9
+addss    FPR8, [STR2 + GPR1*4+28]
+unpcklps FPR1,FPR3
+unpcklps FPR2,FPR4
+unpcklps FPR5,FPR7
+unpcklps FPR6,FPR8
+unpcklps FPR1,FPR2
+unpcklps FPR5,FPR6
+movntps  [STR0 + GPR1*4], FPR1
+movntps  [STR0 + GPR1*4+16], FPR5


### PR DESCRIPTION
This PR adds stream_sp_mem kernel. The kernel is based on stream_sp kernel, the only difference is that movss store instructions were replaced by a combination of:
- unpcklps instructions that unpack scalar values from FPR1-FPR4 into FPR1 and values from FPR5-FPR8 into FPR5
- movntps instructions that store values from FPR1 and FPR5 into memory

Please verify the number of UOPS, as I'm not 100% sure about this.