### PR TITLE
likwid-bench: Add base 2 stream size parameter units, Add 64bit numbers for stream size parameter, Fix testcase parameter segfault

### DIFF
--- a/bench/likwid-bench.c
+++ b/bench/likwid-bench.c
@@ -355,6 +355,7 @@ int main(int argc, char** argv)
                     }
                 }
                 bdestroy(testcase);
+                testcase = bfromcstr("none");
                 if (!builtin)
                 {
                     dynbench_close(test, NULL);
@@ -410,6 +411,7 @@ int main(int argc, char** argv)
                     return EXIT_FAILURE;
                 }
                 bdestroy(testcase);
+                testcase = bfromcstr("none");
                 break;
             case 'o':
             case 'f':

--- a/bench/likwid-bench.c
+++ b/bench/likwid-bench.c
@@ -78,7 +78,7 @@ extern void* getIterSingle(void* arg);
     printf("-t/--test <TEST>\t type of test \n"); \
     printf("-w/--workgroup\t\t <thread_domain>:<size>[:<num_threads>[:<chunk size>:<stride>]-<streamId>:<domain_id>[:<offset>]\n"); \
     printf("-W/--Workgroup\t\t <thread_domain>:<size>[:<num_threads>[:<chunk size>:<stride>]]\n"); \
-    printf("\t\t\t\t <size> in kB, MB or GB (mandatory)\n"); \
+    printf("\t\t\t\t <size> in B, kB, MB, GB, kiB, MiB or GiB (mandatory)\n"); \
     printf("For dynamically loaded benchmarks\n"); \
     printf("-f/--tempdir <PATH>\t Specify a folder for the temporary files. default: /tmp\n"); \
     printf("-o/--asmout <FILE>\t Save generated assembly to file\n"); \

--- a/bench/src/strUtil.c
+++ b/bench/src/strUtil.c
@@ -101,10 +101,13 @@ bstr_to_doubleSize(const_bstring str, DataType type)
     int ret;
     bstring unit = bmidstr(str, blength(str)-2, 2);
     bstring single_unit = bmidstr(str, blength(str)-1, 1);
+    bstring triple_unit = bmidstr(str, blength(str)-3, 3);
     bstring sizeStr = bmidstr(str, 0, blength(str)-2);
     bstring single_sizeStr = bmidstr(str, 0, blength(str)-1);
+    bstring triple_sizeStr = bmidstr(str, 0, blength(str)-3);
     uint64_t sizeU = 0;
     uint64_t single_sizeU = 0;
+    uint64_t triple_sizeU = 0;
     uint64_t junk = 0;
     uint64_t bytesize = 0;
     if (blength(sizeStr) == 0)
@@ -117,6 +120,11 @@ bstr_to_doubleSize(const_bstring str, DataType type)
         return 0;
     }
     ret = str2uint64_t(bdata(single_sizeStr), &single_sizeU);
+    if (ret < 0)
+    {
+        return 0;
+    }
+    ret = str2uint64_t(bdata(triple_sizeStr), &triple_sizeU);
     if (ret < 0)
     {
         return 0;
@@ -136,14 +144,28 @@ bstr_to_doubleSize(const_bstring str, DataType type)
     {
         junk = (sizeU *1000000000)/bytesize;
     }
+    else if ((biseqcstr(triple_unit, "kiB"))||(biseqcstr(triple_unit, "KiB")))
+    {
+        junk = (triple_sizeU *1024)/bytesize;
+    }
+    else if (biseqcstr(triple_unit, "MiB"))
+    {
+        junk = (triple_sizeU *1024*1024)/bytesize;
+    }
+    else if (biseqcstr(triple_unit, "GiB"))
+    {
+        junk = (triple_sizeU *1024*1024*1024)/bytesize;
+    }
     else if (biseqcstr(single_unit, "B"))
     {
         junk = (single_sizeU)/bytesize;
     }
     bdestroy(unit);
     bdestroy(single_unit);
+    bdestroy(triple_unit);
     bdestroy(sizeStr);
     bdestroy(single_sizeStr);
+    bdestroy(triple_sizeStr);
     return junk;
 }
 

--- a/doc/likwid-bench.1
+++ b/doc/likwid-bench.1
@@ -71,7 +71,7 @@ Filepath for the dynamic generation of benchmarks. Default /tmp/. <PID> is alway
 .SH WORKGROUP SYNTAX
 
 .B <thread_domain>:<size> [:<num_threads>[:<chunk_size>:<stride>]] [-<streamId>:<domain_id>]
-with size in kB, MB or GB. The
+with size in B, kB, MB, GB, kiB, MiB or GiB. The
 .B <thread_domain>
 defines where the threads are placed.
 .B <size>


### PR DESCRIPTION
 Regarding the following issues:

* #655 
* #656

Also fix a segfault for the testcase parameter.