### PR TITLE
Remove/rework print macros

### DIFF
--- a/src/access-daemon/accessDaemon.c
+++ b/src/access-daemon/accessDaemon.c
@@ -2642,7 +2642,7 @@ kill_client(void)
 {
     if (connfd != -1)
     {
-        CHECK_ERROR(close(connfd), socket close failed);
+        CHECK_ERROR(close(connfd), "socket close failed");
     }
 
     connfd = -1;
@@ -2655,7 +2655,7 @@ stop_daemon(void)
 
     if (sockfd != -1)
     {
-        CHECK_ERROR(close(sockfd), socket close sockfd failed);
+        CHECK_ERROR(close(sockfd), "socket close sockfd failed");
     }
 
     free(filepath);
@@ -3819,7 +3819,7 @@ int main(void)
     /* Change the file mode mask so only the calling user has access
      * and switch the user/gid with which the following socket creation runs. */
     oldumask = umask(077);
-    CHECK_ERROR(setfsuid(getuid()), setfsuid failed);
+    CHECK_ERROR(setfsuid(getuid()), "setfsuid failed");
 
     /* bind and listen on socket */
     LOG_AND_EXIT_IF_ERROR(bind(sockfd, (SA*) &addr1, sizeof(addr1)), bind failed);
@@ -3851,16 +3851,16 @@ int main(void)
         {
             syslog(LOG_ERR, "accept() failed:  %s", strerror(errno));
         }
-        CHECK_ERROR(unlink(filepath), unlink of socket failed);
+        CHECK_ERROR(unlink(filepath), "unlink of socket failed");
         exit(EXIT_FAILURE);
     }
 
     alarm(0);
-    CHECK_ERROR(unlink(filepath), unlink of socket failed);
+    CHECK_ERROR(unlink(filepath), "unlink of socket failed");
 
     /* Restore the old umask and fs ids. */
     (void) umask(oldumask);
-    CHECK_ERROR(setfsuid(geteuid()), setfsuid failed);
+    CHECK_ERROR(setfsuid(geteuid()), "setfsuid failed");
 
     {
         char* msr_file_name = (char*) malloc(MAX_PATH_LENGTH * sizeof(char));

--- a/src/access-daemon/appDaemon.c
+++ b/src/access-daemon/appDaemon.c
@@ -164,7 +164,7 @@ static int appdaemon_setup_nvmon(char* gpuStr, char* eventStr)
     ret = parse_gpustr(gpuStr, &nvmon_numgpus, &nvmon_gpulist);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to get nvmon gpulist from '%s', gpuStr);
+        ERROR_PRINT("Failed to get nvmon gpulist from '%s'", gpuStr);
         goto appdaemon_setup_nvmon_cleanup;
     }
 
@@ -175,7 +175,7 @@ static int appdaemon_setup_nvmon(char* gpuStr, char* eventStr)
     nvmon_gids = malloc(nvmon_eventlist->qty * sizeof(int));
     if (!nvmon_gids)
     {
-        ERROR_PRINT(Failed to allocate space for nvmon group IDs);
+        ERROR_PRINT("Failed to allocate space for nvmon group IDs");
         goto appdaemon_setup_nvmon_cleanup;
     }
 
@@ -183,7 +183,7 @@ static int appdaemon_setup_nvmon(char* gpuStr, char* eventStr)
     ret = nvmon_init(nvmon_numgpus, nvmon_gpulist);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to initialize nvmon);
+        ERROR_PRINT("Failed to initialize nvmon");
         goto appdaemon_setup_nvmon_cleanup;
     }
     nvmon_initialized = 1;
@@ -194,14 +194,14 @@ static int appdaemon_setup_nvmon(char* gpuStr, char* eventStr)
         ret = nvmon_addEventSet(bdata(nvmon_eventlist->entry[i]));
         if (ret < 0)
         {
-            ERROR_PRINT(Failed to add nvmon group: %s, bdata(nvmon_eventlist->entry[i]));
+            ERROR_PRINT("Failed to add nvmon group: %s", bdata(nvmon_eventlist->entry[i]));
             continue;
         }
         nvmon_gids[nvmon_numgids++] = ret;
     }
     if (nvmon_numgids == 0)
     {
-        ERROR_PRINT(Failed to add any events to nvmon);
+        ERROR_PRINT("Failed to add any events to nvmon");
         goto appdaemon_setup_nvmon_cleanup;
     }
 
@@ -209,7 +209,7 @@ static int appdaemon_setup_nvmon(char* gpuStr, char* eventStr)
     ret = nvmon_setupCounters(nvmon_gids[0]);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to setup nvmon);
+        ERROR_PRINT("Failed to setup nvmon");
         goto appdaemon_setup_nvmon_cleanup;
     }
 
@@ -217,7 +217,7 @@ static int appdaemon_setup_nvmon(char* gpuStr, char* eventStr)
     ret = nvmon_startCounters();
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to start nvmon);
+        ERROR_PRINT("Failed to start nvmon");
         goto appdaemon_setup_nvmon_cleanup;
     }
     return 0;
@@ -253,7 +253,7 @@ static void appdaemon_close_nvmon(void)
     int ret = nvmon_stopCounters();
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to stop nvmon);
+        ERROR_PRINT("Failed to stop nvmon");
     }
 
     // Print results
@@ -335,7 +335,7 @@ static int appdaemon_setup_rocmon(char* gpuStr, char* eventStr)
     ret = parse_gpustr(gpuStr, &rocmon_numgpus, &rocmon_gpulist);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to get rocmon gpulist from '%s', gpuStr);
+        ERROR_PRINT("Failed to get rocmon gpulist from '%s'", gpuStr);
         goto appdaemon_setup_rocmon_cleanup;
     }
 
@@ -346,7 +346,7 @@ static int appdaemon_setup_rocmon(char* gpuStr, char* eventStr)
     rocmon_gids = malloc(rocmon_eventlist->qty * sizeof(int));
     if (!rocmon_gids)
     {
-        ERROR_PRINT(Failed to allocate space for rocmon group IDs);
+        ERROR_PRINT("Failed to allocate space for rocmon group IDs");
         goto appdaemon_setup_rocmon_cleanup;
     }
 
@@ -354,7 +354,7 @@ static int appdaemon_setup_rocmon(char* gpuStr, char* eventStr)
     ret = rocmon_init(rocmon_numgpus, rocmon_gpulist);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to initialize rocmon);
+        ERROR_PRINT("Failed to initialize rocmon");
         goto appdaemon_setup_rocmon_cleanup;
     }
     rocmon_initialized = 1;
@@ -365,12 +365,12 @@ static int appdaemon_setup_rocmon(char* gpuStr, char* eventStr)
         ret = rocmon_addEventSet(bdata(rocmon_eventlist->entry[i]), &rocmon_gids[rocmon_numgids++]);
         if (ret < 0)
         {
-            ERROR_PRINT(Failed to add rocmon group: %s, bdata(rocmon_eventlist->entry[i]));
+            ERROR_PRINT("Failed to add rocmon group: %s", bdata(rocmon_eventlist->entry[i]));
         }
     }
     if (rocmon_numgids == 0)
     {
-        ERROR_PRINT(Failed to add any events to rocmon);
+        ERROR_PRINT("Failed to add any events to rocmon");
         goto appdaemon_setup_rocmon_cleanup;
     }
 
@@ -378,7 +378,7 @@ static int appdaemon_setup_rocmon(char* gpuStr, char* eventStr)
     ret = rocmon_setupCounters(rocmon_gids[0]);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to setup rocmon);
+        ERROR_PRINT("Failed to setup rocmon");
         goto appdaemon_setup_rocmon_cleanup;
     }
 
@@ -386,7 +386,7 @@ static int appdaemon_setup_rocmon(char* gpuStr, char* eventStr)
     ret = rocmon_startCounters();
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to start rocmon);
+        ERROR_PRINT("Failed to start rocmon");
         goto appdaemon_setup_rocmon_cleanup;
     }
     return 0;
@@ -422,7 +422,7 @@ static void appdaemon_close_rocmon(void)
     int ret = rocmon_stopCounters();
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to stop rocmon);
+        ERROR_PRINT("Failed to stop rocmon");
     }
 
     // Print results

--- a/src/access.c
+++ b/src/access.c
@@ -110,7 +110,7 @@ HPMinit(void)
         }
         if (config->daemonMode == ACCESSMODE_DAEMON)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for x86 architecture in daemon mode");
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for x86 architecture in daemon mode");
             access_init = &access_client_init;
             access_read = &access_client_read;
             access_write = &access_client_write;
@@ -119,7 +119,7 @@ HPMinit(void)
         }
         else if (config->daemonMode == ACCESSMODE_DIRECT)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for x86 architecture in direct mode");
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for x86 architecture in direct mode");
             access_init = &access_x86_init;
             access_read = &access_x86_read;
             access_write = &access_x86_write;
@@ -128,7 +128,7 @@ HPMinit(void)
         }
         else
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "HPMinit called in perf_event mode");
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "HPMinit called in perf_event mode");
         }
 #endif
     }

--- a/src/access.c
+++ b/src/access.c
@@ -84,14 +84,14 @@ HPMinit(void)
     if (ret < 0)
     {
         errno = -ret;
-        ERROR_PRINT(Failed to initialize topology);
+        ERROR_PRINT("Failed to initialize topology");
         return ret;
     }
     ret = init_configuration();
     if (ret < 0)
     {
         errno = -ret;
-        ERROR_PRINT(Failed to initialize configuration);
+        ERROR_PRINT("Failed to initialize configuration");
         return ret;
     }
     config = get_configuration();
@@ -110,7 +110,7 @@ HPMinit(void)
         }
         if (config->daemonMode == ACCESSMODE_DAEMON)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, Adjusting functions for x86 architecture in daemon mode);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for x86 architecture in daemon mode");
             access_init = &access_client_init;
             access_read = &access_client_read;
             access_write = &access_client_write;
@@ -119,7 +119,7 @@ HPMinit(void)
         }
         else if (config->daemonMode == ACCESSMODE_DIRECT)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, Adjusting functions for x86 architecture in direct mode);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for x86 architecture in direct mode");
             access_init = &access_x86_init;
             access_read = &access_x86_read;
             access_write = &access_x86_write;
@@ -128,7 +128,7 @@ HPMinit(void)
         }
         else
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, HPMinit called in perf_event mode);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "HPMinit called in perf_event mode");
         }
 #endif
     }
@@ -159,7 +159,7 @@ HPMaddThread(int cpu_id)
             ret = access_init(cpu_id);
             if (ret == 0)
             {
-                DEBUG_PRINT(DEBUGLEV_DETAIL, Adding CPU %d to access module, cpu_id);
+                DEBUG_PRINT(DEBUGLEV_DETAIL, "Adding CPU %d to access module", cpu_id);
                 registeredCpus++;
                 registeredCpuList[cpu_id] = 1;
             }
@@ -186,7 +186,7 @@ HPMfinalize(void)
         {
             if (registeredCpuList[i] == 1)
             {
-                DEBUG_PRINT(DEBUGLEV_DETAIL, Removing CPU %d from access module, i);
+                DEBUG_PRINT(DEBUGLEV_DETAIL, "Removing CPU %d from access module", i);
                 access_finalize(i);
                 registeredCpus--;
                 registeredCpuList[i] = 0;
@@ -242,7 +242,7 @@ HPMwrite(int cpu_id, PciDeviceIndex dev, uint32_t reg, uint64_t data)
     }
     if ((cpu_id < 0) || (cpu_id >= cpuid_topology.numHWThreads))
     {
-        ERROR_PRINT(MSR WRITE C %d OUT OF RANGE, cpu_id);
+        ERROR_PRINT("MSR WRITE C %d OUT OF RANGE", cpu_id);
         return -ERANGE;
     }
     if (registeredCpuList[cpu_id] == 0)

--- a/src/access_client.c
+++ b/src/access_client.c
@@ -144,10 +144,10 @@ access_client_startDaemon_direct(int cpu_id, struct sockaddr_un *address)
 
     if (access(exeprog, X_OK))
     {
-        ERROR_PRINT(Failed to find the daemon '%s'\n, exeprog);
+        ERROR_PRINT("Failed to find the daemon '%s'\n", exeprog);
         return -1;
     }
-    DEBUG_PRINT(DEBUGLEV_INFO, Starting daemon %s, exeprog);
+    DEBUG_PRINT(DEBUGLEV_INFO, "Starting daemon %s", exeprog);
     pid = fork();
 
     if (pid == 0)
@@ -166,13 +166,13 @@ access_client_startDaemon_direct(int cpu_id, struct sockaddr_un *address)
         if (ret < 0)
         {
             //ERRNO_PRINT;
-            ERROR_PRINT(Failed to execute the daemon '%s'\n, exeprog);
+            ERROR_PRINT("Failed to execute the daemon '%s'\n", exeprog);
             return ret;
         }
     }
     else if (pid < 0)
     {
-        ERROR_PRINT(Failed to fork access daemon for CPU %d, cpu_id);
+        ERROR_PRINT("Failed to fork access daemon for CPU %d", cpu_id);
         return pid;
     }
 
@@ -202,13 +202,13 @@ access_client_startDaemon_bridge(int cpu_id, const char *bridge_path, struct soc
     socket_fd = socket(AF_LOCAL, SOCK_STREAM, 0);
     if (socket_fd < 0)
     {
-        ERROR_PRINT(socket() failed);
+        ERROR_PRINT("socket() failed");
         return -1;
     }
 
     address_length = sizeof(struct sockaddr_un);
     filepath = strdup(bridge_address.sun_path);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Waiting for bridge socket file %s, bridge_address.sun_path);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Waiting for bridge socket file %s", bridge_address.sun_path);
     while (access(bridge_address.sun_path, F_OK) && timeout > 0)
     {
         usleep(2500);
@@ -216,7 +216,7 @@ access_client_startDaemon_bridge(int cpu_id, const char *bridge_path, struct soc
     }
     if (!access(bridge_address.sun_path, F_OK))
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Bridge socket file %s exists, bridge_address.sun_path);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Bridge socket file %s exists", bridge_address.sun_path);
     }
     timeout = 1000;
 
@@ -232,7 +232,7 @@ access_client_startDaemon_bridge(int cpu_id, const char *bridge_path, struct soc
         }
 
         timeout--;
-        DEBUG_PRINT(DEBUGLEV_INFO, Still waiting for bridge socket %s for CPU %d..., filepath, cpu_id);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Still waiting for bridge socket %s for CPU %d...", filepath, cpu_id);
     }
 
     if (timeout <= 0)
@@ -247,7 +247,7 @@ access_client_startDaemon_bridge(int cpu_id, const char *bridge_path, struct soc
         close(socket_fd);
         return -1;
     }
-    DEBUG_PRINT(DEBUGLEV_INFO, Successfully opened bridge socket %s to daemon for CPU %d, filepath, cpu_id);
+    DEBUG_PRINT(DEBUGLEV_INFO, "Successfully opened bridge socket %s to daemon for CPU %d", filepath, cpu_id);
     free(filepath);
 
     // request socket creation via the connected bridge
@@ -255,7 +255,7 @@ access_client_startDaemon_bridge(int cpu_id, const char *bridge_path, struct soc
     io_count = send(socket_fd, (char*) &io_buf, sizeof(io_buf), 0);
 
     if (io_count != sizeof(io_buf)) {
-        ERROR_PRINT(Failed to send msg to the bridge socket)
+        ERROR_PRINT("Failed to send msg to the bridge socket");
         close(socket_fd);
         return -1;
     }
@@ -263,7 +263,7 @@ access_client_startDaemon_bridge(int cpu_id, const char *bridge_path, struct soc
     io_count = recv(socket_fd, (char*) &io_buf, sizeof(io_buf), 0);
 
     if (io_count != sizeof(io_buf)) {
-        ERROR_PRINT(Failed to recv msg from the bridge socket)
+        ERROR_PRINT("Failed to recv msg from the bridge socket");
         close(socket_fd);
         return -1;
     }
@@ -288,13 +288,13 @@ access_client_daemon_connect(int cpu_id, struct sockaddr_un *address) {
     socket_fd = socket(AF_LOCAL, SOCK_STREAM, 0);
     if (socket_fd < 0)
     {
-        ERROR_PRINT(socket() failed);
+        ERROR_PRINT("socket() failed");
         return -1;
     }
 
     address_length = sizeof(struct sockaddr_un);
     filepath = strdup(address->sun_path);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Waiting for socket file %s, address->sun_path);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Waiting for socket file %s", address->sun_path);
     while (access(address->sun_path, F_OK) && timeout > 0)
     {
         usleep(2500);
@@ -302,7 +302,7 @@ access_client_daemon_connect(int cpu_id, struct sockaddr_un *address) {
     }
     if (!access(address->sun_path, F_OK))
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Socket file %s exists, address->sun_path);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Socket file %s exists", address->sun_path);
     }
     timeout = 1000;
 
@@ -318,7 +318,7 @@ access_client_daemon_connect(int cpu_id, struct sockaddr_un *address) {
         }
 
         timeout--;
-        DEBUG_PRINT(DEBUGLEV_INFO, Still waiting for socket %s for CPU %d..., filepath, cpu_id);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Still waiting for socket %s for CPU %d...", filepath, cpu_id);
     }
 
     if (timeout <= 0)
@@ -332,7 +332,7 @@ access_client_daemon_connect(int cpu_id, struct sockaddr_un *address) {
         close(socket_fd);
         return -1;
     }
-    DEBUG_PRINT(DEBUGLEV_INFO, Successfully opened socket %s to daemon for CPU %d, filepath, cpu_id);
+    DEBUG_PRINT(DEBUGLEV_INFO, "Successfully opened socket %s to daemon for CPU %d", filepath, cpu_id);
     free(filepath);
     return socket_fd;
 }
@@ -401,7 +401,7 @@ access_client_init(int cpu_id)
         cpuSockets[cpu_id] = access_client_startDaemon(cpu_id);
         if (cpuSockets[cpu_id] < 0)
         {
-            //ERROR_PRINT(Start of access daemon failed for CPU %d, cpu_id);
+            //ERROR_PRINT("Start of access daemon failed for CPU %d", cpu_id);
             pthread_mutex_unlock(&cpuLocks[cpu_id]);
             return cpuSockets[cpu_id];
         }
@@ -446,7 +446,7 @@ access_client_read(PciDeviceIndex dev, const int cpu_id, uint32_t reg, uint64_t 
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             CPU_SET(cpu_id, &cpuset);
-            DEBUG_PRINT(DEBUGLEV_INFO, Pinning daemon %d to CPU %d, daemon_pids[cpu_id], cpu_id);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Pinning daemon %d to CPU %d", daemon_pids[cpu_id], cpu_id);
             sched_setaffinity(daemon_pids[cpu_id], sizeof(cpu_set_t), &cpuset);
             daemon_pinned[cpu_id] = 1;
         }
@@ -458,7 +458,7 @@ access_client_read(PciDeviceIndex dev, const int cpu_id, uint32_t reg, uint64_t 
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
         CPU_SET(cpu_id, &cpuset);
-        DEBUG_PRINT(DEBUGLEV_INFO, Pinning master daemon %d to CPU %d, daemon_pids[cpu_id], cpu_id);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Pinning master daemon %d to CPU %d", daemon_pids[cpu_id], cpu_id);
         sched_setaffinity(daemon_pids[cpu_id], sizeof(cpu_set_t), &cpuset);
         daemon_pinned[cpu_id] = 1;
     }
@@ -487,8 +487,8 @@ access_client_read(PciDeviceIndex dev, const int cpu_id, uint32_t reg, uint64_t 
         record.type = DAEMON_READ;
 
         pthread_mutex_lock(lockptr);
-        CHECK_ERROR(write(socket, &record, sizeof(AccessDataRecord)), socket write failed);
-        CHECK_ERROR(read(socket, &record, sizeof(AccessDataRecord)), socket read failed);
+        CHECK_ERROR(write(socket, &record, sizeof(AccessDataRecord)), "socket write failed");
+        CHECK_ERROR(read(socket, &record, sizeof(AccessDataRecord)), "socket read failed");
         *data = record.data;
         pthread_mutex_unlock(lockptr);
 
@@ -496,12 +496,12 @@ access_client_read(PciDeviceIndex dev, const int cpu_id, uint32_t reg, uint64_t 
         {
             if (dev == MSR_DEV)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Got error '%s' from access daemon reading reg 0x%X at CPU %d,
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Got error '%s' from access daemon reading reg 0x%X at CPU %d",
                             access_client_strerror(record.errorcode), reg, record.cpu);
             }
             else
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Got error '%s' from access daemon reading reg 0x%X on socket %d,
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Got error '%s' from access daemon reading reg 0x%X on socket %d",
                             access_client_strerror(record.errorcode), reg, record.cpu);
             }
             *data = 0;
@@ -543,7 +543,7 @@ access_client_write(PciDeviceIndex dev, const int cpu_id, uint32_t reg, uint64_t
             cpu_set_t cpuset;
             CPU_ZERO(&cpuset);
             CPU_SET(cpu_id, &cpuset);
-            DEBUG_PRINT(DEBUGLEV_INFO, Pinning daemon %d to CPU %d, daemon_pids[cpu_id], cpu_id);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Pinning daemon %d to CPU %d", daemon_pids[cpu_id], cpu_id);
             sched_setaffinity(daemon_pids[cpu_id], sizeof(cpu_set_t), &cpuset);
             daemon_pinned[cpu_id] = 1;
         }
@@ -555,7 +555,7 @@ access_client_write(PciDeviceIndex dev, const int cpu_id, uint32_t reg, uint64_t
         cpu_set_t cpuset;
         CPU_ZERO(&cpuset);
         CPU_SET(cpu_id, &cpuset);
-        DEBUG_PRINT(DEBUGLEV_INFO, Pinning master daemon %d to CPU %d, daemon_pids[cpu_id], cpu_id);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Pinning master daemon %d to CPU %d", daemon_pids[cpu_id], cpu_id);
         sched_setaffinity(daemon_pids[cpu_id], sizeof(cpu_set_t), &cpuset);
         daemon_pinned[cpu_id] = 1;
     }
@@ -578,20 +578,20 @@ access_client_write(PciDeviceIndex dev, const int cpu_id, uint32_t reg, uint64_t
         record.type = DAEMON_WRITE;
 
         pthread_mutex_lock(lockptr);
-        CHECK_ERROR(write(socket, &record, sizeof(AccessDataRecord)), socket write failed);
-        CHECK_ERROR(read(socket, &record, sizeof(AccessDataRecord)), socket read failed);
+        CHECK_ERROR(write(socket, &record, sizeof(AccessDataRecord)), "socket write failed");
+        CHECK_ERROR(read(socket, &record, sizeof(AccessDataRecord)), "socket read failed");
         pthread_mutex_unlock(lockptr);
 
         if (record.errorcode != ERR_NOERROR)
         {
             if (dev == MSR_DEV)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Got error '%s' from access daemon writing reg 0x%X at CPU %d,
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Got error '%s' from access daemon writing reg 0x%X at CPU %d",
                             access_client_strerror(record.errorcode), reg, record.cpu);
             }
             else
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Got error '%s' from access daemon writing reg 0x%X on socket %d,
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Got error '%s' from access daemon writing reg 0x%X on socket %d",
                             access_client_strerror(record.errorcode), reg, record.cpu);
             }
             return access_client_errno(record.errorcode);
@@ -613,12 +613,12 @@ access_client_finalize(int cpu_id)
         memset(&record, 0, sizeof(AccessDataRecord));
         record.type = DAEMON_EXIT;
         record.cpu = cpu_id;
-        CHECK_ERROR(write(cpuSockets[cpu_id], &record, sizeof(AccessDataRecord)),socket write failed);
+        CHECK_ERROR(write(cpuSockets[cpu_id], &record, sizeof(AccessDataRecord)), "socket write failed");
         if (cpuSockets[cpu_id] == globalSocket)
         {
             globalSocket = -1;
         }
-        CHECK_ERROR(close(cpuSockets[cpu_id]),socket close failed);
+        CHECK_ERROR(close(cpuSockets[cpu_id]), "socket close failed");
         cpuSockets[cpu_id] = -1;
         if (daemon_pids[cpu_id] != 0)
         {
@@ -664,8 +664,8 @@ access_client_check(PciDeviceIndex dev, int cpu_id)
     if ((cpuSockets[cpu_id] > 0) || ((cpuSockets_open == 1) && (globalSocket > 0)))
     {
         pthread_mutex_lock(lockptr);
-        CHECK_ERROR(write(socket, &record, sizeof(AccessDataRecord)), socket write failed);
-        CHECK_ERROR(read(socket, &record, sizeof(AccessDataRecord)), socket read failed);
+        CHECK_ERROR(write(socket, &record, sizeof(AccessDataRecord)), "socket write failed");
+        CHECK_ERROR(read(socket, &record, sizeof(AccessDataRecord)), "socket read failed");
         pthread_mutex_unlock(lockptr);
         if (record.errorcode == ERR_NOERROR )
         {
@@ -675,12 +675,12 @@ access_client_check(PciDeviceIndex dev, int cpu_id)
         {
             if (dev == MSR_DEV)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Device check for dev %d on CPU %d with accessDaemon failed,
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Device check for dev %d on CPU %d with accessDaemon failed",
                             dev, record.cpu, access_client_strerror(record.errorcode));
             }
             else
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Device check for dev %d on socket %d with accessDaemon failed,
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Device check for dev %d on socket %d with accessDaemon failed",
                             dev, record.cpu, access_client_strerror(record.errorcode));
             }
         }

--- a/src/access_x86.c
+++ b/src/access_x86.c
@@ -71,7 +71,7 @@ access_x86_init(int cpu_id)
                 ret = access_x86_mmio_init(affinity_thread2socket_lookup[cpu_id]);
                 if (ret < 0)
                 {
-                    ERROR_PRINT(Initialization of MMIO access failed);
+                    ERROR_PRINT("Initialization of MMIO access failed");
                 }
             }
             else if (ARCH_SPR_GNR_SRF)
@@ -197,12 +197,12 @@ access_x86_finalize(int cpu_id)
         }
         if (cpuid_info.family == P6_FAMILY && ((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2)))
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Finalize of MMIO access);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Finalize of MMIO access");
             access_x86_mmio_finalize(affinity_thread2socket_lookup[cpu_id]);
         }
         else if (ARCH_SPR_GNR_SRF)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Finalize of Fake access);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Finalize of Fake access");
             access_x86_translate_finalize(cpu_id);
         }
     }

--- a/src/access_x86_clientmem.c
+++ b/src/access_x86_clientmem.c
@@ -84,20 +84,20 @@ clientmem_getStartAddr(uint64_t* startAddr)
     int pcihandle = open("/proc/bus/pci/00/00.0", O_RDONLY);
     if (pcihandle < 0)
     {
-        ERROR_PLAIN_PRINT("Cannot get start address: failed to open /proc/bus/pci/00/00.0");
+        ERROR_PRINT("Cannot get start address: failed to open /proc/bus/pci/00/00.0");
         return -1;
     }
 
     ssize_t ret = pread(pcihandle, &imcbar, sizeof(uint64_t), PCM_CLIENT_IMC_BAR_OFFSET);
     if (ret < 0)
     {
-        ERROR_PLAIN_PRINT("Cannot get start address: mmap failed");
+        ERROR_PRINT("Cannot get start address: mmap failed");
         close(pcihandle);
         return -1;
     }
     if (!imcbar)
     {
-        ERROR_PLAIN_PRINT("Cannot get start address: imcbar is zero");
+        ERROR_PRINT("Cannot get start address: imcbar is zero");
         close(pcihandle);
         return -1;
     }
@@ -121,14 +121,14 @@ access_x86_clientmem_init(const int socket)
         int ret = clientmem_getStartAddr(&startAddr);
         if (ret < 0)
         {
-            ERROR_PLAIN_PRINT("Failed to get clientmem start address");
+            ERROR_PRINT("Failed to get clientmem start address");
             return -1;
         }
         
         clientmem_handle = open("/dev/mem", O_RDONLY);
         if (clientmem_handle < 0)
         {
-            ERROR_PLAIN_PRINT("Unable to open /dev/mem for clientmem");
+            ERROR_PRINT("Unable to open /dev/mem for clientmem");
             return -1;
         }
 
@@ -136,7 +136,7 @@ access_x86_clientmem_init(const int socket)
         if (clientmem_addr == MAP_FAILED)
         {
             close(clientmem_handle);
-            ERROR_PLAIN_PRINT("Mapping of clientmem device failed");
+            ERROR_PRINT("Mapping of clientmem device failed");
             clientmem_addr = NULL;
             return -1;
         }

--- a/src/access_x86_clientmem.c
+++ b/src/access_x86_clientmem.c
@@ -84,20 +84,20 @@ clientmem_getStartAddr(uint64_t* startAddr)
     int pcihandle = open("/proc/bus/pci/00/00.0", O_RDONLY);
     if (pcihandle < 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get start address: failed to open /proc/bus/pci/00/00.0);
+        ERROR_PLAIN_PRINT("Cannot get start address: failed to open /proc/bus/pci/00/00.0");
         return -1;
     }
 
     ssize_t ret = pread(pcihandle, &imcbar, sizeof(uint64_t), PCM_CLIENT_IMC_BAR_OFFSET);
     if (ret < 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get start address: mmap failed);
+        ERROR_PLAIN_PRINT("Cannot get start address: mmap failed");
         close(pcihandle);
         return -1;
     }
     if (!imcbar)
     {
-        ERROR_PLAIN_PRINT(Cannot get start address: imcbar is zero);
+        ERROR_PLAIN_PRINT("Cannot get start address: imcbar is zero");
         close(pcihandle);
         return -1;
     }
@@ -121,14 +121,14 @@ access_x86_clientmem_init(const int socket)
         int ret = clientmem_getStartAddr(&startAddr);
         if (ret < 0)
         {
-            ERROR_PLAIN_PRINT(Failed to get clientmem start address);
+            ERROR_PLAIN_PRINT("Failed to get clientmem start address");
             return -1;
         }
         
         clientmem_handle = open("/dev/mem", O_RDONLY);
         if (clientmem_handle < 0)
         {
-            ERROR_PLAIN_PRINT(Unable to open /dev/mem for clientmem);
+            ERROR_PLAIN_PRINT("Unable to open /dev/mem for clientmem");
             return -1;
         }
 
@@ -136,7 +136,7 @@ access_x86_clientmem_init(const int socket)
         if (clientmem_addr == MAP_FAILED)
         {
             close(clientmem_handle);
-            ERROR_PLAIN_PRINT(Mapping of clientmem device failed);
+            ERROR_PLAIN_PRINT("Mapping of clientmem device failed");
             clientmem_addr = NULL;
             return -1;
         }
@@ -195,7 +195,7 @@ access_x86_clientmem_read(PciDeviceIndex dev, const int socket, uint32_t reg, ui
             d = d & 0xFF;
             break;
         default:
-            ERROR_PRINT(Read from clientmem device at reg 0x%X failed, reg);
+            ERROR_PRINT("Read from clientmem device at reg 0x%X failed", reg);
             break;
     }
     *data = d;

--- a/src/access_x86_mmio.c
+++ b/src/access_x86_mmio.c
@@ -173,7 +173,7 @@ static int mmio_validDevice(uint32_t pci_bus, uint32_t deviceId)
     FILE* fd = fopen(bdata(bdevfile), "r");
     if (fd < 0)
     {
-        ERROR_PRINT(Cannot get device id: failed to open %s, bdata(bdevfile));
+        ERROR_PRINT("Cannot get device id: failed to open %s", bdata(bdevfile));
         bdestroy(bdevfile);
         return 0;
     }
@@ -181,7 +181,7 @@ static int mmio_validDevice(uint32_t pci_bus, uint32_t deviceId)
     int ret = fread(buf, sizeof(char), 20, fd);
     if (ret < 0)
     {
-        ERROR_PRINT(Cannot get device id: failed to read %s, bdata(bdevfile));
+        ERROR_PRINT("Cannot get device id: failed to read %s", bdata(bdevfile));
         fclose(fd);
         bdestroy(bdevfile);
         return 0;
@@ -190,7 +190,7 @@ static int mmio_validDevice(uint32_t pci_bus, uint32_t deviceId)
     pci_dev = strtoul(buf, NULL, 16);
     if (pci_dev != deviceId)
     {
-        ERROR_PRINT(Cannot get device id: device ids do not match 0x%X and 0x%X, pci_dev, deviceId);
+        ERROR_PRINT("Cannot get device id: device ids do not match 0x%X and 0x%X", pci_dev, deviceId);
         fclose(fd);
         bdestroy(bdevfile);
         return 0;
@@ -219,34 +219,34 @@ mmio_fillBox(MMIOConfig* config, uint32_t pci_bus, int imc_idx, MMIOBoxHandle* h
     int pcihandle = open(bdata(bdevmem), O_RDONLY);
     if (pcihandle < 0)
     {
-        ERROR_PRINT(Cannot get start address: failed to open %s, bdata(bdevmem));
+        ERROR_PRINT("Cannot get start address: failed to open %s", bdata(bdevmem));
         bdestroy(bdevmem);
         return -1;
     }
     int ret = pread(pcihandle, &tmp, sizeof(uint32_t), config->base_offset);
     if (ret < 0 || ret != sizeof(uint32_t))
     {
-        ERROR_PRINT(Cannot get start address: read failed);
+        ERROR_PRINT("Cannot get start address: read failed");
         close(pcihandle);
         bdestroy(bdevmem);
         return -1;
     }
     if (!tmp)
     {
-        ERROR_PRINT(Cannot get address: MMIO base is zero);
+        ERROR_PRINT("Cannot get address: MMIO base is zero");
         close(pcihandle);
         bdestroy(bdevmem);
         return -1;
     }
     addr = (tmp & config->base_mask) << config->base_shift;
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d BASE 0x%lX = (0x%lX & 0x%lX) << %d, imc_idx, addr, tmp, config->base_mask, config->base_shift);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d BASE 0x%lX = (0x%lX & 0x%lX) << %d", imc_idx, addr, tmp, config->base_mask, config->base_shift);
     tmp = 0;
     mem_offset = config->device_offset + (imc_idx / config->channel_count) * config->device_stride;
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d offset 0x%X, imc_idx, mem_offset);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d offset 0x%X", imc_idx, mem_offset);
     ret = pread(pcihandle, &tmp, sizeof(uint32_t), mem_offset);
     if (ret < 0)
     {
-        ERROR_PRINT(Cannot get start address of device: read failed);
+        ERROR_PRINT("Cannot get start address of device: read failed");
         close(pcihandle);
         bdestroy(bdevmem);
         return -1;
@@ -254,28 +254,28 @@ mmio_fillBox(MMIOConfig* config, uint32_t pci_bus, int imc_idx, MMIOBoxHandle* h
     addr |= (tmp & config->device_mask) << config->device_shift;
     addr += config->channel_offset + config->channel_stride * (imc_idx % config->channel_count);
 
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d IMC_OFF 0x%lX (0x%lX & 0x%lX) << %d, imc_idx, addr, tmp, config->device_mask, config->device_shift);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d IMC_OFF 0x%lX (0x%lX & 0x%lX) << %d", imc_idx, addr, tmp, config->device_mask, config->device_shift);
     close(pcihandle);
 
     pcihandle = open("/dev/mem", O_RDWR);
     if (pcihandle < 0)
     {
-        ERROR_PRINT(Cannot get mmap address: failed to open /dev/mem);
+        ERROR_PRINT("Cannot get mmap address: failed to open /dev/mem");
         bdestroy(bdevmem);
         return -1;
     }
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d MMAP 0x%llX, imc_idx, addr);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d MMAP 0x%llX", imc_idx, addr);
 
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, MMap size 0x%x addr %lld (0x%llX), ICX_IMC_MMIO_SIZE, addr & (~(4096 - 1)), addr & (~(4096 - 1)));
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "MMap size 0x%x addr %lld (0x%llX)", ICX_IMC_MMIO_SIZE, addr & (~(4096 - 1)), addr & (~(4096 - 1)));
     void* maddr = mmap(NULL, config->channel_count*ICX_IMC_MMIO_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, pcihandle, addr & (~(4096 - 1)));
     if (maddr == MAP_FAILED)
     {
-        ERROR_PRINT(Cannot get start address of device: mmap failed);
+        ERROR_PRINT("Cannot get start address of device: mmap failed");
         bdestroy(bdevmem);
         close(pcihandle);
         return -1;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d MMAP %p ADDR %lX, imc_idx, maddr, addr);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d MMAP %p ADDR %lX", imc_idx, maddr, addr);
     handle->mmap_addr = maddr;
     handle->addr = addr;
     handle->fd = pcihandle;
@@ -306,34 +306,34 @@ mmio_fillFreerunBox(MMIOConfig* config, uint32_t pci_bus, int imc_idx, MMIOBoxHa
     int pcihandle = open(bdata(bdevmem), O_RDONLY);
     if (pcihandle < 0)
     {
-        ERROR_PRINT(Cannot get start address: failed to open %s, bdata(bdevmem));
+        ERROR_PRINT("Cannot get start address: failed to open %s", bdata(bdevmem));
         bdestroy(bdevmem);
         return -1;
     }
     int ret = pread(pcihandle, &tmp, sizeof(uint32_t), config->base_offset);
     if (ret < 0 || ret != sizeof(uint32_t))
     {
-        ERROR_PRINT(Cannot get start address: read failed);
+        ERROR_PRINT("Cannot get start address: read failed");
         close(pcihandle);
         bdestroy(bdevmem);
         return -1;
     }
     if (!tmp)
     {
-        ERROR_PRINT(Cannot get address: MMIO base is zero);
+        ERROR_PRINT("Cannot get address: MMIO base is zero");
         close(pcihandle);
         bdestroy(bdevmem);
         return -1;
     }
     addr = (tmp & config->base_mask) << config->base_shift;
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d BASE 0x%lX = (0x%lX & 0x%lX) << %d, imc_idx, addr, tmp, config->base_mask, config->base_shift);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d BASE 0x%lX = (0x%lX & 0x%lX) << %d", imc_idx, addr, tmp, config->base_mask, config->base_shift);
     tmp = 0;
     mem_offset = config->device_offset + imc_idx * config->device_stride;
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d offset 0x%X, imc_idx, mem_offset);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d offset 0x%X", imc_idx, mem_offset);
     ret = pread(pcihandle, &tmp, sizeof(uint32_t), mem_offset);
     if (ret < 0)
     {
-        ERROR_PRINT(Cannot get start address of device: read failed);
+        ERROR_PRINT("Cannot get start address of device: read failed");
         close(pcihandle);
         bdestroy(bdevmem);
         return -1;
@@ -341,29 +341,29 @@ mmio_fillFreerunBox(MMIOConfig* config, uint32_t pci_bus, int imc_idx, MMIOBoxHa
     addr |= (tmp & config->device_mask) << config->device_shift;
     addr += config->freerun_offset;
 
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d IMC_OFF 0x%lX (0x%lX & 0x%lX) << %d, imc_idx, addr, tmp, config->device_mask, config->device_shift);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d IMC_OFF 0x%lX (0x%lX & 0x%lX) << %d", imc_idx, addr, tmp, config->device_mask, config->device_shift);
 
     close(pcihandle);
 
     pcihandle = open("/dev/mem", O_RDWR);
     if (pcihandle < 0)
     {
-        ERROR_PRINT(Cannot get mmap address: failed to open /dev/mem);
+        ERROR_PRINT("Cannot get mmap address: failed to open /dev/mem");
         bdestroy(bdevmem);
         return -1;
     }
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d MMAP 0x%llX, imc_idx, addr);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d MMAP 0x%llX", imc_idx, addr);
 
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, MMap size 0x%x addr %lld (0x%llX), ICX_IMC_MMIO_SIZE, addr & (~(4096 - 1)), addr & (~(4096 - 1)));
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "MMap size 0x%x addr %lld (0x%llX)", ICX_IMC_MMIO_SIZE, addr & (~(4096 - 1)), addr & (~(4096 - 1)));
     void* maddr = mmap(NULL, config->channel_count*ICX_IMC_MMIO_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, pcihandle, addr & (~(4096 - 1)));
     if (maddr == MAP_FAILED)
     {
-        ERROR_PRINT(Cannot get start address of device: mmap failed);
+        ERROR_PRINT("Cannot get start address of device: mmap failed");
         bdestroy(bdevmem);
         close(pcihandle);
         return -1;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, IMC %d MMAP %p ADDR %lX, imc_idx, maddr, addr);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "IMC %d MMAP %p ADDR %lX", imc_idx, maddr, addr);
     handle->mmap_addr = maddr;
     handle->addr = addr;
     handle->fd = pcihandle;
@@ -405,11 +405,11 @@ access_x86_mmio_init(const int socket)
 
     if (!access_mmio_initialized[socket])
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, access_x86_mmio_init for socket %d, socket);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "access_x86_mmio_init for socket %d", socket);
         topology_init();
         if (cpuid_info.family != P6_FAMILY)
         {
-            ERROR_PRINT(MMIO only supported for Intel platforms);
+            ERROR_PRINT("MMIO only supported for Intel platforms");
             return -1;
         }
         switch(cpuid_info.model)
@@ -429,7 +429,7 @@ access_x86_mmio_init(const int socket)
             mmio_sockets = malloc(num_mmio_sockets * sizeof(MMIOSocketBoxes));
             if (!mmio_sockets)
             {
-                ERROR_PRINT(Failed to malloc space for socket);
+                ERROR_PRINT("Failed to malloc space for socket");
                 num_mmio_sockets = 0;
                 mmio_config = NULL;
                 return -1;
@@ -452,7 +452,7 @@ access_x86_mmio_init(const int socket)
             sbox->boxes = malloc(num_devs * sizeof(MMIOBoxHandle));
             if (!sbox->boxes)
             {
-                ERROR_PRINT(Failed to malloc space for socket boxes);
+                ERROR_PRINT("Failed to malloc space for socket boxes");
                 num_mmio_sockets = 0;
                 free(mmio_sockets);
                 mmio_sockets = NULL;
@@ -469,7 +469,7 @@ access_x86_mmio_init(const int socket)
             sbox->freerun = malloc(num_devs * sizeof(MMIOBoxHandle));
             if (!sbox->freerun)
             {
-                ERROR_PRINT(Failed to malloc space for freerun boxes);
+                ERROR_PRINT("Failed to malloc space for freerun boxes");
                 free(sbox->boxes);
                 sbox->boxes = 0;
                 sbox->num_boxes = 0;
@@ -654,7 +654,7 @@ access_x86_mmio_read(PciDeviceIndex dev, const int socket, uint32_t reg, uint64_
         {
             d = (uint64_t)(*((uint32_t *)(box->mmap_addr + box->reg_offset + reg)));
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Read MMIO counter 0x%X Dev %d on socket %d: 0x%lX, reg, imc_idx, socket, d);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read MMIO counter 0x%X Dev %d on socket %d: 0x%lX", reg, imc_idx, socket, d);
         *data = d;
         return 0;
     }
@@ -713,7 +713,7 @@ access_x86_mmio_write(PciDeviceIndex dev, const int socket, uint32_t reg, uint64
         MMIOBoxHandle* box = &sbox->boxes[imc_idx];
         if (box)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Write MMIO counter 0x%X Dev %d on socket %d: 0x%lX, reg, imc_idx, socket, data);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Write MMIO counter 0x%X Dev %d on socket %d: 0x%lX", reg, imc_idx, socket, data);
             if (width == 64)
             {
                 *((uint64_t *)(box->mmap_addr + box->reg_offset + reg)) = data;
@@ -758,7 +758,7 @@ access_x86_mmio_check(PciDeviceIndex dev, int socket)
         imc_idx = (dev - MMIO_IMC_DEVICE_0_FREERUN);
         box = &sbox->freerun[imc_idx];
     }
-    //DEBUG_PRINT(DEBUGLEV_DEVELOP, MMIO device check dev %d box %d socket %d, dev, imc_idx, socket);
+    //DEBUG_PRINT(DEBUGLEV_DEVELOP, "MMIO device check dev %d box %d socket %d", dev, imc_idx, socket);
 
     if (box && box->mmap_addr)
     {

--- a/src/access_x86_msr.c
+++ b/src/access_x86_msr.c
@@ -122,9 +122,9 @@ access_x86_msr_init(const int cpu_id)
     fd = open(msr_file_name, O_RDWR);
     if (fd < 0)
     {
-        ERROR_PRINT(Cannot access MSR device file %s: %s.,msr_file_name , strerror(errno))
-        ERROR_PLAIN_PRINT(Please check if 'msr' module is loaded and device files have correct permissions);
-        ERROR_PLAIN_PRINT(Alternatively you might want to look into (sys)daemonmode);
+        ERROR_PRINT("Cannot access MSR device file %s: %s.", msr_file_name , strerror(errno));
+        ERROR_PLAIN_PRINT("Please check if 'msr' module is loaded and device files have correct permissions");
+        ERROR_PLAIN_PRINT("Alternatively you might want to look into (sys)daemonmode");
         free(msr_file_name);
         return -EPERM;
     }
@@ -135,12 +135,12 @@ access_x86_msr_init(const int cpu_id)
     // if (rdpmc_works_pmc < 0)
     // {
     //     rdpmc_works_pmc = test_rdpmc(cpu_id, 0, 0);
-    //     DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for PMC counters returned %d, rdpmc_works_pmc);
+    //     DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for PMC counters returned %d", rdpmc_works_pmc);
     // }
     // if (rdpmc_works_fixed < 0)
     // {
     //     rdpmc_works_fixed = test_rdpmc(cpu_id, (1<<30), 0);
-    //     DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for FIXED counters returned %d, rdpmc_works_fixed);
+    //     DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for FIXED counters returned %d", rdpmc_works_fixed);
     // }
     access_x86_rdpmc_init(cpu_id);
 
@@ -166,11 +166,11 @@ access_x86_msr_init(const int cpu_id)
     FD[cpu_id] = open(msr_file_name, O_RDWR);
     if ( FD[cpu_id] < 0 )
     {
-        ERROR_PRINT(Cannot access MSR device file %s in direct mode, msr_file_name);
+        ERROR_PRINT("Cannot access MSR device file %s in direct mode", msr_file_name);
         free(msr_file_name);
         return -EPERM;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Opened MSR device %s for CPU %d,msr_file_name, cpu_id);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Opened MSR device %s for CPU %d", msr_file_name, cpu_id);
     free(msr_file_name);
 
     return 0;
@@ -183,7 +183,7 @@ access_x86_msr_finalize(const int cpu_id)
     access_x86_rdpmc_finalize(cpu_id);
     if (FD && FD[cpu_id] > 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Closing FD for CPU %d, cpu_id);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Closing FD for CPU %d", cpu_id);
         close(FD[cpu_id]);
         FD[cpu_id] = -1;
     }
@@ -194,7 +194,7 @@ access_x86_msr_finalize(const int cpu_id)
     }
     if (c == 0 && FD)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Free FD space);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Free FD space");
         memset(FD, -1, cpuid_topology.numHWThreads * sizeof(int));
         free(FD);
         FD = NULL;
@@ -210,7 +210,7 @@ access_x86_msr_read( const int cpu_id, uint32_t reg, uint64_t *data)
     ret = access_x86_rdpmc_read(cpu_id, reg, data);
     if (ret == -EAGAIN && FD[cpu_id] > 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Read MSR counter 0x%X with RDMSR instruction on CPU %d, reg, cpu_id);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read MSR counter 0x%X with RDMSR instruction on CPU %d", reg, cpu_id);
         ret = pread(FD[cpu_id], data, sizeof(*data), reg);
         if ( ret != sizeof(*data) )
         {
@@ -219,7 +219,7 @@ access_x86_msr_read( const int cpu_id, uint32_t reg, uint64_t *data)
     }
 //     if ((rdpmc_works_pmc == 1) && (reg >= MSR_PMC0) && (reg <=MSR_PMC7))
 //     {
-//         DEBUG_PRINT(DEBUGLEV_DEVELOP, Read PMC counter with RDPMC instruction with index %d, reg - MSR_PMC0);
+//         DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read PMC counter with RDPMC instruction with index %d", reg - MSR_PMC0);
 //         if (__rdpmc(cpu_id, reg - MSR_PMC0, data) )
 //         {
 //             rdpmc_works_pmc = 0;
@@ -240,7 +240,7 @@ access_x86_msr_read( const int cpu_id, uint32_t reg, uint64_t *data)
 // fallback:
 //         if (FD[cpu_id] > 0)
 //         {
-//             DEBUG_PRINT(DEBUGLEV_DEVELOP, Read MSR counter 0x%X with RDMSR instruction on CPU %d, reg, cpu_id);
+//             DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read MSR counter 0x%X with RDMSR instruction on CPU %d", reg, cpu_id);
 //             ret = pread(FD[cpu_id], data, sizeof(*data), reg);
 //             if ( ret != sizeof(*data) )
 //             {
@@ -257,7 +257,7 @@ access_x86_msr_write( const int cpu_id, uint32_t reg, uint64_t data)
     int ret;
     if (FD[cpu_id] > 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Write MSR counter 0x%X with WRMSR instruction on CPU %d data 0x%lX, reg, cpu_id, data);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Write MSR counter 0x%X with WRMSR instruction on CPU %d data 0x%lX", reg, cpu_id, data);
         ret = pwrite(FD[cpu_id], &data, sizeof(data), reg);
         if (ret != sizeof(data))
         {

--- a/src/access_x86_msr.c
+++ b/src/access_x86_msr.c
@@ -123,8 +123,8 @@ access_x86_msr_init(const int cpu_id)
     if (fd < 0)
     {
         ERROR_PRINT("Cannot access MSR device file %s: %s.", msr_file_name , strerror(errno));
-        ERROR_PLAIN_PRINT("Please check if 'msr' module is loaded and device files have correct permissions");
-        ERROR_PLAIN_PRINT("Alternatively you might want to look into (sys)daemonmode");
+        ERROR_PRINT("Please check if 'msr' module is loaded and device files have correct permissions");
+        ERROR_PRINT("Alternatively you might want to look into (sys)daemonmode");
         free(msr_file_name);
         return -EPERM;
     }

--- a/src/access_x86_pci.c
+++ b/src/access_x86_pci.c
@@ -105,7 +105,7 @@ access_x86_pci_init(const int socket)
         /* PCI is only provided by Intel systems */
         if (!cpuid_info.isIntel)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, PCI based Uncore performance monitoring only supported on Intel systems);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, "PCI based Uncore performance monitoring only supported on Intel systems");
             return -ENODEV;
         }
         switch (cpuid_info.model)
@@ -137,7 +137,7 @@ access_x86_pci_init(const int socket)
                 testDevice = 0x344A;
                 break;
             default:
-                DEBUG_PRINT(DEBUGLEV_INFO,CPU model %s does not support PCI based Uncore performance monitoring, cpuid_info.name);
+                DEBUG_PRINT(DEBUGLEV_INFO, "CPU model %s does not support PCI based Uncore performance monitoring", cpuid_info.name);
                 return -ENODEV;
                 break;
         }
@@ -160,20 +160,20 @@ access_x86_pci_init(const int socket)
 
         ret = 1;
 #ifdef LIKWID_USE_HWLOC
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, Using hwloc to find pci devices);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, "Using hwloc to find pci devices");
         ret = hwloc_pci_init(testDevice, socket_bus, &nr_sockets);
         if (ret)
         {
-            ERROR_PLAIN_PRINT(Using hwloc to find pci devices failed);
+            ERROR_PLAIN_PRINT("Using hwloc to find pci devices failed");
         }
 #endif
         if (ret)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, Using procfs to find pci devices);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, "Using procfs to find pci devices");
             ret = proc_pci_init(testDevice, socket_bus, &nr_sockets);
             if (ret)
             {
-                ERROR_PLAIN_PRINT(Using procfs to find pci devices failed);
+                ERROR_PLAIN_PRINT("Using procfs to find pci devices failed");
                 return -ENODEV;
             }
         }
@@ -193,10 +193,10 @@ access_x86_pci_init(const int socket)
                 if (access_x86_initialized == 0)
                 {
                     DEBUG_PRINT(DEBUGLEV_DETAIL,
-                            PCI device %s (%d) online for socket %d at path %s, pci_devices[j].name,j, socket,bdata(filepath));
+                            "PCI device %s (%d) online for socket %d at path %s", pci_devices[j].name,j, socket,bdata(filepath));
                     if (ownaccess(bdata(filepath),R_OK|W_OK))
                     {
-                        ERROR_PRINT(PCI device %s (%d) online for socket %d at path %s but not accessible, pci_devices[j].name,j, socket,bdata(filepath));
+                        ERROR_PRINT("PCI device %s (%d) online for socket %d at path %s but not accessible", pci_devices[j].name,j, socket,bdata(filepath));
                     }
                 }
             }
@@ -254,19 +254,19 @@ access_x86_pci_read(PciDeviceIndex dev, const int socket, uint32_t reg, uint64_t
 
         if ( FD[socket][dev] < 0)
         {
-            ERROR_PRINT(Failed to open PCI device %s at path %s\n,
+            ERROR_PRINT("Failed to open PCI device %s at path %s\n",
                             pci_devices[dev].name,
                             bdata(filepath));
             *data = 0ULL;
             return -EACCES;
         }
-        DEBUG_PRINT(DEBUGLEV_DETAIL, Opened PCI device %s: %s, pci_devices[dev].name, bdata(filepath));
+        DEBUG_PRINT(DEBUGLEV_DETAIL, "Opened PCI device %s: %s", pci_devices[dev].name, bdata(filepath));
     }
 
     if ( FD[socket][dev] > 0 &&
          pread(FD[socket][dev], &tmp, sizeof(tmp), reg) != sizeof(tmp) )
     {
-        ERROR_PRINT(Read from PCI device %s at register 0x%x failed, pci_devices[dev].name, reg);
+        ERROR_PRINT("Read from PCI device %s at register 0x%x failed", pci_devices[dev].name, reg);
         *data = 0ULL;
         return -EIO;
     }
@@ -297,18 +297,18 @@ access_x86_pci_write(PciDeviceIndex dev, const int socket, uint32_t reg, uint64_
 
         if ( FD[socket][dev] < 0)
         {
-            ERROR_PRINT(Failed to open PCI device %s at path %s\n,
+            ERROR_PRINT("Failed to open PCI device %s at path %s\n",
                                 pci_devices[dev].name,
                                 bdata(filepath));
             return -EACCES;
         }
-        DEBUG_PRINT(DEBUGLEV_DETAIL, Opened PCI device %s: %s, pci_devices[dev].name, bdata(filepath));
+        DEBUG_PRINT(DEBUGLEV_DETAIL, "Opened PCI device %s: %s", pci_devices[dev].name, bdata(filepath));
     }
 
     if ( FD[socket][dev] > 0 &&
          pwrite(FD[socket][dev], &tmp, sizeof tmp, reg) != sizeof tmp)
     {
-        ERROR_PRINT(Write to PCI device %s at register 0x%x failed, pci_devices[dev].name, reg);
+        ERROR_PRINT("Write to PCI device %s at register 0x%x failed", pci_devices[dev].name, reg);
         return -EIO;
     }
     return 0;

--- a/src/access_x86_pci.c
+++ b/src/access_x86_pci.c
@@ -105,7 +105,7 @@ access_x86_pci_init(const int socket)
         /* PCI is only provided by Intel systems */
         if (!cpuid_info.isIntel)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, "PCI based Uncore performance monitoring only supported on Intel systems");
+            DEBUG_PRINT(DEBUGLEV_DETAIL, "PCI based Uncore performance monitoring only supported on Intel systems");
             return -ENODEV;
         }
         switch (cpuid_info.model)
@@ -160,20 +160,20 @@ access_x86_pci_init(const int socket)
 
         ret = 1;
 #ifdef LIKWID_USE_HWLOC
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, "Using hwloc to find pci devices");
+        DEBUG_PRINT(DEBUGLEV_DETAIL, "Using hwloc to find pci devices");
         ret = hwloc_pci_init(testDevice, socket_bus, &nr_sockets);
         if (ret)
         {
-            ERROR_PLAIN_PRINT("Using hwloc to find pci devices failed");
+            ERROR_PRINT("Using hwloc to find pci devices failed");
         }
 #endif
         if (ret)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DETAIL, "Using procfs to find pci devices");
+            DEBUG_PRINT(DEBUGLEV_DETAIL, "Using procfs to find pci devices");
             ret = proc_pci_init(testDevice, socket_bus, &nr_sockets);
             if (ret)
             {
-                ERROR_PLAIN_PRINT("Using procfs to find pci devices failed");
+                ERROR_PRINT("Using procfs to find pci devices failed");
                 return -ENODEV;
             }
         }

--- a/src/access_x86_rdpmc.c
+++ b/src/access_x86_rdpmc.c
@@ -158,14 +158,14 @@ access_x86_rdpmc_init(const int cpu_id)
     if (rdpmc_works_pmc < 0)
     {
         rdpmc_works_pmc = test_rdpmc(cpu_id, 0, 0);
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for PMC counters returned %d, rdpmc_works_pmc);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for PMC counters returned %d", rdpmc_works_pmc);
     }
     if (rdpmc_works_fixed_inst < 0 && cpuid_info.isIntel)
     {
         if (eventSupportedCount > 1 && (!(ebx & (1<<1))))
         {
             rdpmc_works_fixed_inst = test_rdpmc(cpu_id, (1<<30), 0);
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for FIXED instruction counter returned %d, rdpmc_works_fixed_inst);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for FIXED instruction counter returned %d", rdpmc_works_fixed_inst);
         }
     }
     if (rdpmc_works_fixed_cyc < 0 && cpuid_info.isIntel)
@@ -173,7 +173,7 @@ access_x86_rdpmc_init(const int cpu_id)
         if (eventSupportedCount > 0 && (!(ebx & (1<<0))))
         {
             rdpmc_works_fixed_cyc = test_rdpmc(cpu_id, (1<<30) + 1, 0);
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for FIXED core cycles counter returned %d, rdpmc_works_fixed_cyc);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for FIXED core cycles counter returned %d", rdpmc_works_fixed_cyc);
         }
     }
     if (rdpmc_works_fixed_ref < 0 && cpuid_info.isIntel)
@@ -181,7 +181,7 @@ access_x86_rdpmc_init(const int cpu_id)
         if (eventSupportedCount > 2 && (!(ebx & (1<<2))))
         {
             rdpmc_works_fixed_ref = test_rdpmc(cpu_id, (1<<30) + 2, 0);
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for FIXED reference cycle counter returned %d, rdpmc_works_fixed_ref);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for FIXED reference cycle counter returned %d", rdpmc_works_fixed_ref);
         }
     }
     if (rdpmc_works_fixed_slots < 0 && cpuid_info.isIntel)
@@ -189,7 +189,7 @@ access_x86_rdpmc_init(const int cpu_id)
         if (eventSupportedCount > 7 && (!(ebx & (1<<7))))
         {
             rdpmc_works_fixed_slots = test_rdpmc(cpu_id, (1<<30) + 3, 0);
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for FIXED slots counter returned %d, rdpmc_works_fixed_slots);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for FIXED slots counter returned %d", rdpmc_works_fixed_slots);
         }
     }
     if (rdpmc_works_llc < 0 && (!cpuid_info.isIntel))
@@ -198,11 +198,11 @@ access_x86_rdpmc_init(const int cpu_id)
         {
             case 0x17:
                 rdpmc_works_llc = test_rdpmc(cpu_id, 0xA, 0);
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for L3 counters returned %d, rdpmc_works_llc);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for L3 counters returned %d", rdpmc_works_llc);
                 break;
             case 0x19:
                 rdpmc_works_llc = test_rdpmc(cpu_id, 0xA, 0);
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for L3 counters returned %d, rdpmc_works_llc);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for L3 counters returned %d", rdpmc_works_llc);
                 break;
             default:
                 break;
@@ -214,11 +214,11 @@ access_x86_rdpmc_init(const int cpu_id)
         {
             case 0x17:
                 rdpmc_works_mem = test_rdpmc(cpu_id, 0x6, 0);
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for DataFabric counters returned %d, rdpmc_works_mem);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for DataFabric counters returned %d", rdpmc_works_mem);
                 break;
             case 0x19:
                 rdpmc_works_mem = test_rdpmc(cpu_id, 0x6, 0);
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Test for RDPMC for DataFabric counters returned %d, rdpmc_works_mem);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test for RDPMC for DataFabric counters returned %d", rdpmc_works_mem);
                 break;
             default:
                 break;
@@ -259,7 +259,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
         case MSR_PMC7:
             if (rdpmc_works_pmc == 1)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read PMC counter with RDPMC instruction with index 0x%X, reg - MSR_PMC0);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read PMC counter with RDPMC instruction with index 0x%X", reg - MSR_PMC0);
                 ret = __rdpmc(cpu_id, reg - MSR_PMC0, data);
                 if (ret)
                 {
@@ -275,7 +275,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
             if (rdpmc_works_pmc == 1 && !cpuid_info.isIntel)
             {
                 int index = (reg - MSR_AMD17_PMC0)/2;
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read PMC counter with RDPMC instruction with index 0x%X, index);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read PMC counter with RDPMC instruction with index 0x%X", index);
                 ret = __rdpmc(cpu_id, index, data);
                 if (ret)
                 {
@@ -291,7 +291,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
             if (rdpmc_works_pmc == 1 && !cpuid_info.isIntel)
             {
                 int index = (reg - MSR_AMD16_PMC0)/2;
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read PMC counter with RDPMC instruction with index 0x%X, index);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read PMC counter with RDPMC instruction with index 0x%X", index);
                 ret = __rdpmc(cpu_id, index, data);
                 if (ret)
                 {
@@ -303,7 +303,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
         case MSR_PERF_FIXED_CTR0:
             if (rdpmc_works_fixed_inst == 1)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read FIXED instruction counter with RDPMC instruction with index 0x%X, (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read FIXED instruction counter with RDPMC instruction with index 0x%X", (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
                 ret = __rdpmc(cpu_id, (1<<30) + (reg - MSR_PERF_FIXED_CTR0), data);
                 if (ret)
                 {
@@ -315,7 +315,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
         case MSR_PERF_FIXED_CTR1:
             if (rdpmc_works_fixed_cyc == 1)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read FIXED core cycle counter with RDPMC instruction with index 0x%X, (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read FIXED core cycle counter with RDPMC instruction with index 0x%X", (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
                 ret = __rdpmc(cpu_id, (1<<30) + (reg - MSR_PERF_FIXED_CTR0), data);
                 if (ret)
                 {
@@ -327,7 +327,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
         case MSR_PERF_FIXED_CTR2:
             if (rdpmc_works_fixed_ref == 1)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read FIXED reference cycle counter with RDPMC instruction with index 0x%X, (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read FIXED reference cycle counter with RDPMC instruction with index 0x%X", (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
                 ret = __rdpmc(cpu_id, (1<<30) + (reg - MSR_PERF_FIXED_CTR0), data);
                 if (ret)
                 {
@@ -339,7 +339,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
         case MSR_PERF_FIXED_CTR3: //Fixed-purpose counter for TOPDOWN_SLOTS is not readable with RDPMC
             if (rdpmc_works_fixed_slots == 1)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read FIXED slots counter with RDPMC instruction with index 0x%X, (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read FIXED slots counter with RDPMC instruction with index 0x%X", (1<<30) + (reg - MSR_PERF_FIXED_CTR0));
                 ret = __rdpmc(cpu_id, (1<<30) + (reg - MSR_PERF_FIXED_CTR0), data);
                 if (ret)
                 {
@@ -358,7 +358,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
             {
                 int index = (reg - MSR_AMD17_L3_PMC0)/2;
 
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read AMD L3 counter with RDPMC instruction with index 0x%X, 0xA + index);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read AMD L3 counter with RDPMC instruction with index 0x%X", 0xA + index);
                 ret = __rdpmc(cpu_id, 0xA + index, data);
                 if (ret)
                 {
@@ -375,7 +375,7 @@ access_x86_rdpmc_read( const int cpu_id, uint32_t reg, uint64_t *data)
             {
                 int index = (reg - MSR_AMD17_2_DF_PMC0)/2;
 
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Read AMD DF counter with RDPMC instruction with index 0x%X, 0x6 + index);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read AMD DF counter with RDPMC instruction with index 0x%X", 0x6 + index);
                 ret = __rdpmc(cpu_id, 0x6 + index, data);
                 if (ret)
                 {

--- a/src/access_x86_translate.c
+++ b/src/access_x86_translate.c
@@ -68,32 +68,32 @@ int access_x86_translate_open_unit(PerfmonDiscoveryUnit* unit)
     if (pcihandle < 0)
     {
         err = errno;
-        ERROR_PRINT(Failed to open /dev/mem);
+        ERROR_PRINT("Failed to open /dev/mem");
         return -err;
     }
     if (unit->access_type == ACCESS_TYPE_MMIO)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Opening /dev/mem at 0x%X, unit->mmap_addr);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Opening /dev/mem at 0x%X", unit->mmap_addr);
         void* io_addr = mmap(NULL, unit->mmap_size, PROT_READ|PROT_WRITE, MAP_SHARED, pcihandle, unit->mmap_addr);
         if (io_addr == MAP_FAILED)
         {
             err = errno;
             close(pcihandle);
-            ERROR_PRINT(Failed to mmap offset 0x%lX (MMIO), unit->box_ctl);
+            ERROR_PRINT("Failed to mmap offset 0x%lX (MMIO)", unit->box_ctl);
             return -err;
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Opening /dev/mem at 0x%X -> 0x%X, unit->mmap_addr, io_addr);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Opening /dev/mem at 0x%X -> 0x%X", unit->mmap_addr, io_addr);
         unit->io_addr = io_addr;
     }
     else if (unit->access_type == ACCESS_TYPE_PCI)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Opening /dev/mem at 0x%X, unit->mmap_addr);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Opening /dev/mem at 0x%X", unit->mmap_addr);
         void* io_addr = mmap(NULL, unit->mmap_size, PROT_READ|PROT_WRITE, MAP_SHARED, pcihandle, unit->mmap_addr );
         if (io_addr == MAP_FAILED)
         {
             err = errno;
             close(pcihandle);
-            ERROR_PRINT(Failed to mmap offset 0x%lX (PCI), unit->box_ctl);
+            ERROR_PRINT("Failed to mmap offset 0x%lX (PCI)", unit->box_ctl);
             return -err;
         }
         unit->io_addr = io_addr;
@@ -143,11 +143,11 @@ access_x86_translate_init(const int cpu_id)
 {
     if (!perfmon_discovery)
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, Running Perfmon Discovery to populate counter lists);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Running Perfmon Discovery to populate counter lists");
         int ret = perfmon_uncore_discovery(cpuid_info.model, &perfmon_discovery);
         if (ret != 0)
         {
-            ERROR_PRINT(Failed to run Perfmon Discovery);
+            ERROR_PRINT("Failed to run Perfmon Discovery");
             return ret;
         }
     }
@@ -181,7 +181,7 @@ access_x86_translate_read(PciDeviceIndex dev, const int cpu_id, uint32_t reg, ui
                 newreg = cur->global.global_ctl + cur->global.status_offset + ((reg - FAKE_UNC_GLOBAL_STATUS0));
             }
             uint64_t tmp = 0x0;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Read Uncore counter 0x%X (%s) on CPU %d (socket %d), newreg, pci_device_names[dev], cpu_id, socket_id);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read Uncore counter 0x%X (%s) on CPU %d (socket %d)", newreg, pci_device_names[dev], cpu_id, socket_id);
             err = access_x86_msr_read(cpu_id, newreg, &tmp);
             if (err == 0)
             {
@@ -200,16 +200,16 @@ access_x86_translate_read(PciDeviceIndex dev, const int cpu_id, uint32_t reg, ui
                 int err = access_x86_translate_open_unit(unit);
                 if (err < 0)
                 {
-                    ERROR_PRINT(Failed to open unit %s, pci_device_names[dev]);
+                    ERROR_PRINT("Failed to open unit %s", pci_device_names[dev]);
                     return -ENODEV;
                 }
             }
             else if (!unit->mmap_addr)
             {
-                ERROR_PRINT(Failed to find unit %s, pci_device_names[dev]);
+                ERROR_PRINT("Failed to find unit %s", pci_device_names[dev]);
                 return -ENODEV;
             }
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Read Uncore counter 0x%X (%s) on CPU %d (socket %d, access %s), reg, pci_device_names[dev], cpu_id, socket_id, AccessTypeNames[unit->access_type]);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Read Uncore counter 0x%X (%s) on CPU %d (socket %d, access %s)", reg, pci_device_names[dev], cpu_id, socket_id, AccessTypeNames[unit->access_type]);
             switch(reg)
             {
                 case FAKE_UNC_UNIT_CTRL:
@@ -278,12 +278,12 @@ access_x86_translate_read(PciDeviceIndex dev, const int cpu_id, uint32_t reg, ui
                             if ((dev >= MMIO_IMC_DEVICE_0_CH_0 && dev <= MMIO_IMC_DEVICE_1_CH_7) ||
                                 (dev >= MMIO_HBM_DEVICE_0 && dev <= MMIO_HBM_DEVICE_31))
                             {
-                                DEBUG_PRINT(DEBUGLEV_DEVELOP, 0x%X + 0x%X + 0x%X + (%d * %d), unit->io_addr, unit->mmap_offset, unit->ctrl_offset, sizeof(uint32_t), offset);
+                                DEBUG_PRINT(DEBUGLEV_DEVELOP, "0x%X + 0x%X + 0x%X + (%d * %d)", unit->io_addr, unit->mmap_offset, unit->ctrl_offset, sizeof(uint32_t), offset);
                                 *data = (uint32_t)*((uint32_t *)(unit->io_addr + unit->mmap_offset + unit->ctrl_offset + (sizeof(uint32_t) * offset)));
                             }
                             else
                             {
-                                DEBUG_PRINT(DEBUGLEV_DEVELOP, 0x%X + 0x%X + 0x%X + (%d * %d), unit->io_addr, unit->mmap_offset, unit->ctrl_offset, reg_offset, offset);
+                                DEBUG_PRINT(DEBUGLEV_DEVELOP, "0x%X + 0x%X + 0x%X + (%d * %d)", unit->io_addr, unit->mmap_offset, unit->ctrl_offset, reg_offset, offset);
                                 *data = (uint64_t)*((uint64_t *)(unit->io_addr + unit->mmap_offset + unit->ctrl_offset + (reg_offset * offset)));
                             }
                             break;
@@ -409,7 +409,7 @@ access_x86_translate_write(PciDeviceIndex dev, const int cpu_id, uint32_t reg, u
             }
             if (newreg != 0x0)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Write Uncore counter 0x%X (%s) on CPU %d (socket %d): 0x%lX, newreg, pci_device_names[dev], cpu_id, socket_id, data);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Write Uncore counter 0x%X (%s) on CPU %d (socket %d): 0x%lX", newreg, pci_device_names[dev], cpu_id, socket_id, data);
                 err = access_x86_msr_write(cpu_id, newreg, data);
             }
         }
@@ -426,16 +426,16 @@ access_x86_translate_write(PciDeviceIndex dev, const int cpu_id, uint32_t reg, u
                 int err = access_x86_translate_open_unit(unit);
                 if (err < 0)
                 {
-                    ERROR_PRINT(Failed to open unit %s, pci_device_names[dev]);
+                    ERROR_PRINT("Failed to open unit %s", pci_device_names[dev]);
                     return -ENODEV;
                 }
             }
             else if (!unit->mmap_addr)
             {
-                ERROR_PRINT(Failed to find unit %s, pci_device_names[dev]);
+                ERROR_PRINT("Failed to find unit %s", pci_device_names[dev]);
                 return -ENODEV;
             }
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Write Uncore counter 0x%X (%s) on CPU %d (socket %d, access %s): 0x%lX, reg, pci_device_names[dev], cpu_id, socket_id, AccessTypeNames[unit->access_type], data);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Write Uncore counter 0x%X (%s) on CPU %d (socket %d, access %s): 0x%lX", reg, pci_device_names[dev], cpu_id, socket_id, AccessTypeNames[unit->access_type], data);
             switch(reg)
             {
                 case FAKE_UNC_UNIT_CTRL:
@@ -501,12 +501,12 @@ access_x86_translate_write(PciDeviceIndex dev, const int cpu_id, uint32_t reg, u
                             if ((dev >= MMIO_IMC_DEVICE_0_CH_0 && dev <= MMIO_IMC_DEVICE_1_CH_7) ||
                                 (dev >= MMIO_HBM_DEVICE_0 && dev <= MMIO_HBM_DEVICE_31))
                             {
-                                DEBUG_PRINT(DEBUGLEV_DEVELOP, 0x%X + 0x%X + 0x%X + (%d * %d) = 0x%X, unit->io_addr, unit->mmap_offset, unit->ctrl_offset, sizeof(uint32_t), offset, (uint32_t)data);
+                                DEBUG_PRINT(DEBUGLEV_DEVELOP, "0x%X + 0x%X + 0x%X + (%d * %d) = 0x%X", unit->io_addr, unit->mmap_offset, unit->ctrl_offset, sizeof(uint32_t), offset, (uint32_t)data);
                                 *((uint32_t *)(unit->io_addr + unit->mmap_offset + unit->ctrl_offset + (sizeof(uint32_t) * offset))) = (uint32_t)data;
                             }
                             else
                             {
-                                DEBUG_PRINT(DEBUGLEV_DEVELOP, 0x%X + 0x%X + 0x%X + (%d * %d) = 0x%X, unit->io_addr, unit->mmap_offset, unit->ctrl_offset, reg_offset, offset, (uint64_t)data);
+                                DEBUG_PRINT(DEBUGLEV_DEVELOP, "0x%X + 0x%X + 0x%X + (%d * %d) = 0x%X", unit->io_addr, unit->mmap_offset, unit->ctrl_offset, reg_offset, offset, (uint64_t)data);
                                 *((uint64_t *)(unit->io_addr + unit->mmap_offset + unit->ctrl_offset + (reg_offset * offset))) = (uint64_t)data;
                             }
                             break;
@@ -614,7 +614,7 @@ access_x86_translate_check(PciDeviceIndex dev, int cpu_id)
 {
     if (cpu_id < 0 || (!perfmon_discovery))
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, CPU < 0 or no perfmon_initialization)
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "CPU < 0 or no perfmon_initialization");
         return 0;
     }
     int socket_id = affinity_thread2socket_lookup[cpu_id];

--- a/src/access_x86_translate.c
+++ b/src/access_x86_translate.c
@@ -143,7 +143,7 @@ access_x86_translate_init(const int cpu_id)
 {
     if (!perfmon_discovery)
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Running Perfmon Discovery to populate counter lists");
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Running Perfmon Discovery to populate counter lists");
         int ret = perfmon_uncore_discovery(cpuid_info.model, &perfmon_discovery);
         if (ret != 0)
         {

--- a/src/affinity.c
+++ b/src/affinity.c
@@ -125,7 +125,7 @@ treeFillNextEntries(
         node = tree_getNextNode(node);
         if ( node == NULL )
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Cannot find socket %d in topology tree, i);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Cannot find socket %d in topology tree", i);
         }
     }
 
@@ -137,7 +137,7 @@ treeFillNextEntries(
 
         if ( node == NULL )
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Cannot find core %d in topology tree, i);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Cannot find core %d in topology tree", i);
         }
     }
 
@@ -458,7 +458,7 @@ static int create_lookups()
             int numberOfCoresPerCache = cachelimit/cputopo->numThreadsPerCore;
             affinity_thread2sharedl3_lookup[hwthreadid] = coreid / numberOfCoresPerCache;
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, T %d T2C %d T2S %d T2D %d T2LLC %d T2M %d, hwthreadid,
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "T %d T2C %d T2S %d T2D %d T2LLC %d T2M %d", hwthreadid,
                                         affinity_thread2core_lookup[hwthreadid],
                                         affinity_thread2socket_lookup[hwthreadid],
                                         affinity_thread2die_lookup[hwthreadid],
@@ -545,7 +545,7 @@ static int affinity_addNodeDomain(AffinityDomain* domain, int* help)
         domain->numberOfCores = cores;
         domain->tag[0] = 'N';
         domain->tag[1] = '\0';
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity domain N: %d HW threads on %d cores, domain->numberOfProcessors, domain->numberOfCores);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity domain N: %d HW threads on %d cores", domain->numberOfProcessors, domain->numberOfCores);
         return 0;
     }
     return -EINVAL;
@@ -582,7 +582,7 @@ static int affinity_addSocketDomain(int socket, AffinityDomain* domain, int* hel
         domain->numberOfProcessors = tmp;
         domain->numberOfCores = affinity_countSocketCores(domain->numberOfProcessors, domain->processorList, help);
         snprintf(domain->tag, 9, "S%d", socket);
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity domain S%d: %d HW threads on %d cores, socket, domain->numberOfProcessors, domain->numberOfCores);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity domain S%d: %d HW threads on %d cores", socket, domain->numberOfProcessors, domain->numberOfCores);
         return 0;
     }
     return -EINVAL;
@@ -625,7 +625,7 @@ static int affinity_addDieDomain(int socket, int die, AffinityDomain* domain, in
         domain->numberOfProcessors = tmp;
         domain->numberOfCores = affinity_countSocketCores(domain->numberOfProcessors, domain->processorList, help);
         snprintf(domain->tag, 9, "D%d", dieId);
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity domain D%d: %d HW threads on %d cores, dieId, domain->numberOfProcessors, domain->numberOfCores);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity domain D%d: %d HW threads on %d cores", dieId, domain->numberOfProcessors, domain->numberOfCores);
         return 0;
     }
     return -EINVAL;
@@ -667,7 +667,7 @@ static int affinity_addCacheDomain(int socket, int cacheId, AffinityDomain* doma
         domain->numberOfProcessors = tmp;
         domain->numberOfCores = affinity_countSocketCores(domain->numberOfProcessors, domain->processorList, help);
         snprintf(domain->tag, 9, "C%d", cid);
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity domain C%d: %d HW threads on %d cores, cid, domain->numberOfProcessors, domain->numberOfCores);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity domain C%d: %d HW threads on %d cores", cid, domain->numberOfProcessors, domain->numberOfCores);
         return 0;
     }
     return -EINVAL;
@@ -721,7 +721,7 @@ static int affinity_addMemoryDomain(int nodeId, AffinityDomain* domain, int* hel
     int err = _affinity_addMemoryDomain(nodeId, domain, help);
     if (err == 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity domain M%d: %d HW threads on %d cores, nodeId, domain->numberOfProcessors, domain->numberOfCores);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity domain M%d: %d HW threads on %d cores", nodeId, domain->numberOfProcessors, domain->numberOfCores);
     }
     return err;
 }
@@ -749,7 +749,7 @@ static int affinity_addCudaDomain(int nodeId, AffinityDomain* domain, int offset
                 if (err == 0)
                 {
                     snprintf(domain->tag, 9, "G%d", nodeId+offset);
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity domain %s: %d HW threads on %d cores, domain->tag, domain->numberOfProcessors, domain->numberOfCores);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity domain %s: %d HW threads on %d cores", domain->tag, domain->numberOfProcessors, domain->numberOfCores);
                     return 0;
                 }
             }
@@ -782,13 +782,13 @@ static int affinity_addRocmDomain(int nodeId, AffinityDomain* domain, int offset
                 if (err == 0)
                 {
                     snprintf(domain->tag, 9, "G%d", nodeId+offset);
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity domain %s: %d HW threads on %d cores, domain->tag, domain->numberOfProcessors, domain->numberOfCores);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity domain %s: %d HW threads on %d cores", domain->tag, domain->numberOfProcessors, domain->numberOfCores);
                     return 0;
                 }
             }
             else
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Skipping affinity domain G%d because NUMA node unknown, nodeId);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Skipping affinity domain G%d because NUMA node unknown", nodeId);
             }
         }
     }
@@ -862,21 +862,21 @@ affinity_init(void)
     /* determine total number of domains */
     numberOfDomains = 1;
     numberOfDomains += cputopo->numSockets;
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: Socket domains %d, cputopo->numSockets);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: Socket domains %d", cputopo->numSockets);
     numberOfDomains += (cputopo->numDies > 0 ? cputopo->numDies : cputopo->numSockets);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: CPU die domains %d, (cputopo->numDies > 0 ? cputopo->numDies : cputopo->numSockets));
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: CPU die domains %d", (cputopo->numDies > 0 ? cputopo->numDies : cputopo->numSockets));
     if (doCacheDomains && cputopo->numCacheLevels > 0)
     {
         numberOfProcessorsPerCache = cputopo->cacheLevels[cputopo->numCacheLevels-1].threads;
         numberOfCoresPerCache = numberOfProcessorsPerCache / cputopo->numThreadsPerCore;
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: CPU cores per LLC %d, numberOfCoresPerCache);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: CPU cores per LLC %d", numberOfCoresPerCache);
         int numCachesPerSocket = cputopo->numCoresPerSocket / numberOfCoresPerCache;
         numberOfCacheDomains = cputopo->numSockets * MAX(numCachesPerSocket, 1);
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: Cache domains %d, numberOfCacheDomains);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: Cache domains %d", numberOfCacheDomains);
         numberOfDomains += numberOfCacheDomains;
     }
     numberOfDomains += numatopo->numberOfNodes;
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: NUMA domains %d, numatopo->numberOfNodes);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: NUMA domains %d", numatopo->numberOfNodes);
 #if defined(LIKWID_WITH_NVMON) || defined(LIKWID_WITH_ROCMON)
     int gpuDomains = 0;
 #ifdef LIKWID_WITH_NVMON
@@ -891,7 +891,7 @@ affinity_init(void)
                 numCudaDomains++;
             }
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: CUDA domains %d (%d device(s)), numCudaDomains, cudatopo->numDevices);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: CUDA domains %d (%d device(s))", numCudaDomains, cudatopo->numDevices);
         gpuDomains += numCudaDomains;
     }
 #endif
@@ -907,13 +907,13 @@ affinity_init(void)
                 numRocmDomains++;
             }
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: ROCm domains %d (%d device(s)), numRocmDomains, rocmtopo->numDevices);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: ROCm domains %d (%d device(s))", numRocmDomains, rocmtopo->numDevices);
         gpuDomains += numRocmDomains;
     }
 #endif
     numberOfDomains += gpuDomains;
 #endif
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Affinity: All domains %d, numberOfDomains);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Affinity: All domains %d", numberOfDomains);
 
     domains = (AffinityDomain*) malloc(numberOfDomains * sizeof(AffinityDomain));
     if (!domains)

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -121,7 +121,7 @@ use_hardcoded:
     {
         if (getenv("LIKWID_NO_ACCESS") == NULL)
         {
-            ERROR_PLAIN_PRINT(Unable to get path to access daemon. Maybe your PATH environment variable does not contain the folder where you installed it or the file was moved away / not copied to that location?);
+            ERROR_PLAIN_PRINT("Unable to get path to access daemon. Maybe your PATH environment variable does not contain the folder where you installed it or the file was moved away / not copied to that location?");
             return -1;
         }
     }
@@ -162,7 +162,7 @@ init_configuration(void)
     {
         if (1023 == strlen(filename) && access(filename, R_OK))
         {
-            ERROR_PLAIN_PRINT(Topology file path too long for internal buffer);
+            ERROR_PLAIN_PRINT("Topology file path too long for internal buffer");
             return -1;
         }
         config.topologyCfgFileName = (char*)malloc((strlen(filename)+1) * sizeof(char));
@@ -187,7 +187,7 @@ init_configuration(void)
     {
         if (1023 == strlen(filename) && access(filename, R_OK))
         {
-            ERROR_PLAIN_PRINT(Config file path too long for internal buffer);
+            ERROR_PLAIN_PRINT("Config file path too long for internal buffer");
             if (config.topologyCfgFileName) free(config.topologyCfgFileName);
             return -1;
         }
@@ -199,7 +199,7 @@ init_configuration(void)
         return default_configuration();
     }
 
-    DEBUG_PRINT(DEBUGLEV_INFO, Reading configuration from %s, config.configFileName)
+    DEBUG_PRINT(DEBUGLEV_INFO, "Reading configuration from %s", config.configFileName);
     fp = fopen(config.configFileName, "r");
     while (fgets(line, 512, fp) != NULL) {
         if (sscanf(line,"%s = %s", name, value) != 2)
@@ -223,7 +223,7 @@ init_configuration(void)
             {
                 if (default_configuration() < 0)
                 {
-                    ERROR_PLAIN_PRINT(Unable to get path to access daemon);
+                    ERROR_PLAIN_PRINT("Unable to get path to access daemon");
                     fclose(fp);
                     if (config.topologyCfgFileName) free(config.topologyCfgFileName);
                     if (config.configFileName) free(config.configFileName);
@@ -243,7 +243,7 @@ init_configuration(void)
             }
             else
             {
-                ERROR_PRINT(Path to group files %s is not a directory, value);
+                ERROR_PRINT("Path to group files %s is not a directory", value);
                 fclose(fp);
                 if (config.topologyCfgFileName) free(config.topologyCfgFileName);
                 if (config.configFileName) free(config.configFileName);
@@ -266,7 +266,7 @@ init_configuration(void)
 #ifdef LIKWID_USE_PERFEVENT
                 config.daemonMode = ACCESSMODE_PERF;
 #else
-                ERROR_PRINT(Invalid access mode 'perf_event'. Library not built with 'perf_event' support);
+                ERROR_PRINT("Invalid access mode 'perf_event'. Library not built with 'perf_event' support");
 #endif
             }
         }

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -121,7 +121,7 @@ use_hardcoded:
     {
         if (getenv("LIKWID_NO_ACCESS") == NULL)
         {
-            ERROR_PLAIN_PRINT("Unable to get path to access daemon. Maybe your PATH environment variable does not contain the folder where you installed it or the file was moved away / not copied to that location?");
+            ERROR_PRINT("Unable to get path to access daemon. Maybe your PATH environment variable does not contain the folder where you installed it or the file was moved away / not copied to that location?");
             return -1;
         }
     }
@@ -162,7 +162,7 @@ init_configuration(void)
     {
         if (1023 == strlen(filename) && access(filename, R_OK))
         {
-            ERROR_PLAIN_PRINT("Topology file path too long for internal buffer");
+            ERROR_PRINT("Topology file path too long for internal buffer");
             return -1;
         }
         config.topologyCfgFileName = (char*)malloc((strlen(filename)+1) * sizeof(char));
@@ -187,7 +187,7 @@ init_configuration(void)
     {
         if (1023 == strlen(filename) && access(filename, R_OK))
         {
-            ERROR_PLAIN_PRINT("Config file path too long for internal buffer");
+            ERROR_PRINT("Config file path too long for internal buffer");
             if (config.topologyCfgFileName) free(config.topologyCfgFileName);
             return -1;
         }
@@ -223,7 +223,7 @@ init_configuration(void)
             {
                 if (default_configuration() < 0)
                 {
-                    ERROR_PLAIN_PRINT("Unable to get path to access daemon");
+                    ERROR_PRINT("Unable to get path to access daemon");
                     fclose(fp);
                     if (config.topologyCfgFileName) free(config.topologyCfgFileName);
                     if (config.configFileName) free(config.configFileName);

--- a/src/cpuFeatures.c
+++ b/src/cpuFeatures.c
@@ -292,7 +292,7 @@ cpuFeatures_init(void)
         int ret = HPMaddThread(cpuid_topology.threadPool[i].apicId);
         if (ret != 0)
         {
-            ERROR_PRINT(Cannot get access to register CPU feature register on CPU %d, cpuid_topology.threadPool[i].apicId);
+            ERROR_PRINT("Cannot get access to register CPU feature register on CPU %d", cpuid_topology.threadPool[i].apicId);
             return;
         }
     }

--- a/src/devstring.c
+++ b/src/devstring.c
@@ -223,7 +223,7 @@ static int parse_node(const bstring domain_selector, LikwidDeviceList_t dev_list
     const char *ds = bdata(domain_selector);
     if (domain_selector && strcmp(ds, "0") != 0)
     {
-        ERROR_PRINT(If specified node domain may only sppecify node '0' found: '%s', bdata(domain_selector));
+        ERROR_PRINT("If specified node domain may only sppecify node '0' found: '%s'", bdata(domain_selector));
         return -EINVAL;
     }
 
@@ -237,7 +237,7 @@ static int parse_simple(const bstring domain_selector, LikwidDeviceType type, Li
     int err = range_create(domain_selector, &range_list);
     if (err < 0)
     {
-        ERROR_PRINT(Unable to parse malformed range: %s, bdata(domain_selector));
+        ERROR_PRINT("Unable to parse malformed range: %s", bdata(domain_selector));
         return err;
     }
 

--- a/src/frequency_cpu.c
+++ b/src/frequency_cpu.c
@@ -321,7 +321,7 @@ freq_client_startDaemon()
         fprintf(stderr, "Failed to find the daemon '%s'\n", exeprog);
         return -1;
     }
-    DEBUG_PRINT(DEBUGLEV_INFO, Starting daemon %s, exeprog);
+    DEBUG_PRINT(DEBUGLEV_INFO, "Starting daemon %s", exeprog);
     pid = fork();
 
     if (pid == 0)
@@ -353,7 +353,7 @@ freq_client_startDaemon()
     socket_fd = socket(AF_LOCAL, SOCK_STREAM, 0);
     if (socket_fd < 0)
     {
-        ERROR_PRINT(socket() failed);
+        ERROR_PRINT("socket() failed");
         return -1;
     }
 
@@ -361,7 +361,7 @@ freq_client_startDaemon()
     address_length = sizeof(address);
     snprintf(address.sun_path, sizeof(address.sun_path), TOSTRING(LIKWIDSOCKETBASE) "-freq-%d", pid);
     filepath = strdup(address.sun_path);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Waiting for socket file %s, address.sun_path);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Waiting for socket file %s", address.sun_path);
     while (access(address.sun_path, F_OK) && timeout > 0)
     {
         usleep(1000);
@@ -369,7 +369,7 @@ freq_client_startDaemon()
     }
     if (!access(address.sun_path, F_OK))
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Socket file %s exists, address.sun_path);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Socket file %s exists", address.sun_path);
     }
 
     res = connect(socket_fd, (struct sockaddr *) &address, address_length);
@@ -399,7 +399,7 @@ freq_client_startDaemon()
         socket_fd = -1;
         return -1;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Successfully opened socket %s to daemon, filepath);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Successfully opened socket %s to daemon", filepath);
     free(filepath);
 
     return socket_fd;
@@ -464,39 +464,39 @@ static int freq_send_direct(FreqDataRecordType type, FreqDataRecordLocation loc,
         case FREQ_LOC_CUR:
             fd = f->cur_freq;
             only_read = 1;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_CUR FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_CUR FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         case FREQ_LOC_MIN:
             fd = f->min_freq;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_MIN FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_MIN FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         case FREQ_LOC_MAX:
             fd = f->max_freq;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_MAX FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_MAX FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         case FREQ_LOC_GOV:
             fd = f->set_gov;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_GOV FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_GOV FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         case FREQ_LOC_AVAIL_GOV:
             fd = f->avail_govs;
             only_read = 1;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_AVAIL_GOV FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_AVAIL_GOV FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         case FREQ_LOC_AVAIL_FREQ:
             fd = f->avail_freq;
             only_read = 1;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_AVAIL_FREQ FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_AVAIL_FREQ FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         case FREQ_LOC_CONF_MIN:
             fd = f->conf_min_freq;
             only_read = 1;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_CONF_MIN FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_CONF_MIN FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         case FREQ_LOC_CONF_MAX:
             fd = f->conf_max_freq;
             only_read = 1;
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, CMD %s CPU %d FREQ_LOC_CONF_MAX FD %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "CMD %s CPU %d FREQ_LOC_CONF_MAX FD %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, fd);
             break;
         default:
             fprintf(stderr,"Invalid location specified in record\n");
@@ -569,9 +569,9 @@ static int freq_send_client(FreqDataRecordType type, FreqDataRecordLocation loc,
         record.errorcode = FREQ_ERR_NONE;
         snprintf(record.data, LIKWID_FREQUENCY_MAX_DATA_LENGTH, "%.*s", len, data);
         record.datalen = len;
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, DAEMON CMD %s CPU %d LOC %d, (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, loc);
-        CHECK_ERROR(write(fsocket, &record, sizeof(FreqDataRecord)),socket write failed);
-        CHECK_ERROR(read(fsocket, &record, sizeof(FreqDataRecord)), socket read failed);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "DAEMON CMD %s CPU %d LOC %d", (type == FREQ_WRITE ? "WRITE" : "READ"), cpu, loc);
+        CHECK_ERROR(write(fsocket, &record, sizeof(FreqDataRecord)), "socket write failed");
+        CHECK_ERROR(read(fsocket, &record, sizeof(FreqDataRecord)), "socket read failed");
         if (record.errorcode != FREQ_ERR_NONE)
         {
             switch(record.errorcode)
@@ -602,9 +602,9 @@ static void freq_finalize_client()
     {
         memset(&record, 0, sizeof(FreqDataRecord));
         record.type = FREQ_EXIT;
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, DAEMON CMD CLOSE);
-        CHECK_ERROR(write(fsocket, &record, sizeof(FreqDataRecord)),socket write failed);
-        CHECK_ERROR(close(fsocket),socket close failed);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "DAEMON CMD CLOSE");
+        CHECK_ERROR(write(fsocket, &record, sizeof(FreqDataRecord)), "socket write failed");
+        CHECK_ERROR(close(fsocket), "socket close failed");
         fsocket = -1;
     }
     return;
@@ -632,7 +632,7 @@ static int getAMDTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -641,7 +641,7 @@ static int getAMDTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -650,7 +650,7 @@ static int getAMDTurbo(const int cpu_id)
     err = HPMread(cpu_id, MSR_DEV, 0xC0010015, &tmp);
     if (err)
     {
-        ERROR_PLAIN_PRINT(Cannot read register 0xC0010015);
+        ERROR_PLAIN_PRINT("Cannot read register 0xC0010015");
         return err;
     }
 
@@ -680,7 +680,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -689,7 +689,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -698,7 +698,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
     err = HPMread(cpu_id, MSR_DEV, 0xC0010015, &tmp);
     if (err)
     {
-        ERROR_PLAIN_PRINT(Cannot read register 0xC0010015);
+        ERROR_PLAIN_PRINT("Cannot read register 0xC0010015");
         return err;
     }
 
@@ -713,7 +713,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
     err = HPMwrite(cpu_id, MSR_DEV, 0xC0010015, tmp);
     if (err)
     {
-        ERROR_PLAIN_PRINT(Cannot write register 0xC0010015);
+        ERROR_PLAIN_PRINT("Cannot write register 0xC0010015");
         return err;
     }
 
@@ -741,7 +741,7 @@ static int getIntelTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -750,7 +750,7 @@ static int getIntelTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -759,7 +759,7 @@ static int getIntelTurbo(const int cpu_id)
     err = HPMread(cpu_id, MSR_DEV, MSR_IA32_MISC_ENABLE, &tmp);
     if (err)
     {
-        ERROR_PRINT(Cannot read register 0x%x, MSR_IA32_MISC_ENABLE);
+        ERROR_PRINT("Cannot read register 0x%x", MSR_IA32_MISC_ENABLE);
         return err;
     }
 
@@ -789,7 +789,7 @@ static int setIntelTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -798,7 +798,7 @@ static int setIntelTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -807,7 +807,7 @@ static int setIntelTurbo(const int cpu_id, const int turbo)
     err = HPMread(cpu_id, MSR_DEV, MSR_IA32_MISC_ENABLE, &tmp);
     if (err)
     {
-        ERROR_PRINT(Cannot read register 0x%x, MSR_IA32_MISC_ENABLE);
+        ERROR_PRINT("Cannot read register 0x%x", MSR_IA32_MISC_ENABLE);
         return err;
     }
     if (turbo)
@@ -821,7 +821,7 @@ static int setIntelTurbo(const int cpu_id, const int turbo)
     err = HPMwrite(cpu_id, MSR_DEV, MSR_IA32_MISC_ENABLE, tmp);
     if (err)
     {
-        ERROR_PRINT(Cannot write register 0x%x, MSR_IA32_MISC_ENABLE);
+        ERROR_PRINT("Cannot write register 0x%x", MSR_IA32_MISC_ENABLE);
         return err;
     }
     return err == 0;
@@ -858,7 +858,7 @@ static int getIntelHWP(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -867,7 +867,7 @@ static int getIntelHWP(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -876,7 +876,7 @@ static int getIntelHWP(const int cpu_id)
     err = HPMread(cpu_id, MSR_DEV, MSR_HWP_ENABLE, &tmp);
     if (err)
     {
-        ERROR_PRINT(Cannot read register 0x%x, MSR_HWP_ENABLE);
+        ERROR_PRINT("Cannot read register 0x%x", MSR_HWP_ENABLE);
         return err;
     }
 
@@ -904,7 +904,7 @@ static int getBaseFreq(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -913,7 +913,7 @@ static int getBaseFreq(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -949,21 +949,21 @@ _freqInit(void)
         }
         if (config.daemonMode == ACCESSMODE_DAEMON)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, Adjusting functions for daemon mode);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for daemon mode");
             freq_init_f = freq_init_client;
             freq_send = freq_send_client;
             freq_finalize_f = freq_finalize_client;
         }
         else if (config.daemonMode == ACCESSMODE_DIRECT)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, Adjusting functions for direct mode);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for direct mode");
             freq_init_f = freq_init_direct;
             freq_send = freq_send_direct;
             freq_finalize_f = freq_finalize_direct;
         }
         else if (config.daemonMode == ACCESSMODE_PERF)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, Frequency module not usable in perf_event mode);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Frequency module not usable in perf_event mode");
         }
         else
         {

--- a/src/frequency_cpu.c
+++ b/src/frequency_cpu.c
@@ -602,7 +602,7 @@ static void freq_finalize_client()
     {
         memset(&record, 0, sizeof(FreqDataRecord));
         record.type = FREQ_EXIT;
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "DAEMON CMD CLOSE");
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "DAEMON CMD CLOSE");
         CHECK_ERROR(write(fsocket, &record, sizeof(FreqDataRecord)), "socket write failed");
         CHECK_ERROR(close(fsocket), "socket close failed");
         fsocket = -1;
@@ -632,7 +632,7 @@ static int getAMDTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -641,7 +641,7 @@ static int getAMDTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -650,7 +650,7 @@ static int getAMDTurbo(const int cpu_id)
     err = HPMread(cpu_id, MSR_DEV, 0xC0010015, &tmp);
     if (err)
     {
-        ERROR_PLAIN_PRINT("Cannot read register 0xC0010015");
+        ERROR_PRINT("Cannot read register 0xC0010015");
         return err;
     }
 
@@ -680,7 +680,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -689,7 +689,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -698,7 +698,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
     err = HPMread(cpu_id, MSR_DEV, 0xC0010015, &tmp);
     if (err)
     {
-        ERROR_PLAIN_PRINT("Cannot read register 0xC0010015");
+        ERROR_PRINT("Cannot read register 0xC0010015");
         return err;
     }
 
@@ -713,7 +713,7 @@ static int setAMDTurbo(const int cpu_id, const int turbo)
     err = HPMwrite(cpu_id, MSR_DEV, 0xC0010015, tmp);
     if (err)
     {
-        ERROR_PLAIN_PRINT("Cannot write register 0xC0010015");
+        ERROR_PRINT("Cannot write register 0xC0010015");
         return err;
     }
 
@@ -741,7 +741,7 @@ static int getIntelTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -750,7 +750,7 @@ static int getIntelTurbo(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -789,7 +789,7 @@ static int setIntelTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -798,7 +798,7 @@ static int setIntelTurbo(const int cpu_id, const int turbo)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -858,7 +858,7 @@ static int getIntelHWP(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -867,7 +867,7 @@ static int getIntelHWP(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -904,7 +904,7 @@ static int getBaseFreq(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -913,7 +913,7 @@ static int getBaseFreq(const int cpu_id)
         err = HPMaddThread(cpu_id);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return err;
         }
     }
@@ -949,21 +949,21 @@ _freqInit(void)
         }
         if (config.daemonMode == ACCESSMODE_DAEMON)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for daemon mode");
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for daemon mode");
             freq_init_f = freq_init_client;
             freq_send = freq_send_client;
             freq_finalize_f = freq_finalize_client;
         }
         else if (config.daemonMode == ACCESSMODE_DIRECT)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for direct mode");
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adjusting functions for direct mode");
             freq_init_f = freq_init_direct;
             freq_send = freq_send_direct;
             freq_finalize_f = freq_finalize_direct;
         }
         else if (config.daemonMode == ACCESSMODE_PERF)
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "Frequency module not usable in perf_event mode");
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Frequency module not usable in perf_event mode");
         }
         else
         {

--- a/src/frequency_uncore.c
+++ b/src/frequency_uncore.c
@@ -198,7 +198,7 @@ int freq_setUncoreFreqMin(const int socket_id, const uint64_t freq)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+        ERROR_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -267,7 +267,7 @@ uint64_t freq_getUncoreFreqMin(const int socket_id)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+        ERROR_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -329,7 +329,7 @@ int freq_setUncoreFreqMax(const int socket_id, const uint64_t freq)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+        ERROR_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -396,7 +396,7 @@ uint64_t freq_getUncoreFreqMax(const int socket_id)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+        ERROR_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -454,7 +454,7 @@ uint64_t freq_getUncoreFreqCur(const int socket_id)
         err = HPMaddThread(cpuId);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
+            ERROR_PRINT("Cannot get access to MSRs");
             return 0;
         }
     }

--- a/src/frequency_uncore.c
+++ b/src/frequency_uncore.c
@@ -178,12 +178,12 @@ int freq_setUncoreFreqMin(const int socket_id, const uint64_t freq)
     }
     if (freq < (uint64_t)fmin)
     {
-        ERROR_PRINT(Given frequency %llu MHz lower than system limit of %.0f MHz, freq, fmin);
+        ERROR_PRINT("Given frequency %llu MHz lower than system limit of %.0f MHz", freq, fmin);
         return -EINVAL;
     }
     if (freq > (uint64_t)fmax)
     {
-        ERROR_PRINT(Given frequency %llu MHz higher than system limit of %.0f MHz, freq, fmax);
+        ERROR_PRINT("Given frequency %llu MHz higher than system limit of %.0f MHz", freq, fmax);
         return -EINVAL;
     }
 #ifdef LIKWID_USE_PERFEVENT
@@ -198,7 +198,7 @@ int freq_setUncoreFreqMin(const int socket_id, const uint64_t freq)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -206,7 +206,7 @@ int freq_setUncoreFreqMin(const int socket_id, const uint64_t freq)
     err = HPMread(cpuId, MSR_DEV, MSR_UNCORE_FREQ, &tmp);
     if (err)
     {
-        //ERROR_PRINT(Cannot read register 0x%X on CPU %d, MSR_UNCORE_FREQ, cpuId);
+        //ERROR_PRINT("Cannot read register 0x%X on CPU %d", MSR_UNCORE_FREQ, cpuId);
         return err;
     }
     tmp &= ~(0xFF00);
@@ -214,7 +214,7 @@ int freq_setUncoreFreqMin(const int socket_id, const uint64_t freq)
     err = HPMwrite(cpuId, MSR_DEV, MSR_UNCORE_FREQ, tmp);
     if (err)
     {
-        ERROR_PRINT(Cannot write register 0x%X on CPU %d, MSR_UNCORE_FREQ, cpuId);
+        ERROR_PRINT("Cannot write register 0x%X on CPU %d", MSR_UNCORE_FREQ, cpuId);
         return err;
     }
 
@@ -252,7 +252,7 @@ uint64_t freq_getUncoreFreqMin(const int socket_id)
     }
     if (cpuId < 0)
     {
-        ERROR_PRINT(Unknown socket ID %d, socket_id);
+        ERROR_PRINT("Unknown socket ID %d", socket_id);
         return 0;
     }
 #ifdef LIKWID_USE_PERFEVENT
@@ -267,7 +267,7 @@ uint64_t freq_getUncoreFreqMin(const int socket_id)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -275,7 +275,7 @@ uint64_t freq_getUncoreFreqMin(const int socket_id)
     err = HPMread(cpuId, MSR_DEV, MSR_UNCORE_FREQ, &tmp);
     if (err)
     {
-        //ERROR_PRINT(Cannot read register 0x%X on CPU %d, MSR_UNCORE_FREQ, cpuId);
+        //ERROR_PRINT("Cannot read register 0x%X on CPU %d", MSR_UNCORE_FREQ, cpuId);
         return 0;
     }
     tmp = ((tmp>>8) & 0xFFULL) * 100;
@@ -309,12 +309,12 @@ int freq_setUncoreFreqMax(const int socket_id, const uint64_t freq)
     }
     if (freq < (uint64_t)fmin)
     {
-        ERROR_PRINT(Given frequency %llu MHz lower than system limit of %.0f MHz, freq, fmin);
+        ERROR_PRINT("Given frequency %llu MHz lower than system limit of %.0f MHz", freq, fmin);
         return -EINVAL;
     }
     if (freq > (uint64_t)fmax)
     {
-        ERROR_PRINT(Given frequency %llu MHz higher than system limit of %.0f MHz, freq, fmax);
+        ERROR_PRINT("Given frequency %llu MHz higher than system limit of %.0f MHz", freq, fmax);
         return -EINVAL;
     }
 #ifdef LIKWID_USE_PERFEVENT
@@ -329,7 +329,7 @@ int freq_setUncoreFreqMax(const int socket_id, const uint64_t freq)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -337,7 +337,7 @@ int freq_setUncoreFreqMax(const int socket_id, const uint64_t freq)
     err = HPMread(cpuId, MSR_DEV, MSR_UNCORE_FREQ, &tmp);
     if (err)
     {
-        //ERROR_PRINT(Cannot read register 0x%X on CPU %d, MSR_UNCORE_FREQ, cpuId);
+        //ERROR_PRINT("Cannot read register 0x%X on CPU %d", MSR_UNCORE_FREQ, cpuId);
         return err;
     }
     tmp &= ~(0xFFULL);
@@ -345,7 +345,7 @@ int freq_setUncoreFreqMax(const int socket_id, const uint64_t freq)
     err = HPMwrite(cpuId, MSR_DEV, MSR_UNCORE_FREQ, tmp);
     if (err)
     {
-        ERROR_PRINT(Cannot write register 0x%X on CPU %d, MSR_UNCORE_FREQ, cpuId);
+        ERROR_PRINT("Cannot write register 0x%X on CPU %d", MSR_UNCORE_FREQ, cpuId);
         return err;
     }
 
@@ -381,7 +381,7 @@ uint64_t freq_getUncoreFreqMax(const int socket_id)
     }
     if (cpuId < 0)
     {
-        ERROR_PRINT(Unknown socket ID %d, socket_id);
+        ERROR_PRINT("Unknown socket ID %d", socket_id);
         return 0;
     }
 #ifdef LIKWID_USE_PERFEVENT
@@ -396,7 +396,7 @@ uint64_t freq_getUncoreFreqMax(const int socket_id)
     err = HPMaddThread(cpuId);
     if (err != 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+        ERROR_PLAIN_PRINT("Cannot get access to MSRs");
         return 0;
     }
 
@@ -404,7 +404,7 @@ uint64_t freq_getUncoreFreqMax(const int socket_id)
     err = HPMread(cpuId, MSR_DEV, MSR_UNCORE_FREQ, &tmp);
     if (err)
     {
-        //ERROR_PRINT(Cannot read register 0x%X on CPU %d, MSR_UNCORE_FREQ, cpuId);
+        //ERROR_PRINT("Cannot read register 0x%X on CPU %d", MSR_UNCORE_FREQ, cpuId);
         return 0;
     }
     tmp = (tmp & 0xFFULL) * 100;
@@ -440,7 +440,7 @@ uint64_t freq_getUncoreFreqCur(const int socket_id)
     }
     if (cpuId < 0)
     {
-        ERROR_PRINT(Unknown socket ID %d, socket_id);
+        ERROR_PRINT("Unknown socket ID %d", socket_id);
         return 0;
     }
 #ifdef LIKWID_USE_PERFEVENT
@@ -454,7 +454,7 @@ uint64_t freq_getUncoreFreqCur(const int socket_id)
         err = HPMaddThread(cpuId);
         if (err != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to MSRs)
+            ERROR_PLAIN_PRINT("Cannot get access to MSRs");
             return 0;
         }
     }
@@ -463,7 +463,7 @@ uint64_t freq_getUncoreFreqCur(const int socket_id)
     err = HPMread(cpuId, MSR_DEV, MSR_UNCORE_FREQ_READ, &tmp);
     if (err)
     {
-        //ERROR_PRINT(Cannot read register 0x%X on CPU %d, MSR_UNCORE_FREQ_READ, cpuId);
+        //ERROR_PRINT("Cannot read register 0x%X on CPU %d", MSR_UNCORE_FREQ_READ, cpuId);
         return 0;
     }
     tmp = (tmp & 0xFFULL) * 100;

--- a/src/includes/error.h
+++ b/src/includes/error.h
@@ -57,7 +57,7 @@
     } while (0)
 
 #define CHECK_AND_RETURN_ERROR(func, msg)  \
-    while { \
+    do { \
         if ((func) < 0) { \
             ERROR_PRINT(msg); \
             return errno; \
@@ -65,7 +65,7 @@
     } while (0)
 
 #define EXIT_IF_ERROR(func, msg)  \
-    while { \
+    do { \
         if ((func) < 0) {  \
             fprintf(stderr,"ERROR - [%s:%d] %s - %s \n", __FILE__, __LINE__, msg, strerror(errno)); \
             exit(EXIT_FAILURE); \
@@ -106,7 +106,7 @@
             fprintf(stdout, "DEBUG - [%s:%d] " fmt "\n", __func__, __LINE__, ##__VA_ARGS__); \
             fflush(stdout); \
         } \
-    while (0)
+    } while (0)
 
 #define ROCMON_DEBUG_PRINT(lev, fmt, ...) \
     do { \

--- a/src/includes/error.h
+++ b/src/includes/error.h
@@ -33,106 +33,126 @@
 
 #include <likwid.h>
 #include <stdio.h>
+#include <stdlib.h>
 
-#define str(x) #x
+#define ERRNO_PRINT \
+    fprintf(stderr, "ERROR - [%s:%d] %s\n", __FILE__, __LINE__, strerror(errno))
 
-#define ERRNO_PRINT fprintf(stderr, "ERROR - [%s:%d] %s\n", __FILE__, __LINE__, strerror(errno))
-
-#define ERROR  \
-    ERRNO_PRINT; \
-    exit(EXIT_FAILURE)
+#define ERROR \
+    do { \
+        ERRNO_PRINT; \
+        exit(EXIT_FAILURE); \
+    } while (0)
 
 #define ERROR_PLAIN_PRINT(msg) \
-   fprintf(stderr,  "ERROR - [%s:%s:%d] " str(msg) "\n", __FILE__, __func__,__LINE__);
+   fprintf(stderr,  "ERROR - [%s:%s:%d] %s\n", __FILE__, __func__,__LINE__, msg)
 
 #define ERROR_PRINT(fmt, ...) \
-   fprintf(stderr,  "ERROR - [%s:%s:%d] %s.\n" str(fmt) "\n", __FILE__,  __func__,__LINE__, strerror(errno), ##__VA_ARGS__);
+   fprintf(stderr,  "ERROR - [%s:%s:%d] %s.\n" fmt "\n", __FILE__,  __func__,__LINE__, strerror(errno), ##__VA_ARGS__)
 
-#define CHECK_ERROR(func, msg)  \
-    if ((func) < 0) { \
-        ERROR_PRINT(msg); \
-    }
+#define CHECK_ERROR(func, msg) \
+    do { \
+        if ((func) < 0) \
+            ERROR_PRINT(msg); \
+    } while (0)
 
 #define CHECK_AND_RETURN_ERROR(func, msg)  \
-    if ((func) < 0) { \
-        ERROR_PRINT(msg); \
-        return errno; \
-    }
+    while { \
+        if ((func) < 0) { \
+            ERROR_PRINT(msg); \
+            return errno; \
+        } \
+    } while (0)
 
 #define EXIT_IF_ERROR(func, msg)  \
-    if ((func) < 0) {  \
-        fprintf(stderr,"ERROR - [%s:%d] " str(msg) " - %s \n", __FILE__, __LINE__, strerror(errno)); \
-        exit(EXIT_FAILURE); \
-    }
+    while { \
+        if ((func) < 0) {  \
+            fprintf(stderr,"ERROR - [%s:%d] %s - %s \n", __FILE__, __LINE__, msg, strerror(errno)); \
+            exit(EXIT_FAILURE); \
+        } \
+    } while (0)
 
-#define VERBOSEPRINTREG(cpuid,reg,flags,msg) \
-    if (perfmon_verbosity >= DEBUGLEV_DETAIL) \
-    { \
-        printf("DEBUG - [%s:%d] "  str(msg) " [%d] Register 0x%llX , Flags: 0x%llX \n",  \
-                __func__, __LINE__,  (cpuid), LLU_CAST (reg), LLU_CAST (flags)); \
-        fflush(stdout);  \
-    }
+#define VERBOSEPRINTREG(cpuid, reg, flags, msg) \
+    do { \
+        if (perfmon_verbosity >= DEBUGLEV_DETAIL) \
+        { \
+            printf("DEBUG - [%s:%d] %s [%d] Register 0x%llX , Flags: 0x%llX \n", \
+                    __func__, __LINE__, msg, (cpuid), LLU_CAST (reg), LLU_CAST (flags)); \
+            fflush(stdout);  \
+        } \
+    } while (0)
 
-#define VERBOSEPRINTPCIREG(cpuid,dev,reg,flags,msg) \
-    if (perfmon_verbosity >= DEBUGLEV_DETAIL) \
-    { \
-        printf("DEBUG - [%s:%d] "  str(msg) " [%d] Device %d Register 0x%llX , Flags: 0x%llX \n",  \
-                __func__, __LINE__,  (cpuid), dev, LLU_CAST (reg), LLU_CAST (flags)); \
-        fflush(stdout);  \
-    }
-
+#define VERBOSEPRINTPCIREG(cpuid, dev, reg, flags, msg) \
+    do { \
+        if (perfmon_verbosity >= DEBUGLEV_DETAIL) \
+        { \
+            printf("DEBUG - [%s:%d] %s [%d] Device %d Register 0x%llX , Flags: 0x%llX \n",  \
+                    __func__, __LINE__, msg, (cpuid), dev, LLU_CAST (reg), LLU_CAST (flags)); \
+            fflush(stdout);  \
+        } \
+    } while (0)
 
 #define DEBUG_PRINT(lev, fmt, ...) \
-    if ((lev >= 0) && (lev <= perfmon_verbosity)) { \
-        fprintf(stdout, "DEBUG - [%s:%d] " str(fmt) "\n", __func__, __LINE__,##__VA_ARGS__); \
-        fflush(stdout); \
-    }
+    do { \
+        if ((lev) >= 0 && (lev) <= perfmon_verbosity) { \
+            fprintf(stdout, "DEBUG - [%s:%d] " fmt "\n", __func__, __LINE__, ##__VA_ARGS__); \
+            fflush(stdout); \
+        } \
+    } while (0)
 
 #define GPUDEBUG_PRINT(lev, fmt, ...) \
-    if ((lev >= 0) && (lev <= likwid_nvmon_verbosity)) { \
-        fprintf(stdout, "DEBUG - [%s:%d] " str(fmt) "\n", __func__, __LINE__,##__VA_ARGS__); \
-        fflush(stdout); \
-    }
+    do { \
+        if ((lev) >= 0 && (lev) <= likwid_nvmon_verbosity) { \
+            fprintf(stdout, "DEBUG - [%s:%d] " fmt "\n", __func__, __LINE__, ##__VA_ARGS__); \
+            fflush(stdout); \
+        } \
+    while (0)
 
 #define ROCMON_DEBUG_PRINT(lev, fmt, ...) \
-    if ((lev >= 0) && (lev <= likwid_rocmon_verbosity)) { \
-        fprintf(stdout, "ROCMON DEBUG - [%s:%d] " str(fmt) "\n", __func__, __LINE__,##__VA_ARGS__); \
-        fflush(stdout); \
-    }
+    do { \
+        if ((lev) >= 0 && (lev) <= likwid_rocmon_verbosity) { \
+            fprintf(stdout, "ROCMON DEBUG - [%s:%d] " fmt "\n", __func__, __LINE__, ##__VA_ARGS__); \
+            fflush(stdout); \
+        } \
+    } while (0)
 
 #define DEBUG_PLAIN_PRINT(lev, msg) \
-    if ((lev >= 0) && (lev <= perfmon_verbosity)) { \
-        fprintf(stdout, "DEBUG - [%s:%d] " str(msg) "\n",__func__, __LINE__);  \
-        fflush(stdout); \
-    }
+    do { \
+        if ((lev) >= 0 && (lev) <= perfmon_verbosity) { \
+            fprintf(stdout, "DEBUG - [%s:%d] %s\n",__func__, __LINE__, msg); \
+            fflush(stdout); \
+        } \
+    } while (0)
 
 #define INFO_PRINT(fmt, ...) \
-    if (perfmon_verbosity >= DEBUGLEV_INFO) \
-    { \
-        fprintf(stdout, "INFO - " STRINGIFY(fmt) "\n", ##__VA_ARGS__); \
-    }
+    do { \
+        if (perfmon_verbosity >= DEBUGLEV_INFO) \
+            fprintf(stdout, "INFO - " fmt "\n", ##__VA_ARGS__); \
+    } while (0)
+
 #define GPUINFO_PRINT(fmt, ...) \
-    if (likwid_nvmon_verbosity >= DEBUGLEV_INFO) \
-    { \
-        fprintf(stdout, "INFO - " STRINGIFY(fmt) "\n", ##__VA_ARGS__); \
-    }
+    do { \
+        if (likwid_nvmon_verbosity >= DEBUGLEV_INFO) \
+            fprintf(stdout, "INFO - " fmt "\n", ##__VA_ARGS__); \
+    } while (0)
+
 #define ROCMON_INFO_PRINT(fmt, ...) \
-    if (likwid_rocmon_verbosity >= DEBUGLEV_INFO) \
-    { \
-        fprintf(stdout, "ROCMON INFO - " STRINGIFY(fmt) "\n", ##__VA_ARGS__); \
-    }
+    do { \
+        if (likwid_rocmon_verbosity >= DEBUGLEV_INFO) \
+            fprintf(stdout, "ROCMON INFO - " fmt "\n", ##__VA_ARGS__); \
+    } while (0)
 
-#define TODO_PRINT(fmt, ...)  \
-    fprintf(stdout, "TODO - " STRINGIFY(fmt) "\n", ##__VA_ARGS__);
+#define TODO_PRINT(fmt, ...) \
+    fprintf(stdout, "TODO - " fmt "\n", ##__VA_ARGS__)
 
 
-#define CHECK_MSR_WRITE_ERROR(func) CHECK_AND_RETURN_ERROR(func, MSR write operation failed);
-#define CHECK_MSR_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, MSR read operation failed);
-#define CHECK_PCI_WRITE_ERROR(func) CHECK_AND_RETURN_ERROR(func, PCI write operation failed);
-#define CHECK_PCI_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, PCI read operation failed);
-#define CHECK_MMIO_WRITE_ERROR(func) CHECK_AND_RETURN_ERROR(func, MMIO write operation failed);
-#define CHECK_MMIO_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, MMIO read operation failed);
-#define CHECK_POWER_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, Power register read operation failed);
-#define CHECK_TEMP_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, Temperature register read operation failed);
+#define CHECK_MSR_WRITE_ERROR(func) CHECK_AND_RETURN_ERROR(func, "MSR write operation failed")
+#define CHECK_MSR_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, "MSR read operation failed")
+#define CHECK_PCI_WRITE_ERROR(func) CHECK_AND_RETURN_ERROR(func, "PCI write operation failed")
+#define CHECK_PCI_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, "PCI read operation failed")
+#define CHECK_MMIO_WRITE_ERROR(func) CHECK_AND_RETURN_ERROR(func, "MMIO write operation failed")
+#define CHECK_MMIO_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, "MMIO read operation failed")
+#define CHECK_POWER_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, "Power register read operation failed")
+#define CHECK_TEMP_READ_ERROR(func) CHECK_AND_RETURN_ERROR(func, "Temperature register read operation failed")
 
 #endif /*ERROR_H*/

--- a/src/includes/error.h
+++ b/src/includes/error.h
@@ -44,9 +44,6 @@
         exit(EXIT_FAILURE); \
     } while (0)
 
-#define ERROR_PLAIN_PRINT(msg) \
-   fprintf(stderr,  "ERROR - [%s:%s:%d] %s\n", __FILE__, __func__,__LINE__, msg)
-
 #define ERROR_PRINT(fmt, ...) \
    fprintf(stderr,  "ERROR - [%s:%s:%d] %s.\n" fmt "\n", __FILE__,  __func__,__LINE__, strerror(errno), ##__VA_ARGS__)
 
@@ -112,14 +109,6 @@
     do { \
         if ((lev) >= 0 && (lev) <= likwid_rocmon_verbosity) { \
             fprintf(stdout, "ROCMON DEBUG - [%s:%d] " fmt "\n", __func__, __LINE__, ##__VA_ARGS__); \
-            fflush(stdout); \
-        } \
-    } while (0)
-
-#define DEBUG_PLAIN_PRINT(lev, msg) \
-    do { \
-        if ((lev) >= 0 && (lev) <= perfmon_verbosity) { \
-            fprintf(stdout, "DEBUG - [%s:%d] %s\n",__func__, __LINE__, msg); \
             fflush(stdout); \
         } \
     } while (0)

--- a/src/includes/nvmon_cupti.h
+++ b/src/includes/nvmon_cupti.h
@@ -187,7 +187,7 @@ static int check_nv_context(NvmonDevice_t device, CUcontext currentContext)
 {
     int j = 0;
     int need_pop = 0;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Current context %ld DevContext %ld, currentContext, device->context);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Current context %ld DevContext %ld", currentContext, device->context);
     if (!device->context)
     {
         int context_of_dev = -1;
@@ -203,25 +203,25 @@ static int check_nv_context(NvmonDevice_t device, CUcontext currentContext)
         if (context_of_dev < 0 && !device->context)
         {
             device->context = currentContext;
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Reuse context %ld for device %d, device->context, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Reuse context %ld for device %d", device->context, device->deviceId);
         }
         else
         {
             CUDA_CALL((*cudaSetDevicePtr)(device->deviceId), return -EFAULT);
             CUDA_CALL((*cudaFreePtr)(NULL), return -EFAULT);
             CU_CALL((*cuCtxGetCurrentPtr)(&device->context), return -EFAULT);
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, New context %ld for device %d, device->context, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "New context %ld for device %d", device->context, device->deviceId);
         }
     }
     else if (device->context != currentContext)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Use context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Use context %ld for device %d", device->context, device->deviceId);
         CU_CALL((*cuCtxPushCurrentPtr)(device->context), return -EFAULT);
         need_pop = 1;
     }
     else
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Context %ld fits for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Context %ld fits for device %d", device->context, device->deviceId);
     }
     return need_pop;
 }
@@ -345,7 +345,7 @@ nvmon_cupti_createDevice(int id, NvmonDevice *dev)
 
     // Get the number of event domains of the device
     CUPTI_CALL((*cuptiDeviceGetNumEventDomainsPtr)(dev->cuDevice, &numDomains), return -1);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Nvmon: Dev %d Domains %d, id, numDomains);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Nvmon: Dev %d Domains %d", id, numDomains);
 
     // Get the domain IDs for the device
     size_t domainarraysize = numDomains * sizeof(CUpti_EventDomainID);
@@ -361,7 +361,7 @@ nvmon_cupti_createDevice(int id, NvmonDevice *dev)
         uint32_t domainNumEvents = 0;
         CUpti_EventDomainID domainID = eventDomainIds[j];
         CUPTI_CALL((*cuptiEventDomainGetNumEventsPtr)(domainID, &domainNumEvents), return -1);
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Nvmon: Dev %d Domain %d Events %d, id, j, domainNumEvents);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Nvmon: Dev %d Domain %d Events %d", id, j, domainNumEvents);
         totalEvents += domainNumEvents;
     }
     // Now we now how many events are provided by the device, so allocate a big enough event list
@@ -423,7 +423,7 @@ nvmon_cupti_createDevice(int id, NvmonDevice *dev)
             event->domainId = j;
             event->type = NVMON_CUPTI_EVENT;
             event->active = 0;
-            //GPUDEBUG_PRINT(DEBUGLEV_DETAIL, New Event %d CuEvent %d Domain %d CuDomain %d Name %s, event->eventId, (int)event->cuEventId, event->domainId, (int)event->cuDomainId, event->name);
+            //GPUDEBUG_PRINT(DEBUGLEV_DETAIL, "New Event %d CuEvent %d Domain %d CuDomain %d Name %s", event->eventId, (int)event->cuEventId, event->domainId, (int)event->cuDomainId, event->name);
             // Add the object to the event list
             dev->allevents[dev->numAllEvents] = event;
             dev->numAllEvents++;
@@ -512,7 +512,7 @@ int nvmon_cupti_getEventsOfGpu(int gpuId, NvmonEventList_t* list)
     }
     else
     {
-        ERROR_PRINT(No such device %d, gpuId);
+        ERROR_PRINT("No such device %d, gpuId");
     }
     return 0;
 }
@@ -549,7 +549,7 @@ nvmon_cupti_addEventSets(NvmonDevice_t device, const char* eventString)
     NvmonEventSet* tmpEventSet = realloc(device->nvEventSets, (device->numNvEventSets+1)*sizeof(NvmonEventSet));
     if (!tmpEventSet)
     {
-        ERROR_PRINT(Cannot enlarge GPU %d eventSet list, device->deviceId);
+        ERROR_PRINT("Cannot enlarge GPU %d eventSet list", device->deviceId);
         return -ENOMEM;
     }
     device->nvEventSets = tmpEventSet;
@@ -558,20 +558,20 @@ nvmon_cupti_addEventSets(NvmonDevice_t device, const char* eventString)
     devEventSet->nvEvents = (NvmonEvent_t*) malloc(eventtokens->qty * sizeof(NvmonEvent_t));
     if (devEventSet->nvEvents == NULL)
     {
-        ERROR_PRINT(Cannot allocate event list for group %d\n, groupSet->numberOfActiveGroups);
+        ERROR_PRINT("Cannot allocate event list for group %d", groupSet->numberOfActiveGroups);
         return -ENOMEM;
     }
     devEventSet->cuEventIDs = (CUpti_EventID*) malloc(eventtokens->qty * sizeof(CUpti_EventID));
     if (devEventSet->cuEventIDs == NULL)
     {
-        ERROR_PRINT(Cannot allocate event ID list for group %d\n, groupSet->numberOfActiveGroups);
+        ERROR_PRINT("Cannot allocate event ID list for group %d", groupSet->numberOfActiveGroups);
         free(devEventSet->nvEvents);
         return -ENOMEM;
     }
     devEventSet->results = malloc(eventtokens->qty * sizeof(NvmonEventResult));
     if (devEventSet->cuEventIDs == NULL)
     {
-        ERROR_PRINT(Cannot allocate result list for group %d\n, groupSet->numberOfActiveGroups);
+        ERROR_PRINT("Cannot allocate result list for group %d", groupSet->numberOfActiveGroups);
         free(devEventSet->cuEventIDs);
         free(devEventSet->nvEvents);
         return -ENOMEM;
@@ -591,16 +591,16 @@ nvmon_cupti_addEventSets(NvmonDevice_t device, const char* eventString)
         struct bstrList* evset = bsplit(eventtokens->entry[i], ':');
         if (evset->qty != 2)
         {
-            ERROR_PRINT(NVMON: Event %s invalid: Format <event>:<gpucounter>, bdata(eventtokens->entry[i]));
+            ERROR_PRINT("NVMON: Event %s invalid: Format <event>:<gpucounter>", bdata(eventtokens->entry[i]));
         }
         if (blength(evset->entry[0]) == 0 || blength(evset->entry[1]) == 0)
         {
-            ERROR_PRINT(NVMON: Event %s invalid: Format <event>:<gpucounter>, bdata(eventtokens->entry[i]));
+            ERROR_PRINT("NVMON: Event %s invalid: Format <event>:<gpucounter>", bdata(eventtokens->entry[i]));
         }
         NvmonEvent_t event = g_hash_table_lookup(device->eventHash, (gpointer)bdata(evset->entry[0]));
         if (!event)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_INFO, NVMON: Event %s unknown. Skipping..., bdata(evset->entry[0]));
+            GPUDEBUG_PRINT(DEBUGLEV_INFO, "NVMON: Event %s unknown. Skipping...", bdata(evset->entry[0]));
             continue; //unknown event
         }
         else
@@ -613,7 +613,7 @@ nvmon_cupti_addEventSets(NvmonDevice_t device, const char* eventString)
             CUPTI_CALL((*cuptiEventGroupSetsCreatePtr)(device->context, s, devEventSet->cuEventIDs, &cuEventSets), devEventSet->numberOfEvents--;);
             if (cuEventSets->numSets > 1)
             {
-                ERROR_PRINT(Error adding event %s. Multiple measurement runs are required. skipping event ..., bdata(evset->entry[i]));
+                ERROR_PRINT("Error adding event %s. Multiple measurement runs are required. skipping event ...", bdata(evset->entry[i]));
                 continue;
             }
         }
@@ -637,7 +637,7 @@ int nvmon_cupti_setupCounters(NvmonDevice_t device, NvmonEventSet* eventSet)
 
     if (eventSet->numberOfEvents == 0)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DETAIL, Skipping GPU%d it has no events in group %d, device->deviceId, eventSet->id);
+        GPUDEBUG_PRINT(DEBUGLEV_DETAIL, "Skipping GPU%d it has no events in group %d", device->deviceId, eventSet->id);
         return -EINVAL;
     }
     // Currently we are on which device?
@@ -750,7 +750,7 @@ int nvmon_cupti_setupCounters(NvmonDevice_t device, NvmonEventSet* eventSet)
                         }
                         // Mark event as active. This is used to avoid measuring the same event on the same device twice
                         eventSet->nvEvents[m]->active = 1;
-                        GPUDEBUG_PRINT(DEBUGLEV_INFO, Setup event %s (%d) for GPU %d, eventSet->nvEvents[m]->name, device->activeEvents[m].cuEventId, device->deviceId);
+                        GPUDEBUG_PRINT(DEBUGLEV_INFO, "Setup event %s (%d) for GPU %d", eventSet->nvEvents[m]->name, device->activeEvents[m].cuEventId, device->deviceId);
                         device->numActiveEvents++;
                     }
                 }
@@ -786,12 +786,12 @@ int nvmon_cupti_startCounters(NvmonDevice_t device)
     //NvmonDevice_t device = &nvGroupSet->gpus[i];
     if (device->numActiveCuGroups == 0)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DETAIL, Skipping GPU%d it has no events in group %d, device->deviceId, nvGroupSet->activeGroup);
+        GPUDEBUG_PRINT(DEBUGLEV_DETAIL, "Skipping GPU%d it has no events in group %d", device->deviceId, nvGroupSet->activeGroup);
         return 0;
     }
     if (device->deviceId != oldDevId)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Change GPU device %d -> %d, oldDevId, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Change GPU device %d -> %d", oldDevId, device->deviceId);
         CUDA_CALL((*cudaSetDevicePtr)(device->deviceId), return -EFAULT);
         CUDA_CALL((*cudaGetDevicePtr)(&oldDevId), return -EFAULT);
     }
@@ -815,14 +815,14 @@ int nvmon_cupti_startCounters(NvmonDevice_t device)
 
     for (j = 0; j < device->numActiveCuGroups; j++)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Enable group %ld on Dev %d, device->activeCuGroups[j], device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Enable group %ld on Dev %d", device->activeCuGroups[j], device->deviceId);
         CUPTI_CALL((*cuptiEventGroupSetEnablePtr)(device->activeCuGroups[j]), return -EFAULT);
     }
 
     // If we added the device context to the stack, pop it again
     if (popContext)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
         CU_CALL((*cuCtxPopCurrentPtr)(&device->context), return -EFAULT);
     }
     return 0;
@@ -851,7 +851,7 @@ int nvmon_cupti_stopCounters(NvmonDevice_t device)
         NvmonDevice_t device = &nvGroupSet->gpus[i];
         if (device->deviceId != oldDevId)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Change GPU device %d -> %d, oldDevId, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Change GPU device %d -> %d", oldDevId, device->deviceId);
             CUDA_CALL((*cudaSetDevicePtr)(device->deviceId), return -EFAULT);
             CUDA_CALL((*cudaGetDevicePtr)(&oldDevId), return -EFAULT);
         }
@@ -859,7 +859,7 @@ int nvmon_cupti_stopCounters(NvmonDevice_t device)
         NvmonEventSet* nvEventSet = &device->nvEventSets[nvGroupSet->activeGroup];
         if (device->numActiveCuGroups == 0)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DETAIL, Skipping GPU%d it has no events in group %d, device->deviceId, nvGroupSet->activeGroup);
+            GPUDEBUG_PRINT(DEBUGLEV_DETAIL, "Skipping GPU%d it has no events in group %d", device->deviceId, nvGroupSet->activeGroup);
             continue;
         }
         device->timeStop = timestamp;
@@ -878,7 +878,7 @@ int nvmon_cupti_stopCounters(NvmonDevice_t device)
             NvmonActiveEvent_t event = &device->activeEvents[j];
             valuesSize = sizeof(uint64_t) * event->numTotalInstances;
             memset(tmpValues, 0, valuesSize);
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Read Grp %ld Ev %ld for device %d, event->cuGroup, event->cuEventId, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Read Grp %ld Ev %ld for device %d", event->cuGroup, event->cuEventId, device->deviceId);
             CUPTI_CALL((*cuptiEventGroupReadEventPtr)(event->cuGroup, CUPTI_EVENT_READ_FLAG_NONE, event->cuEventId, &valuesSize, tmpValues), free(tmpValues); return -EFAULT);
             uint64_t valuesum = 0;
             for (unsigned k = 0; k < event->numInstances; k++)
@@ -894,13 +894,13 @@ int nvmon_cupti_stopCounters(NvmonDevice_t device)
         }
         for (int j = 0; j < device->numActiveCuGroups; j++)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Disable group %ld, device->activeCuGroups[j]);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Disable group %ld", device->activeCuGroups[j]);
             CUPTI_CALL((*cuptiEventGroupSetDisablePtr)(device->activeCuGroups[j]), return -EFAULT);
         }
         // If we added the device context to the stack, pop it again
         if (popContext)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
             CU_CALL((*cuCtxPopCurrentPtr)(&device->context), return -EFAULT);
         }
     }
@@ -928,7 +928,7 @@ int nvmon_cupti_readCounters(NvmonDevice_t device)
     uint64_t *tmpValues = (uint64_t *) malloc(valuesSize);
     if (!tmpValues)
     {
-        ERROR_PRINT(Not enough memory to allocate space for instance values);
+        ERROR_PRINT("Not enough memory to allocate space for instance values");
         return -ENOMEM;
     }
 
@@ -944,12 +944,12 @@ int nvmon_cupti_readCounters(NvmonDevice_t device)
     int popContext = 0;
     if (device->numActiveEvents == 0)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DETAIL, Skipping GPU%d it has no events in group %d, device->deviceId, nvGroupSet->activeGroup);
+        GPUDEBUG_PRINT(DEBUGLEV_DETAIL, "Skipping GPU%d it has no events in group %d", device->deviceId, nvGroupSet->activeGroup);
         return 0;
     }
     if (device->deviceId != oldDevId)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Change GPU device %d -> %d, oldDevId, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Change GPU device %d -> %d", oldDevId, device->deviceId);
         CUDA_CALL((*cudaSetDevicePtr)(device->deviceId), return -EFAULT);
         CUDA_CALL((*cudaGetDevicePtr)(&oldDevId), return -EFAULT);
     }
@@ -971,7 +971,7 @@ int nvmon_cupti_readCounters(NvmonDevice_t device)
         valuesSize = sizeof(uint64_t) * event->numTotalInstances;
         memset(tmpValues, 0, valuesSize);
         // Read all instance values
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Read Grp %ld Ev %ld for device %d, event->cuGroup, event->cuEventId, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Read Grp %ld Ev %ld for device %d", event->cuGroup, event->cuEventId, device->deviceId);
         CUPTI_CALL((*cuptiEventGroupReadEventPtr)(event->cuGroup, CUPTI_EVENT_READ_FLAG_NONE, event->cuEventId, &valuesSize, tmpValues), return -EFAULT);
         // Sum all instance values
         uint64_t valuesum = 0;
@@ -988,7 +988,7 @@ int nvmon_cupti_readCounters(NvmonDevice_t device)
     }
     if (popContext)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
         CU_CALL((*cuCtxPopCurrentPtr)(&device->context), return -EFAULT);
     }
     free(tmpValues);

--- a/src/includes/nvmon_perfworks.h
+++ b/src/includes/nvmon_perfworks.h
@@ -53,7 +53,7 @@ static void *dl_perfworks_libcudart = NULL;
   do {                                                                         \
     CUresult _status = (call);                                                 \
     if (_status != CUDA_SUCCESS) {                                             \
-      ERROR_PRINT(Function % s failed with error % d, #call, _status);         \
+      ERROR_PRINT("Function %s failed with error %d", #call, _status);         \
       handleerror;                                                             \
     }                                                                          \
   } while (0)
@@ -62,7 +62,7 @@ static void *dl_perfworks_libcudart = NULL;
   do {                                                                         \
     NVPA_Status _status = (call);                                              \
     if (_status != NVPA_STATUS_SUCCESS) {                                      \
-      ERROR_PRINT(Function % s failed with error % d, #call, _status);         \
+      ERROR_PRINT("Function %s failed with error %d", #call, _status);         \
       handleerror;                                                             \
     }                                                                          \
   } while (0)
@@ -71,12 +71,12 @@ static void *dl_perfworks_libcudart = NULL;
   do {                                                                         \
     CUptiResult _status = (call);                                              \
     if (_status != CUPTI_SUCCESS) {                                            \
-      ERROR_PRINT(Function % s failed with error % d, #call, _status);         \
+      ERROR_PRINT("Function %s failed with error %d", #call, _status);         \
       if (cuptiGetResultStringPtr) {                                           \
         const char *es = NULL;                                                 \
         (*cuptiGetResultStringPtr)(_status, &es);                              \
         if (es)                                                                \
-          ERROR_PRINT(% s, es);                                                \
+          ERROR_PRINT("%s", es);                                               \
       }                                                                        \
       handleerror;                                                             \
     }                                                                          \
@@ -86,7 +86,7 @@ static void *dl_perfworks_libcudart = NULL;
   do {                                                                         \
     cudaError_t _status = (call);                                              \
     if (_status != cudaSuccess) {                                              \
-      ERROR_PRINT(Function %s failed with error %d, #call, _status);          \
+      ERROR_PRINT("Function %s failed with error %d", #call, _status);         \
       handleerror;                                                             \
     }                                                                          \
   } while (0)
@@ -666,12 +666,12 @@ static int link_perfworks_libraries(void) {
         snprintf(libnvperfpath, sizeof(libnvperfpath), "libnvperf_host.so");
         snprintf(libcuptipath, sizeof(libcuptipath), "libcupti.so");
     }
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, LD_LIBRARY_PATH = % s,
-            getenv("LD_LIBRARY_PATH"))
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, CUDA_HOME = % s, getenv("CUDA_HOME"))
-        dl_perfworks_libcuda = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "LD_LIBRARY_PATH = %s",
+            getenv("LD_LIBRARY_PATH"));
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "CUDA_HOME = %s", getenv("CUDA_HOME"));
+    dl_perfworks_libcuda = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
     if (!dl_perfworks_libcuda || dlerror() != NULL) {
-        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcuda.so not found);
+        DEBUG_PRINT(DEBUGLEV_INFO, "CUDA library libcuda.so not found");
         return -1;
     }
     cuCtxGetCurrentPtr = DLSYM_AND_CHECK(dl_perfworks_libcuda, "cuCtxGetCurrent");
@@ -696,7 +696,7 @@ static int link_perfworks_libraries(void) {
     dl_perfworks_libcudart =
         dlopen(libcudartpath, RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
     if ((!dl_perfworks_libcudart) || (dlerror() != NULL)) {
-        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcudart.so not found);
+        DEBUG_PRINT(DEBUGLEV_INFO, "CUDA library libcudart.so not found");
         return -1;
     }
     cudaGetDevicePtr = DLSYM_AND_CHECK(dl_perfworks_libcudart, "cudaGetDevice");
@@ -715,7 +715,7 @@ static int link_perfworks_libraries(void) {
         dl_libhost =
             dlopen("libnvperf_host.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
         if ((!dl_libhost) || (dlerror() != NULL)) {
-            DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libnvperf_host.so not found);
+            DEBUG_PRINT(DEBUGLEV_INFO, "CUDA library libnvperf_host.so not found");
             return -1;
         }
     }
@@ -801,7 +801,7 @@ static int link_perfworks_libraries(void) {
     if ((!dl_cupti) || (dlerror() != NULL)) {
         dl_cupti = dlopen("libcupti.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
         if ((!dl_cupti) || (dlerror() != NULL)) {
-            DEBUG_PRINT(DEBUGLEV_INFO, CUpti library libcupti.so not found);
+            DEBUG_PRINT(DEBUGLEV_INFO, "CUpti library libcupti.so not found");
             return -1;
         }
     }
@@ -854,21 +854,21 @@ static int link_perfworks_libraries(void) {
 
     dlerror();
     int curDeviceId = -1;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Run cuInit);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Run cuInit");
     LIKWID_CU_CALL(cuInitPtr(0), return -EFAULT);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Run cuDeviceGetCount);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Run cuDeviceGetCount");
     LIKWID_CU_CALL(cuDeviceGetCountPtr(&curDeviceId), return -EFAULT);
-    // GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Run cudaGetDevice);
+    // GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Run cudaGetDevice");
     // LIKWID_CUDA_API_CALL(cudaGetDevicePtr(&curDeviceId), return -EFAULT);
     CUdevice dev;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Run cuDeviceGet);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Run cuDeviceGet");
     LIKWID_CU_CALL(cuDeviceGetPtr(&dev, 0), return -EFAULT);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Run cuDeviceGetAttribute for major CC);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Run cuDeviceGetAttribute for major CC");
     LIKWID_CU_CALL(
             cuDeviceGetAttributePtr(
                 &curDeviceId, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, dev),
             return -EFAULT);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Run cuDeviceGetAttribute for minor CC);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Run cuDeviceGetAttribute for minor CC");
     LIKWID_CU_CALL(
             cuDeviceGetAttributePtr(
                 &curDeviceId, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, dev),
@@ -895,7 +895,7 @@ static int link_perfworks_libraries(void) {
 }
 
 static void release_perfworks_libraries(void) {
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Finalize PerfWorks Libaries);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Finalize PerfWorks Libaries");
     if (dl_perfworks_libcuda) {
         dlclose(dl_perfworks_libcuda);
         dl_perfworks_libcuda = NULL;
@@ -917,7 +917,7 @@ static void release_perfworks_libraries(void) {
 static int perfworks_check_nv_context(NvmonDevice_t device,
                                       CUcontext currentContext) {
     int need_pop = 0;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Current context % ld DevContext % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Current context %ld DevContext %ld",
             currentContext, device->context);
     if (!device->context) {
         int context_of_dev = -1;
@@ -931,28 +931,28 @@ static int perfworks_check_nv_context(NvmonDevice_t device,
         if (context_of_dev < 0) // && !device->context)
         {
             device->context = currentContext;
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Reuse context %ld for device %d, device->context, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Reuse context %ld for device %d", device->context, device->deviceId);
         } else {
             LIKWID_CUDA_API_CALL(cudaSetDevicePtr(device->deviceId), return -EFAULT);
             LIKWID_CUDA_API_CALL(cudaFreePtr(NULL), return -EFAULT);
             LIKWID_CU_CALL(
                     cuDevicePrimaryCtxRetainPtr(&device->context, device->cuDevice),
                     return -EFAULT);
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, New context %ld for device %d, device->context, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "New context %ld for device %d", device->context, device->deviceId);
         }
     } else if (device->context != currentContext) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Use context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Use context %ld for device %d", device->context, device->deviceId);
         LIKWID_CU_CALL(cuCtxPushCurrentPtr(device->context), return -EFAULT);
         need_pop = 1;
     } else {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Context %ld fits for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Context %ld fits for device %d", device->context, device->deviceId);
     }
     return need_pop;
 }
 
 static int cuptiProfiler_init() {
     if (!cuptiProfiler_initialized) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Init CUpti Profiler);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Init CUpti Profiler");
         if (dl_perfworks_libcuda == NULL || dl_perfworks_libcudart == NULL ||
                 dl_libhost == NULL || dl_cupti == NULL) {
             if (link_perfworks_libraries() < 0)
@@ -977,7 +977,7 @@ static int cuptiProfiler_init() {
 
 static void cuptiProfiler_finalize() {
     if (cuptiProfiler_initialized) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Finalize CUpti Profiler);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Finalize CUpti Profiler");
         CUpti_Profiler_DeInitialize_Params profilerDeInitializeParams = {
             .structSize = CUpti_Profiler_DeInitialize_Params_STRUCT_SIZE,
         };
@@ -1152,7 +1152,7 @@ static int nvmon_perfworks_getChipName(int id, char **name) {
         .deviceIndex = id,
     };
     LIKWID_CUPTI_API_CALL(cuptiDeviceGetChipNamePtr(&getChipNameParams), return -ENODEV);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Current GPU chip %s,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Current GPU chip %s",
                    getChipNameParams.pChipName);
     *name = strdup(getChipNameParams.pChipName);
     if (!name)
@@ -1223,7 +1223,7 @@ static int nvmon_perfworks_populateEvents_nvpw(NvmonDevice *dev) {
     };
     LIKWID_NVPW_API_CALL(
         NVPW_CUDA_MetricsContext_CreatePtr(&metricsContextCreateParams), return -EPERM);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, NVPW Metrics Context created, dev->deviceId);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "NVPW Metrics Context created", dev->deviceId);
 
     NVPW_MetricsContext_GetMetricNames_Begin_Params getMetricNameBeginParams = {
         .structSize = NVPW_MetricsContext_GetMetricNames_Begin_Params_STRUCT_SIZE,
@@ -1234,7 +1234,7 @@ static int nvmon_perfworks_populateEvents_nvpw(NvmonDevice *dev) {
         // .hidePctOfPeakSubMetricsOnThroughputs = 1,
     };
     int err = 0;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Create metric context getMetricNames);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Create metric context getMetricNames");
     LIKWID_NVPW_API_CALL(NVPW_MetricsContext_GetMetricNames_BeginPtr(
                              &getMetricNameBeginParams), err = -EPERM; goto deinit);
 
@@ -1243,7 +1243,7 @@ static int nvmon_perfworks_populateEvents_nvpw(NvmonDevice *dev) {
             getMetricNameBeginParams.numMetrics);
 
     /* Cleanup NVPW stuff */
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Destroy metric context getMetricNames);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Destroy metric context getMetricNames");
     NVPW_MetricsContext_GetMetricNames_End_Params getMetricNameEndParams = {
         .structSize = NVPW_MetricsContext_GetMetricNames_End_Params_STRUCT_SIZE,
         .pMetricsContext = metricsContextCreateParams.pMetricsContext,
@@ -1252,7 +1252,7 @@ static int nvmon_perfworks_populateEvents_nvpw(NvmonDevice *dev) {
         NVPW_MetricsContext_GetMetricNames_EndPtr(&getMetricNameEndParams),);
 
 deinit:
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Destroy metric context);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Destroy metric context");
     NVPW_MetricsContext_Destroy_Params metricsContextDestroyParams = {
         .structSize = NVPW_MetricsContext_Destroy_Params_STRUCT_SIZE,
         .pMetricsContext = metricsContextCreateParams.pMetricsContext,
@@ -1298,7 +1298,7 @@ static int nvmon_perfworks_populateEvents_cuptiProfilerHost(NvmonDevice *dev) {
     };
     LIKWID_CUPTI_API_CALL(cuptiProfilerHostInitializePtr(&initParams), return -EPERM);
     CUpti_Profiler_Host_Object *hobj = initParams.pHostObject;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, CUDA12.6+ CUPTI Profiler Host created, dev->deviceId);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "CUDA12.6+ CUPTI Profiler Host created", dev->deviceId);
 
     /* Get base metrics. */
     static const char *suffixesCnt[] = { "avg", "max", "min", "sum" };
@@ -1333,7 +1333,7 @@ static int nvmon_perfworks_populateEvents_cuptiProfilerHost(NvmonDevice *dev) {
     if (err < 0)
         goto deinit;
 
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Got supported metrics list, dev->deviceId);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Got supported metrics list", dev->deviceId);
 
     /* hopefully CUPTI auto frees ppMetricNames on deinit, because it does not
      * appear to have an explicit free functions. */
@@ -1351,7 +1351,7 @@ deinit:
 static int nvmon_perfworks_createDevice(int id, NvmonDevice *dev) {
     if (dl_perfworks_libcuda == NULL || dl_perfworks_libcudart == NULL ||
             dl_libhost == NULL || dl_cupti == NULL) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, link_perfworks_libraries in createDevice);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "link_perfworks_libraries in createDevice");
         int err = link_perfworks_libraries();
         if (err < 0)
             return err;
@@ -1367,7 +1367,7 @@ static int nvmon_perfworks_createDevice(int id, NvmonDevice *dev) {
         printf("GPU %d not available\n", id);
         return -1;
     }
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Found % d GPUs, count);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Found %d GPUs", count);
 
     // Assign device ID and get cuDevice from CUDA
     CU_CALL(cuDeviceGetPtr(&dev->cuDevice, id), return -1);
@@ -1375,7 +1375,7 @@ static int nvmon_perfworks_createDevice(int id, NvmonDevice *dev) {
     dev->context = NULL;
 
     /* initialize */
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Current GPU % d, id);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Current GPU %d", id);
     CUpti_Profiler_Initialize_Params profilerInitializeParams = {
         .structSize = CUpti_Profiler_Initialize_Params_STRUCT_SIZE,
     };
@@ -1393,7 +1393,7 @@ static int nvmon_perfworks_createDevice(int id, NvmonDevice *dev) {
         return err;
 
     /* Get events. Different implementation for different CUDA versions. */
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Get events for chip '%s', dev->chip);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Get events for chip '%s'", dev->chip);
     dev->allevents = NULL;
     dev->numAllEvents = 0;
     if (cuda_runtime_version >= 12060)
@@ -1411,7 +1411,7 @@ int nvmon_perfworks_getEventsOfGpu(int gpuId, NvmonEventList_t *list) {
     NvmonDevice device;
     int err = nvmon_perfworks_createDevice(gpuId, &device);
     if (err < 0) {
-        ERROR_PRINT(No such device %d, gpuId);
+        ERROR_PRINT("No such device %d", gpuId);
         return err;
     }
 
@@ -1481,7 +1481,7 @@ static int nvmon_perfworks_getMetricRequests114(
             NVPW_CUDA_MetricsEvaluator_CalculateScratchBufferSizePtr(
                 &calculateScratchBufferSizeParam),
             return -1);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Create scratch buffer for %s and %p, chip, availImage);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Create scratch buffer for %s and %p", chip, availImage);
     uint8_t *scratch =
         malloc(calculateScratchBufferSizeParam.scratchBufferSize);
     if (!scratch)
@@ -1494,7 +1494,7 @@ static int nvmon_perfworks_getMetricRequests114(
         .pChipName = chip,
         .pCounterAvailabilityImage = availImage,
     };
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Init Metric evaluator);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Init Metric evaluator");
     LIKWID_NVPW_API_CALL(NVPW_CUDA_MetricsEvaluator_InitializePtr(
                 &metricEvaluatorInitializeParams),
             free(scratch);
@@ -1598,7 +1598,7 @@ static int nvmon_perfworks_getMetricRequests114(
             raw_metrics++;
         }
     }
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Destroy Metric evaluator);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Destroy Metric evaluator");
     NVPW_MetricsEvaluator_Destroy_Params metricEvaluatorDestroyParams = {
         .structSize = NVPW_MetricsEvaluator_Destroy_Params_STRUCT_SIZE,
         .pMetricsEvaluator = metricEvaluator,
@@ -1706,7 +1706,7 @@ static int nvmon_perfworks_getMetricRequests(NVPA_MetricsContext *context,
         // nvmon_perfworks_parse_metric(events->entry[i], &isolated,
         // &keepInstances);
         //keepInstances = 1; /* Bug in Nvidia API */
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Metric % s, bdata(events->entry[i]));
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Metric %s", bdata(events->entry[i]));
         NVPW_MetricsContext_GetMetricProperties_Begin_Params
             getMetricPropertiesBeginParams = {
                 .structSize = NVPW_MetricsContext_GetMetricProperties_Begin_Params_STRUCT_SIZE,
@@ -1722,7 +1722,7 @@ static int nvmon_perfworks_getMetricRequests(NVPA_MetricsContext *context,
         for (const char **dep =
                 getMetricPropertiesBeginParams.ppRawMetricDependencies;
                 *dep; ++dep) {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Metric depend % s, *dep);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Metric depend %s", *dep);
             bstrListAddChar(temp, (char *)*dep);
         }
 
@@ -1753,7 +1753,7 @@ static int nvmon_perfworks_getMetricRequests(NVPA_MetricsContext *context,
         }
         req->structSize = NVPA_RAW_METRIC_REQUEST_STRUCT_SIZE;
         req->pMetricName = s;
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Metric Request % s, s);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Metric Request %s", s);
         req->isolated = isolated;
         req->keepInstances = keepInstances;
         num_reqs++;
@@ -1780,13 +1780,13 @@ static int nvmon_perfworks_createConfigImage(const char *chip,
     NVPA_RawMetricRequest *reqs = NULL;
     NVPA_RawMetricsConfig *pRawMetricsConfig = NULL;
     if (cuda_runtime_version < 11040 && NVPA_RawMetricsConfig_CreatePtr) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Create Metrics Context);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Create Metrics Context");
         LIKWID_NVPW_API_CALL(
                 NVPW_CUDA_MetricsContext_CreatePtr(&metricsContextCreateParams),
                 return -1;);
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Create config image for chip %s, chip);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Create config image for chip %s", chip);
         num_reqs = nvmon_perfworks_getMetricRequests3(metricsContextCreateParams.pMetricsContext, events, &reqs);
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Create config image for chip %s with %d metric requests, chip, num_reqs);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Create config image for chip %s with %d metric requests", chip, num_reqs);
 
         NVPA_RawMetricsConfigOptions metricsConfigOptions = {
             .structSize = NVPA_RAW_METRICS_CONFIG_OPTIONS_STRUCT_SIZE,
@@ -1796,9 +1796,9 @@ static int nvmon_perfworks_createConfigImage(const char *chip,
         LIKWID_NVPW_API_CALL(NVPA_RawMetricsConfig_CreatePtr(&metricsConfigOptions, &pRawMetricsConfig), ierr = -1; goto nvmon_perfworks_createConfigImage_out);
     }
     else if (cuda_runtime_version >= 11040 && NVPW_CUDA_RawMetricsConfig_Create_V2Ptr) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Create config image for chip %s, chip);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Create config image for chip %s", chip);
         num_reqs = nvmon_perfworks_getMetricRequests114(chip, events, availImage, &reqs);
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Create config image for chip %s with %d metric requests, chip, num_reqs);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Create config image for chip %s with %d metric requests", chip, num_reqs);
 
         NVPW_CUDA_RawMetricsConfig_Create_V2_Params rawMetricsConfigCreateParams = {
             .structSize = NVPW_CUDA_RawMetricsConfig_Create_V2_Params_STRUCT_SIZE,
@@ -1866,8 +1866,8 @@ static int nvmon_perfworks_createConfigImage(const char *chip,
             1) {
         errno = 1; // why do we set errno here an nowhere else ???
         ierr = -errno;
-        ERROR_PRINT(Given GPU eventset requires multiple passes
-                .Currently not supported.);
+        ERROR_PRINT("Given GPU eventset requires multiple passes. "
+                "Currently not supported.");
         goto nvmon_perfworks_createConfigImage_out;
     }
 
@@ -1898,7 +1898,7 @@ static int nvmon_perfworks_createConfigImage(const char *chip,
         goto nvmon_perfworks_createConfigImage_out;
     }
     int ci_size = getConfigImageParams.bytesCopied;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Allocated %d byte for configImage, ci_size);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Allocated %d byte for configImage", ci_size);
 
     getConfigImageParams.bytesAllocated = getConfigImageParams.bytesCopied;
     getConfigImageParams.pBuffer = cimage;
@@ -1909,8 +1909,8 @@ static int nvmon_perfworks_createConfigImage(const char *chip,
 
 nvmon_perfworks_createConfigImage_out:
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP,
-            nvmon_perfworks_createConfigImage_out enter % d, ierr);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, NVPW_RawMetricsConfig_Destroy);
+            "nvmon_perfworks_createConfigImage_out enter %d", ierr);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "NVPW_RawMetricsConfig_Destroy");
     NVPW_RawMetricsConfig_Destroy_Params rawMetricsConfigDestroyParams = {
         .structSize = NVPW_RawMetricsConfig_Destroy_Params_STRUCT_SIZE,
         .pRawMetricsConfig = pRawMetricsConfig,
@@ -1920,7 +1920,7 @@ nvmon_perfworks_createConfigImage_out:
             return -1;);
 
     if (metricsContextCreateParams.pMetricsContext) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, NVPW_MetricsContext_Destroy);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "NVPW_MetricsContext_Destroy");
         NVPW_MetricsContext_Destroy_Params metricsContextDestroyParams = {
             .structSize = NVPW_MetricsContext_Destroy_Params_STRUCT_SIZE,
             .pMetricsContext = metricsContextCreateParams.pMetricsContext,
@@ -1942,7 +1942,7 @@ nvmon_perfworks_createConfigImage_out:
     }
 
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP,
-            nvmon_perfworks_createConfigImage returns % d, ierr);
+            "nvmon_perfworks_createConfigImage returns %d", ierr);
     return ierr;
 }
 
@@ -2006,7 +2006,7 @@ static int nvmon_perfworks_createCounterDataPrefixImage(
         goto nvmon_perfworks_createCounterDataPrefixImage_out;
     }
     int pi_size = getCounterDataPrefixParams.bytesCopied;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Allocated %d byte for configPrefixImage, pi_size);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Allocated %d byte for configPrefixImage", pi_size);
 
     getCounterDataPrefixParams.bytesAllocated =
         getCounterDataPrefixParams.bytesCopied + 10; // why +10?
@@ -2019,7 +2019,7 @@ static int nvmon_perfworks_createCounterDataPrefixImage(
 
 nvmon_perfworks_createCounterDataPrefixImage_out:
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP,
-                   nvmon_perfworks_createCounterDataPrefixImage_out enter % d,
+                   "nvmon_perfworks_createCounterDataPrefixImage_out enter %d",
                    err);
     // for (i = 0; i < num_reqs; i++)
     // {
@@ -2056,7 +2056,7 @@ nvmon_perfworks_createCounterDataPrefixImage_out:
         free(cdp);
     }
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP,
-                   nvmon_perfworks_createCounterDataPrefixImage returns % d,
+                   "nvmon_perfworks_createCounterDataPrefixImage returns %d",
                    err);
     return err;
 }
@@ -2074,11 +2074,11 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
     CUcontext curContext;
     LIKWID_CU_CALL(cuCtxGetCurrentPtr(&curContext), return -EFAULT);
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP,
-            Add events to GPU device % d with context % u,
+            "Add events to GPU device %d with context %u",
             device->deviceId, curContext);
 
     if (curDeviceId != device->deviceId) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Switching to GPU device % d,
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Switching to GPU device %d",
                 device->deviceId);
         LIKWID_CUDA_API_CALL(cudaSetDevicePtr(device->deviceId),
                 return -EFAULT);
@@ -2087,7 +2087,7 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
     int popContext = perfworks_check_nv_context(device, curContext);
     if (popContext < 0) {
         errno = -popContext;
-        ERROR_PRINT(Failed to get context);
+        ERROR_PRINT("Failed to get context");
     }
 
     bstring eventBString = bfromcstr(eventString);
@@ -2103,13 +2103,13 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
 
     for (int i = 0; i < tmp->qty; i++) {
         struct bstrList *parts = bsplit(tmp->entry[i], ':');
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, % s, bdata(parts->entry[0]));
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(parts->entry[0]));
         for (int j = 0; j < device->numAllEvents; j++) {
             bstring bname = bfromcstr(device->allevents[j]->name);
             if (bstrcmp(parts->entry[0], bname) == BSTR_OK) {
                 bstrListAddChar(eventtokens, device->allevents[j]->real);
                 nvEvents[i] = device->allevents[j];
-                GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Adding real event % s,
+                GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding real event %s",
                         device->allevents[j]->real);
             }
         }
@@ -2117,14 +2117,14 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
     }
     bstrListDestroy(tmp);
     if (eventtokens->qty == 0) {
-        ERROR_PRINT(No event in eventset);
+        ERROR_PRINT("No event in eventset");
         bstrListDestroy(eventtokens);
         if (popContext > 0) {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
             LIKWID_CU_CALL(cuCtxPopCurrentPtr(&device->context), return -EFAULT);
         }
         if (curDeviceId != device->deviceId) {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Switching to GPU device % d,
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Switching to GPU device %d",
                     device->deviceId);
             LIKWID_CUDA_API_CALL(cudaSetDevicePtr(device->deviceId),
                     return -EFAULT);
@@ -2133,19 +2133,19 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
     }
 
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP,
-            Increase size of eventSet space on device % d,
+            "Increase size of eventSet space on device %d",
             device->deviceId);
     NvmonEventSet *tmpEventSet =
         realloc(device->nvEventSets,
                 (device->numNvEventSets + 1) * sizeof(NvmonEventSet));
     if (!tmpEventSet) {
-        ERROR_PRINT(Cannot enlarge GPU % d eventSet list, device->deviceId);
+        ERROR_PRINT("Cannot enlarge GPU %d eventSet list", device->deviceId);
         bstrListDestroy(eventtokens);
         return -ENOMEM;
     }
     device->nvEventSets = tmpEventSet;
     NvmonEventSet *newEventSet = &device->nvEventSets[device->numNvEventSets];
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Filling eventset % d on device % d,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Filling eventset %d on device %d",
             device->numNvEventSets, device->deviceId);
 
     size_t availImageSize = 0;
@@ -2181,7 +2181,7 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
     int pi_size = nvmon_perfworks_createCounterDataPrefixImage(
             device->chip, eventtokens, &prefixImage);
 
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Filling eventset % d on device % d,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Filling eventset %d on device %d",
             device->numNvEventSets, device->deviceId);
 
     int gid = -1;
@@ -2202,7 +2202,7 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
         gid = device->numNvEventSets;
         newEventSet->nvEvents = calloc(eventtokens->qty, sizeof(NvmonEvent_t));
         if (newEventSet->nvEvents == NULL) {
-            ERROR_PRINT(Cannot allocate event list for group %d\n, gid);
+            ERROR_PRINT("Cannot allocate event list for group %d", gid);
             return -ENOMEM;
         }
         for (int i = 0; i < eventtokens->qty; i++) {
@@ -2215,16 +2215,16 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
         }
         newEventSet->results = calloc(eventtokens->qty, sizeof(NvmonEventResult));
         if (newEventSet->results == NULL) {
-            ERROR_PRINT(Cannot allocate result list for group %d\n, gid);
+            ERROR_PRINT("Cannot allocate result list for group %d", gid);
             return -ENOMEM;
         }
         newEventSet->nvEvents = nvEvents;
         device->numNvEventSets++;
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Adding eventset % d, gid);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding eventset %d", gid);
     }
 
     if (popContext > 0) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
         LIKWID_CU_CALL(cuCtxPopCurrentPtr(&device->context), return -EFAULT);
     }
     if (curDeviceId != device->deviceId) {
@@ -2234,7 +2234,7 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
 }
 
 static int nvmon_perfworks_setupCounterImageData(NvmonEventSet *eventSet) {
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, counterDataPrefixSize % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "counterDataPrefixSize %ld",
             eventSet->counterDataImagePrefixSize);
 
     CUpti_Profiler_CounterDataImageOptions counterDataImageOptions = {
@@ -2253,7 +2253,7 @@ static int nvmon_perfworks_setupCounterImageData(NvmonEventSet *eventSet) {
             cuptiProfilerCounterDataImageCalculateSizePtr(&calculateSizeParams),
             return -EFAULT);
 
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Resize counterDataImage to % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Resize counterDataImage to %ld",
             calculateSizeParams.counterDataImageSize);
     uint8_t *tmp = realloc(eventSet->counterDataImage,
             calculateSizeParams.counterDataImageSize);
@@ -2262,7 +2262,7 @@ static int nvmon_perfworks_setupCounterImageData(NvmonEventSet *eventSet) {
 
     eventSet->counterDataImage = tmp;
     eventSet->counterDataImageSize = calculateSizeParams.counterDataImageSize;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Resized counterDataImage to % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Resized counterDataImage to %ld",
             eventSet->counterDataImageSize);
 
     CUpti_Profiler_CounterDataImage_Initialize_Params initializeParams = {
@@ -2287,7 +2287,7 @@ static int nvmon_perfworks_setupCounterImageData(NvmonEventSet *eventSet) {
                 &scratchBufferSizeParams),
             return -EFAULT);
 
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Resize counterDataScratchBuffer to % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Resize counterDataScratchBuffer to %ld",
             scratchBufferSizeParams.counterDataScratchBufferSize);
     tmp = realloc(eventSet->counterDataScratchBuffer,
             scratchBufferSizeParams.counterDataScratchBufferSize);
@@ -2297,7 +2297,7 @@ static int nvmon_perfworks_setupCounterImageData(NvmonEventSet *eventSet) {
     eventSet->counterDataScratchBuffer = tmp;
     eventSet->counterDataScratchBufferSize =
         scratchBufferSizeParams.counterDataScratchBufferSize;
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Resized counterDataScratchBuffer to % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Resized counterDataScratchBuffer to %ld",
             eventSet->counterDataScratchBufferSize);
 
     CUpti_Profiler_CounterDataImage_InitializeScratchBuffer_Params
@@ -2398,8 +2398,8 @@ static int nvmon_perfworks_getMetricValue12(
     };
     LIKWID_NVPW_API_CALL(NVPW_MetricsEvaluator_EvaluateToGpuValuesPtr(&evalParams), err = -EPERM; goto cleanup);
     for (int i = 0; i < eventSet->events->qty; i++) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Final Eval %s
-                : %f, bdata(eventSet->events->entry[i]), gpuValues[i]);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Final Eval %s: %f",
+                bdata(eventSet->events->entry[i]), gpuValues[i]);
     }
     *values = gpuValues;
 cleanup:
@@ -2476,8 +2476,8 @@ static int nvmon_perfworks_getMetricValue11(
     //     r->values[j] += gpuValues[j];
     // }
     for (int j = 0; j < eventSet->events->qty; j++) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Final Eval % s
-                : % f, bdata(eventSet->events->entry[j]), gpuValues[j]);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Final Eval %s: %f",
+                bdata(eventSet->events->entry[j]), gpuValues[j]);
     }
     *values = gpuValues;
 
@@ -2522,9 +2522,9 @@ static int nvmon_perfworks_setupCounters(NvmonDevice_t device,
     int popContext = perfworks_check_nv_context(device, curContext);
     if (popContext < 0) {
         errno = -popContext;
-        ERROR_PRINT(Failed to get context)
+        ERROR_PRINT("Failed to get context");
     }
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Setup Counters on device % d,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Setup Counters on device %d",
             device->deviceId);
 
     // cuptiProfiler_init();
@@ -2533,7 +2533,7 @@ static int nvmon_perfworks_setupCounters(NvmonDevice_t device,
     device->activeEventSet = eventSet->id;
     nvGroupSet->activeGroup = eventSet->id;
     if (popContext > 0) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
         LIKWID_CU_CALL(cuCtxPopCurrentPtr(&device->context), return -EFAULT);
     }
     if (curDeviceId != device->deviceId) {
@@ -2555,10 +2555,10 @@ static int nvmon_perfworks_startCounters(NvmonDevice_t device) {
     int popContext = perfworks_check_nv_context(device, curContext);
     if (popContext < 0) {
         errno = -popContext;
-        ERROR_PRINT(Failed to get context)
+        ERROR_PRINT("Failed to get context");
     }
 
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Start Counters on device % d(Eventset % d),
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Start Counters on device %d (Eventset %d)",
             device->deviceId, device->activeEventSet);
     NvmonEventSet *eventSet = &device->nvEventSets[device->activeEventSet];
 
@@ -2574,9 +2574,9 @@ static int nvmon_perfworks_startCounters(NvmonDevice_t device) {
         .maxRangesPerPass = 1,
         .maxLaunchesPerPass = 1,
     };
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, (START)counterDataImageSize % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "(START)counterDataImageSize %ld",
             eventSet->counterDataImageSize);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, (START)counterDataScratchBufferSize % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "(START)counterDataScratchBufferSize %ld",
             eventSet->counterDataScratchBufferSize);
     LIKWID_CUPTI_API_CALL(cuptiProfilerBeginSessionPtr(&beginSessionParams), return -1);
 
@@ -2593,7 +2593,7 @@ static int nvmon_perfworks_startCounters(NvmonDevice_t device) {
         .passIndex = 0,
         .targetNestingLevel = 1,
     };
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, (START)configImage % ld,
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "(START)configImage %ld",
             eventSet->configImageSize);
     LIKWID_CUPTI_API_CALL(cuptiProfilerSetConfigPtr(&setConfigParams), return -1);
 
@@ -2617,7 +2617,7 @@ static int nvmon_perfworks_startCounters(NvmonDevice_t device) {
     LIKWID_CUPTI_API_CALL(cuptiProfilerPushRangePtr(&pushRangeParams), return -1);
 
     if (popContext > 0) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
         LIKWID_CU_CALL(cuCtxPopCurrentPtr(&device->context), return -EFAULT);
     }
     if (curDeviceId != device->deviceId) {
@@ -2642,9 +2642,9 @@ static int nvmon_perfworks_stopCounters(NvmonDevice_t device) {
     int popContext = perfworks_check_nv_context(device, curContext);
     if (popContext < 0) {
         errno = -popContext;
-        ERROR_PRINT(Failed to get context);
+        ERROR_PRINT("Failed to get context");
     }
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Stop Counters on device % d(Eventset % d),
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Stop Counters on device %d (Eventset %d)",
             device->deviceId, device->activeEventSet);
     NvmonEventSet *eventSet = &device->nvEventSets[device->activeEventSet];
 
@@ -2684,8 +2684,8 @@ static int nvmon_perfworks_stopCounters(NvmonDevice_t device) {
     LIKWID_CUPTI_API_CALL(cuptiProfilerEndPassPtr(&endPassParams),
             return -1);
     if (endPassParams.allPassesSubmitted != 1) {
-        ERROR_PRINT(Events cannot be measured in a single pass and
-                multi - pass / kernel replay is current not supported);
+        ERROR_PRINT("Events cannot be measured in a single pass and "
+                "multi - pass / kernel replay is current not supported");
     }
     CUpti_Profiler_FlushCounterData_Params flushCounterDataParams = {
         .structSize = CUpti_Profiler_FlushCounterData_Params_size,
@@ -2708,7 +2708,7 @@ static int nvmon_perfworks_stopCounters(NvmonDevice_t device) {
     };
     LIKWID_CUPTI_API_CALL(cuptiProfilerEndSessionPtr(&endSessionParams),
             return -1);
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Get results on device % d(Eventset % d),
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Get results on device %d (Eventset %d)",
             device->deviceId, device->activeEventSet);
 
     double *values;
@@ -2740,14 +2740,14 @@ static int nvmon_perfworks_stopCounters(NvmonDevice_t device) {
         }
         eventSet->results[j].stopValue = eventSet->results[j].fullValue;
         eventSet->results[j].overflows = 0;
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, % s Last % f Full % f,
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "%s Last %f Full %f",
                 bdata(eventSet->events->entry[j]),
                 eventSet->results[j].lastValue,
                 eventSet->results[j].fullValue);
     }
 
     if (popContext > 0) {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Pop Context %ld for device %d, device->context, device->deviceId);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %ld for device %d", device->context, device->deviceId);
         LIKWID_CU_CALL(cuCtxPopCurrentPtr(&device->context), return -EFAULT);
     }
     if (curDeviceId != device->deviceId) {

--- a/src/includes/perfmon_broadwell.h
+++ b/src/includes/perfmon_broadwell.h
@@ -195,7 +195,7 @@ int bdw_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -204,12 +204,12 @@ int bdw_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -250,7 +250,7 @@ int bdw_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -289,7 +289,7 @@ int bdw_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -363,7 +363,7 @@ int bdwep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     
     if (filter_flags0 != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, SETUP_CBOX_FILTER0);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, "SETUP_CBOX_FILTER0");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags0));
     }
     else
@@ -372,7 +372,7 @@ int bdwep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (filter_flags1 != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, SETUP_CBOX_FILTER1);
+        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, "SETUP_CBOX_FILTER1");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags1));
     }
     else
@@ -384,12 +384,12 @@ int bdwep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags0));
         filter_flags0 |= (0x1F << 17);
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, SETUP_CBOX_DEF_FILTER_STATE);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, "SETUP_CBOX_DEF_FILTER_STATE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags0));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -438,7 +438,7 @@ int bdw_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_OCCUPANCY_FILTER:
                     clean_filter = 0;
-                    VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), SETUP_WBOX_FILTER);
+                    VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), "SETUP_WBOX_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter, (event->options[j].value & 0xFFFFFFFFULL)));
                     break;
                 case EVENT_OPTION_OCCUPANCY_EDGE:
@@ -455,12 +455,12 @@ int bdw_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (clean_filter)
     {
-        VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), CLEAN_WBOX_FILTER);
+        VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), "CLEAN_WBOX_FILTER");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter, 0x0ULL));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_WBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -504,17 +504,17 @@ int bdw_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_OPCODE:
                     VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH,
-                                        (event->options[j].value & 0x3FULL), SETUP_BBOX_OPCODE);
+                                        (event->options[j].value & 0x3FULL), "SETUP_BBOX_OPCODE");
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH,
                                         (event->options[j].value & 0x3FULL)));
                     opcode_flag = 1;
                     break;
                 case EVENT_OPTION_MATCH0:
                     filter = ((event->options[j].value & 0xFFFFFFC0ULL));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter, SETUP_ADDR0_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter, "SETUP_ADDR0_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter));
                     filter = (((event->options[j].value>>32) & 0x3FFFULL));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter, SETUP_ADDR1_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter, "SETUP_ADDR1_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter));
                     match_flag = 1;
                     break;
@@ -525,19 +525,19 @@ int bdw_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (!opcode_flag)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, 0x0ULL, CLEAR_BBOX_OPCODE);
+        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, 0x0ULL, "CLEAR_BBOX_OPCODE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, 0x0ULL));
     }
     if (!match_flag)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, 0x0ULL, CLEAR_BBOX_MATCH0);
+        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, 0x0ULL, "CLEAR_BBOX_MATCH0");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, 0x0ULL));
-        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, 0x0ULL, CLEAR_BBOX_MATCH1);
+        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, 0x0ULL, "CLEAR_BBOX_MATCH1");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, 0x0ULL));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_BBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_BBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -583,7 +583,7 @@ int bdw_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_MBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_MBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -622,7 +622,7 @@ int bdw_mboxfix_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_MBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_MBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -668,7 +668,7 @@ int bdw_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_IBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_IBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -714,11 +714,11 @@ int bdw_pbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_PBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_PBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_PBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_PBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -764,11 +764,11 @@ int bdw_rbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_PBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_PBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_PBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_PBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -816,7 +816,7 @@ int bdw_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_SBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_SBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device, counter_map[index].configRegister, flags));
         flags |= (1ULL<<22);
         /* Due to an issue found with the Intel® Xeon® Processor E5 and E7 v4 Product Families
@@ -824,7 +824,7 @@ int bdw_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
          * the Event Select field to take hold. It is recommended that SW perform the first write
          * with the enable bit set to 0 followed by a write of the same control register value but
          * with the enable bit set to 1.*/
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_SBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_SBOX_TWICE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -874,12 +874,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MATCH_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_RX_MATCH0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_RX_MATCH0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MATCH1:
@@ -887,12 +887,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MATCH_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_RX_MATCH1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_RX_MATCH1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MATCH2:
@@ -900,12 +900,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MATCH_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_TX_MATCH0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_TX_MATCH0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MATCH3:
@@ -913,12 +913,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MATCH_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_TX_MATCH1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_TX_MATCH1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK0:
@@ -926,12 +926,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MASK_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_RX_MASK0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_RX_MASK0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK1:
@@ -939,12 +939,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MASK_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_RX_MASK1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_RX_MASK1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK2:
@@ -952,12 +952,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MASK_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_TX_MASK0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_TX_MASK0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK3:
@@ -965,12 +965,12 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MASK_0;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_QBOX_TX_MASK1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_QBOX_TX_MASK1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 default:
@@ -980,7 +980,7 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_QBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_QBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -990,7 +990,7 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
 #define BDW_FREEZE_UNCORE \
     if (haveLock && MEASURE_UNCORE(eventSet) && (cpuid_info.model == BROADWELL_E || cpuid_info.model == BROADWELL_D)) \
     { \
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<31), FREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<31), "FREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<31))); \
     } \
     else if (haveLock && MEASURE_UNCORE(eventSet) && (cpuid_info.model == BROADWELL || cpuid_info.model == BROADWELL_E3)) \
@@ -1000,7 +1000,7 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
         if (!(data & (1ULL<<29))) \
         { \
             data &= ~(1ULL<<29); \
-            VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, FREEZE_UNCORE); \
+            VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, "FREEZE_UNCORE"); \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, data)); \
         } \
     } \
@@ -1008,7 +1008,7 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
 #define BDW_UNFREEZE_UNCORE \
     if (haveLock && MEASURE_UNCORE(eventSet) && (cpuid_info.model == BROADWELL_E || cpuid_info.model == BROADWELL_D)) \
     { \
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<29), UNFREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<29), "UNFREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<29))); \
     } \
     else if (haveLock && MEASURE_UNCORE(eventSet) && (cpuid_info.model == BROADWELL || cpuid_info.model == BROADWELL_E3)) \
@@ -1016,7 +1016,7 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
         uint64_t data = 0x0ULL; \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, &data)); \
         data |= (1ULL<<29);\
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, FREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, "FREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, data)); \
     } \
 
@@ -1033,11 +1033,11 @@ int bdw_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
             } \
             PciDeviceIndex dev = counter_map[index].device; \
             if (HPMcheck(dev, cpu_id)) { \
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR_MANUAL); \
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR_MANUAL"); \
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL)); \
                 if (counter_map[index].counterRegister2 != 0x0) \
                 { \
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR_MANUAL); \
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR_MANUAL"); \
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL)); \
                 } \
             } \
@@ -1062,7 +1062,7 @@ int perfmon_setupCounterThread_broadwell(
     BDW_FREEZE_UNCORE;
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL));
@@ -1103,7 +1103,7 @@ int perfmon_setupCounterThread_broadwell(
                 if (haveLock)
                 {
                     flags = (1ULL<<22)|(1ULL<<20);
-                    VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_UBOXFIX);
+                    VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_UBOXFIX");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
                 }
                 break;
@@ -1204,13 +1204,13 @@ int perfmon_setupCounterThread_broadwell(
     {
         if (haveLock && TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
         {
-            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
             HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
         }
     }
     if (fixed_flags > 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -1259,7 +1259,7 @@ int perfmon_startCountersThread_broadwell(int thread_id, PerfmonEventSet* eventS
                     {
                         tmp = 0x0ULL;
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1,(uint32_t*)&tmp));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, START_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "START_POWER");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -1268,14 +1268,14 @@ int perfmon_startCountersThread_broadwell(int thread_id, PerfmonEventSet* eventS
                     {
                         if (!cpuid_info.supportClientmem)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_BOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_BOX");
                             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                         }
                         else
                         {
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, READ_MBOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "READ_MBOX");
                         }
                     }
                     break;
@@ -1290,7 +1290,7 @@ int perfmon_startCountersThread_broadwell(int thread_id, PerfmonEventSet* eventS
                     {
                         if (!cpuid_info.supportClientmem)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_BOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_BOX");
                             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                         }
                     }
@@ -1300,7 +1300,7 @@ int perfmon_startCountersThread_broadwell(int thread_id, PerfmonEventSet* eventS
                     {
                         tmp = 0x0ULL;
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, START_WBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, "START_WBOXFIX");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -1311,7 +1311,7 @@ int perfmon_startCountersThread_broadwell(int thread_id, PerfmonEventSet* eventS
                         if (eventSet->events[i].event.eventId != 0x00)
                         {
                             CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, START_QBOXFIX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, "START_QBOXFIX");
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                         }
                     }
@@ -1328,9 +1328,9 @@ int perfmon_startCountersThread_broadwell(int thread_id, PerfmonEventSet* eventS
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -1354,21 +1354,21 @@ int bdw_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
     }
 
     CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &result));
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, READ_REG_1);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, "READ_REG_1");
     if (flags & FREEZE_FLAG_CLEAR_CTR)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, CLEAR_PCI_REG_1);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, "CLEAR_PCI_REG_1");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0U));
     }
     if (counter2 != 0x0)
     {
         result <<= 32;
         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter2, &tmp));
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp, READ_REG_2);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp, "READ_REG_2");
         result += tmp;
         if (flags & FREEZE_FLAG_CLEAR_CTR)
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST 0x0U, CLEAR_PCI_REG_2);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST 0x0U, "CLEAR_PCI_REG_2");
             CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter2, 0x0U));
         }
     }
@@ -1386,10 +1386,10 @@ int bdw_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV,
                                            global_status_reg,
                                            &ovf_values));
-            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, READ_GLOBAL_OVFL);
+            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, "READ_GLOBAL_OVFL");
             if (ovf_values & (1ULL<<global_offset))
             {
-                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), CLEAR_GLOBAL_OVFL);
+                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), "CLEAR_GLOBAL_OVFL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV,
                                                  global_status_reg,
                                                  (1<<global_offset)));
@@ -1407,11 +1407,11 @@ int bdw_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev,
                                               box_map[type].statusRegister,
                                               &ovf_values));
-            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, READ_BOX_OVFL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, "READ_BOX_OVFL");
             if (ovf_values & (1ULL<<box_offset))
             {
                 (*overflows)++;
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), RESET_BOX_OVFL);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), "RESET_BOX_OVFL");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev,
                                                     box_map[type].statusRegister,
                                                     (1<<box_offset)));
@@ -1461,7 +1461,7 @@ int perfmon_stopCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     BDW_FREEZE_UNCORE;
@@ -1488,23 +1488,23 @@ int perfmon_stopCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     BDW_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     BDW_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1539,11 +1539,11 @@ int perfmon_stopCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, PCI_IMC_DEVICE_0_CH_0, counter1, &counter_result));
                             if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                             {
-                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                                 eventSet->events[i].threadCounter[thread_id].overflows++;
                             }
                         }
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
                 case MBOX1:
@@ -1620,7 +1620,7 @@ int perfmon_stopCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                     if (haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_WBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_WBOXFIX");
                     }
                     break;
 
@@ -1629,7 +1629,7 @@ int perfmon_stopCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                     if (haveLock)
                     {
                         HPMread(cpu_id, dev, counter1, &counter_result);
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_QBOXFIX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_QBOXFIX");
                         eventSet->events[i].threadCounter[thread_id].startData = 0;
                         if (eventSet->events[i].event.eventId == 0x00)
                         {
@@ -1694,9 +1694,9 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
     BDW_FREEZE_UNCORE;
 
@@ -1722,14 +1722,14 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     BDW_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     BDW_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
@@ -1737,10 +1737,10 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -1769,11 +1769,11 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = counter_result;
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
 
@@ -1845,7 +1845,7 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                     if (haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_WBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_WBOXFIX");
                     }
                     break;
 
@@ -1853,7 +1853,7 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                 case QBOX1FIX:
                     if (haveLock)
                     {
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_QBOXFIX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_QBOXFIX");
                         if (eventSet->events[i].event.eventId == 0x00)
                         {
                             HPMread(cpu_id, dev, counter1, &counter_result);
@@ -1901,7 +1901,7 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
     BDW_UNFREEZE_UNCORE;
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -1940,12 +1940,12 @@ int perfmon_finalizeCountersThread_broadwell(int thread_id, PerfmonEventSet* eve
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 break;
@@ -1958,19 +1958,19 @@ int perfmon_finalizeCountersThread_broadwell(int thread_id, PerfmonEventSet* eve
         if ((reg) && (((type == PMC)||(type == FIXED))||((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, reg, &ovf_values_uncore));
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, SHOW_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, "SHOW_CTL");
             ovf_values_uncore = 0x0ULL;
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if (type >= SBOX0 && type <= SBOX3)
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (type >= SBOX0 && type <= SBOX3)
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
                 if (type >= SBOX0 && type <= SBOX3)
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
@@ -1981,26 +1981,26 @@ int perfmon_finalizeCountersThread_broadwell(int thread_id, PerfmonEventSet* eve
 
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_STATUS, LLU_CAST ovf_values_uncore, CLEAR_UNCORE_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_STATUS, LLU_CAST ovf_values_uncore, "CLEAR_UNCORE_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_STATUS, ovf_values_uncore));
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST 0x0ULL, CLEAR_UNCORE_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST 0x0ULL, "CLEAR_UNCORE_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, 0x0ULL));
         for (int i=UNCORE;i<NUM_UNITS;i++)
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (i >= SBOX0 && i <= SBOX3)
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }
@@ -2009,9 +2009,9 @@ int perfmon_finalizeCountersThread_broadwell(int thread_id, PerfmonEventSet* eve
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_core2.h
+++ b/src/includes/perfmon_core2.h
@@ -99,7 +99,7 @@ int core2_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -140,7 +140,7 @@ int perfmon_setupCounterThread_core2( int thread_id, PerfmonEventSet* eventSet)
     }
     if (fixed_flags > 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -179,7 +179,7 @@ int perfmon_startCountersThread_core2(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
     }
@@ -206,7 +206,7 @@ int perfmon_stopCountersThread_core2(int thread_id, PerfmonEventSet* eventSet)
     /* stop counters */
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -228,12 +228,12 @@ int perfmon_stopCountersThread_core2(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
                     CORE2_CHECK_OVERFLOW(index - cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
                     CORE2_CHECK_OVERFLOW(index + 32);
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                     break;
                 default:
                     break;
@@ -254,9 +254,9 @@ int perfmon_readCountersThread_core2(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
 
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -276,12 +276,12 @@ int perfmon_readCountersThread_core2(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
                     CORE2_CHECK_OVERFLOW(index - cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
                     CORE2_CHECK_OVERFLOW(index - 32);
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                     break;
                 default:
                     break;
@@ -292,7 +292,7 @@ int perfmon_readCountersThread_core2(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -325,17 +325,17 @@ int perfmon_finalizeCountersThread_core2(int thread_id, PerfmonEventSet* eventSe
         }
         if ((reg) && ((type == PMC)||(type == FIXED)))
         {
-            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST 0x0ULL, CLEAR_CTRL);
+            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST 0x0ULL, "CLEAR_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, 0x0ULL));
-            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
         }
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_goldmont.h
+++ b/src/includes/perfmon_goldmont.h
@@ -134,7 +134,7 @@ int glm_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -143,12 +143,12 @@ int glm_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -164,7 +164,7 @@ int perfmon_setupCounterThread_goldmont(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL));
@@ -200,7 +200,7 @@ int perfmon_setupCounterThread_goldmont(
     }
     if ((fixed_flags > 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -252,7 +252,7 @@ int perfmon_startCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSe
                     {
                         tmp = 0x0ULL;
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1,(uint32_t*)&tmp));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, START_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "START_POWER");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -265,9 +265,9 @@ int perfmon_startCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSe
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -313,7 +313,7 @@ int perfmon_stopCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSet
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -338,14 +338,14 @@ int perfmon_stopCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSet
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     GLM_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     GLM_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
@@ -353,7 +353,7 @@ int perfmon_stopCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSet
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
                             eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -393,9 +393,9 @@ int perfmon_readCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSet
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
 
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -419,14 +419,14 @@ int perfmon_readCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSet
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     GLM_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     eventSet->events[i].threadCounter[thread_id].counterData = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     GLM_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     eventSet->events[i].threadCounter[thread_id].counterData = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
@@ -434,7 +434,7 @@ int perfmon_readCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSet
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
                             eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -452,7 +452,7 @@ int perfmon_readCountersThread_goldmont(int thread_id, PerfmonEventSet* eventSet
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -491,12 +491,12 @@ int perfmon_finalizeCountersThread_goldmont(int thread_id, PerfmonEventSet* even
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 break;
@@ -508,13 +508,13 @@ int perfmon_finalizeCountersThread_goldmont(int thread_id, PerfmonEventSet* even
         }
         if ((reg) && (((type == PMC)||(type == FIXED))||((type >= UBOXFIX) && (haveLock))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
             }
         }
@@ -523,9 +523,9 @@ int perfmon_finalizeCountersThread_goldmont(int thread_id, PerfmonEventSet* even
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_graniterapids.h
+++ b/src/includes/perfmon_graniterapids.h
@@ -249,13 +249,13 @@ int perfmon_setupCounterThread_graniterapids(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -296,7 +296,7 @@ int perfmon_setupCounterThread_graniterapids(
     }
     if ((fixed_flags > 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -365,23 +365,23 @@ int perfmon_startCountersThread_graniterapids(int thread_id, PerfmonEventSet* ev
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, UNFREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, "UNFREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, 0x0ULL);
     }
     if (MEASURE_CORE(eventSet))
     {
         if (flags & (1ULL << 48))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, CLEAR_METRICS)
+            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, "CLEAR_METRICS");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_METRICS, 0x0ULL));
         }
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -403,7 +403,7 @@ int perfmon_stopCountersThread_graniterapids(int thread_id, PerfmonEventSet* eve
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
@@ -412,11 +412,11 @@ int perfmon_stopCountersThread_graniterapids(int thread_id, PerfmonEventSet* eve
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), FREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), "FREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, (1ULL<<0));
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
 
@@ -482,9 +482,9 @@ int perfmon_readCountersThread_graniterapids(int thread_id, PerfmonEventSet* eve
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
@@ -492,11 +492,11 @@ int perfmon_readCountersThread_graniterapids(int thread_id, PerfmonEventSet* eve
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), FREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), "FREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, (1ULL<<0));
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -545,16 +545,16 @@ int perfmon_readCountersThread_graniterapids(int thread_id, PerfmonEventSet* eve
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, UNFREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, 0x0ULL));
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -603,17 +603,17 @@ int perfmon_finalizeCountersThread_graniterapids(int thread_id, PerfmonEventSet*
         }
         if ((reg) && (((type == PMC)||(type == FIXED))||(type == METRICS)|| ((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
             {
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             }
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (box_map[type].filterRegister1 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL));
             }
         }
@@ -621,9 +621,9 @@ int perfmon_finalizeCountersThread_graniterapids(int thread_id, PerfmonEventSet*
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_haswell.h
+++ b/src/includes/perfmon_haswell.h
@@ -179,7 +179,7 @@ int hasep_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -188,12 +188,12 @@ int hasep_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -232,7 +232,7 @@ int has_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -280,26 +280,26 @@ int hasep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter1, &filter_flags));
                     filter_flags |= (0x3<<27);
                     filter_flags |= (extractBitField(event->options[j].value,5,0) << 20);
-                    VERBOSEPRINTREG(cpu_id, filter1, filter_flags, SETUP_CBOX_FILTER_OPCODE);
+                    VERBOSEPRINTREG(cpu_id, filter1, filter_flags, "SETUP_CBOX_FILTER_OPCODE");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags));
                     break;
                 case EVENT_OPTION_NID:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter1, &filter_flags));
                     filter_flags |= (extractBitField(event->options[j].value,16,0));
-                    VERBOSEPRINTREG(cpu_id, filter1, filter_flags, SETUP_CBOX_FILTER_NID);
+                    VERBOSEPRINTREG(cpu_id, filter1, filter_flags, "SETUP_CBOX_FILTER_NID");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags));
                     break;
                 case EVENT_OPTION_STATE:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags));
                     filter_flags |= (extractBitField(event->options[j].value,6,0) << 17);
-                    VERBOSEPRINTREG(cpu_id, filter0, filter_flags, SETUP_CBOX_FILTER_STATE);
+                    VERBOSEPRINTREG(cpu_id, filter0, filter_flags, "SETUP_CBOX_FILTER_STATE");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags));
                     set_state_all = 0;
                     break;
                 case EVENT_OPTION_TID:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags));
                     filter_flags |= (extractBitField(event->options[j].value,6,0));
-                    VERBOSEPRINTREG(cpu_id, filter0, filter_flags, SETUP_CBOX_FILTER_TID);
+                    VERBOSEPRINTREG(cpu_id, filter0, filter_flags, "SETUP_CBOX_FILTER_TID");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags));
                     flags |= (1ULL<<19);
                     break;
@@ -313,12 +313,12 @@ int hasep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags));
         filter_flags |= (0x1F << 17);
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags, SETUP_CBOX_DEF_FILTER_STATE);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags, "SETUP_CBOX_DEF_FILTER_STATE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -359,7 +359,7 @@ int hasep_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -408,7 +408,7 @@ int hasep_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_OCCUPANCY_FILTER:
                     clean_filter_reg = 0;
-                    VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), SETUP_WBOX_FILTER);
+                    VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), "SETUP_WBOX_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter, (event->options[j].value & 0xFFFFFFFFULL)));
                     break;
                 case EVENT_OPTION_OCCUPANCY_EDGE:
@@ -429,7 +429,7 @@ int hasep_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_WBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -474,17 +474,17 @@ int hasep_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_OPCODE:
                     VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH,
-                                        (event->options[j].value & 0x3FULL), SETUP_BBOX_OPCODE);
+                                        (event->options[j].value & 0x3FULL), "SETUP_BBOX_OPCODE");
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH,
                                         (event->options[j].value & 0x3FULL)));
                     opcode_flag = 1;
                     break;
                 case EVENT_OPTION_MATCH0:
                     filter = ((event->options[j].value & 0xFFFFFFC0ULL));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter, SETUP_ADDR0_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter, "SETUP_ADDR0_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter));
                     filter = (((event->options[j].value>>32) & 0x3FFFULL));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter, SETUP_ADDR1_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter, "SETUP_ADDR1_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter));
                     match_flag = 1;
                     break;
@@ -496,25 +496,25 @@ int hasep_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (!opcode_flag)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, 0x0ULL, CLEAR_BBOX_OPCODE);
+        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, 0x0ULL, "CLEAR_BBOX_OPCODE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, 0x0ULL));
     }
     if (!match_flag)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, 0x0ULL, CLEAR_BBOX_MATCH0);
+        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, 0x0ULL, "CLEAR_BBOX_MATCH0");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, 0x0ULL));
-        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, 0x0ULL, CLEAR_BBOX_MATCH1);
+        VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, 0x0ULL, "CLEAR_BBOX_MATCH1");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, 0x0ULL));
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_BBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_BBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite( cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable.
          * Not mentioned for the BBOX but we do it to be sure.
          */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_BBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_BBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -562,10 +562,10 @@ int hasep_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_SBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_SBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device, counter_map[index].configRegister, flags));
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_SBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_SBOX_TWICE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -612,11 +612,11 @@ int hasep_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_MBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_MBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_MBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_MBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -662,11 +662,11 @@ int hasep_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_IBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_IBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_IBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_IBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -713,11 +713,11 @@ int hasep_pbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_PBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_PBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_PBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_PBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -763,11 +763,11 @@ int hasep_rbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_PBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_PBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_PBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_PBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -817,12 +817,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MATCH_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_RX_MATCH0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_RX_MATCH0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MATCH1:
@@ -830,12 +830,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MATCH_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_RX_MATCH1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_RX_MATCH1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MATCH2:
@@ -843,12 +843,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MATCH_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_TX_MATCH0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_TX_MATCH0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MATCH3:
@@ -856,12 +856,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MATCH_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_TX_MATCH1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_TX_MATCH1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK0:
@@ -869,12 +869,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MASK_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_RX_MASK0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_RX_MASK0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK1:
@@ -882,12 +882,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_RX_MASK_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_RX_MASK1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_RX_MASK1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK2:
@@ -895,12 +895,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MASK_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_TX_MASK0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_TX_MASK0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK3:
@@ -908,12 +908,12 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                     {
                         filterreg = PCI_UNC_V3_QPI_PMON_TX_MASK_0;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_TX_MASK1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_TX_MASK1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 default:
@@ -923,11 +923,11 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
     }
     if ((flags|(1ULL<<22)) != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_QBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_QBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         /* Intel notes the registers must be written twice to hold, once without enable and again with enable */
         flags |= (1ULL<<22);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_QBOX_TWICE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_QBOX_TWICE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -937,7 +937,7 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
 #define HASEP_FREEZE_UNCORE \
     if (haveLock && MEASURE_UNCORE(eventSet) && cpuid_info.model == HASWELL_EP) \
     { \
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<31), FREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<31), "FREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<31))); \
     } \
     else if (haveLock && MEASURE_UNCORE(eventSet) && haswell_cbox_setup == has_cbox_setup) \
@@ -947,7 +947,7 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
         if (!(data & (1ULL<<29))) \
         { \
             data &= ~(1ULL<<29); \
-            VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, FREEZE_UNCORE); \
+            VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, "FREEZE_UNCORE"); \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, data)); \
         } \
     } \
@@ -955,7 +955,7 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
 #define HASEP_UNFREEZE_UNCORE \
     if (haveLock && MEASURE_UNCORE(eventSet) && cpuid_info.model == HASWELL_EP) \
     { \
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<29), UNFREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<29), "UNFREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<29))); \
     } \
     else if (haveLock && MEASURE_UNCORE(eventSet) && haswell_cbox_setup == has_cbox_setup) \
@@ -963,7 +963,7 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
         uint64_t data = 0x0ULL; \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, &data)); \
         data |= (1ULL<<29); \
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, UNFREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, data, "UNFREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, data)); \
     }
 
@@ -981,7 +981,7 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
             PciDeviceIndex dev = counter_map[index].device; \
             if (HPMcheck(dev, cpu_id)) { \
                 int err = 0; \
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR_MANUAL); \
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR_MANUAL"); \
                 err = HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL); \
                 if (err != 0) \
                 { \
@@ -989,7 +989,7 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
                 } \
                 else if (counter_map[index].counterRegister2 != 0x0) \
                 { \
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR_MANUAL); \
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR_MANUAL"); \
                     err = HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL); \
                     if (err != 0) \
                     { \
@@ -1015,19 +1015,19 @@ int hasep_qbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDe
             } \
             PciDeviceIndex dev = counter_map[index].device; \
             if (HPMcheck(dev, cpu_id)) { \
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, 0x0ULL, CLEAR_CTL_MANUAL); \
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, 0x0ULL, "CLEAR_CTL_MANUAL"); \
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, 0x0ULL)); \
                 if ((type >= SBOX0) && (type <= SBOX3)) { \
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, 0x0ULL)); \
                 } \
                 if (box_map[type].filterRegister1 != 0x0) \
                 { \
-                    VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, CLEAR_FILTER); \
+                    VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, "CLEAR_FILTER"); \
                     HPMwrite(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL); \
                 } \
                 if (box_map[type].filterRegister2 != 0x0) \
                 { \
-                    VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister2, 0x0ULL, CLEAR_FILTER); \
+                    VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister2, 0x0ULL, "CLEAR_FILTER"); \
                     HPMwrite(cpu_id, dev, box_map[type].filterRegister2, 0x0ULL); \
                 } \
             } \
@@ -1053,7 +1053,7 @@ int perfmon_setupCounterThread_haswell(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL));
@@ -1115,7 +1115,7 @@ int perfmon_setupCounterThread_haswell(
                 if (haveLock)
                 {
                     flags = (1ULL<<22)|(1ULL<<20);
-                    VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_UBOXFIX);
+                    VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_UBOXFIX");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
                 }
                 break;
@@ -1163,7 +1163,7 @@ int perfmon_setupCounterThread_haswell(
              case MBOX7FIX:
                  if (haveLock && HPMcheck(counter_map[index].device, cpu_id))
                  {
-                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device, reg, ((1ULL<<20)|(1ULL<<22))))
+                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device, reg, ((1ULL<<20)|(1ULL<<22))));
                  }
                  break;
 
@@ -1196,16 +1196,16 @@ int perfmon_setupCounterThread_haswell(
     {
         if (haveLock && TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
         {
-            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
             HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
         }
     }
     if (fixed_flags > 0x0ULL)
     {
         // Erratum HSW143
-        //VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED_WORKAROUND)
+        //VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED_WORKAROUND");
         //CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, (1ULL<<32)));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -1243,13 +1243,13 @@ int perfmon_startCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet
                 case PMC:
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     flags |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));  /* enable counter */
-                    VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, START_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "START_PMC");
                     break;
 
                 case FIXED:
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     flags |= (1ULL<<(index+32));  /* enable fixed counter */
-                    VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, START_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "START_FIXED");
                     break;
 
                 case POWER:
@@ -1257,7 +1257,7 @@ int perfmon_startCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet
                     {
                         tmp = 0x0ULL;
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1,(uint32_t*)&tmp));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, START_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "START_POWER");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -1266,7 +1266,7 @@ int perfmon_startCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet
                     {
                         tmp = 0x0ULL;
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, START_WBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, "START_WBOXFIX");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -1277,7 +1277,7 @@ int perfmon_startCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet
                         if (eventSet->events[i].event.eventId != 0x00)
                         {
                             CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, START_QBOXFIX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, "START_QBOXFIX");
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                         }
                     }
@@ -1287,14 +1287,14 @@ int perfmon_startCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet
                     {
                         if (!cpuid_info.supportClientmem)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_BOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_BOX");
                             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                         }
                         else
                         {
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, READ_MBOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "READ_MBOX");
                         }
                     }
                     break;
@@ -1310,9 +1310,9 @@ int perfmon_startCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -1336,21 +1336,21 @@ int has_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
     }
 
     CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &result));
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, READ_REG_1);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, "READ_REG_1");
     if (flags & FREEZE_FLAG_CLEAR_CTR)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, CLEAR_PCI_REG_1);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, "CLEAR_PCI_REG_1");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0U));
     }
     if (counter2 != 0x0)
     {
         result <<= 32;
         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter2, &tmp));
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp, READ_REG_2);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp, "READ_REG_2");
         result += tmp;
         if (flags & FREEZE_FLAG_CLEAR_CTR)
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST 0x0U, CLEAR_PCI_REG_2);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST 0x0U, "CLEAR_PCI_REG_2");
             CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter2, 0x0U));
         }
     }
@@ -1369,10 +1369,10 @@ int has_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV,
                                            global_status_reg,
                                            &ovf_values));
-            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, READ_GLOBAL_OVFL);
+            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, "READ_GLOBAL_OVFL");
             if (ovf_values & (1ULL<<global_offset))
             {
-                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), CLEAR_GLOBAL_OVFL);
+                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), "CLEAR_GLOBAL_OVFL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV,
                                                  global_status_reg,
                                                  (1<<global_offset)));
@@ -1390,11 +1390,11 @@ int has_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev,
                                               box_map[type].statusRegister,
                                               &ovf_values));
-            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, READ_BOX_OVFL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, "READ_BOX_OVFL");
             if (ovf_values & (1ULL<<box_offset))
             {
                 (*overflows)++;
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), RESET_BOX_OVFL);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), "RESET_BOX_OVFL");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev,
                                                     box_map[type].statusRegister,
                                                     (1<<box_offset)));
@@ -1444,7 +1444,7 @@ int perfmon_stopCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -1473,14 +1473,14 @@ int perfmon_stopCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     HASEP_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_PMC");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     HASEP_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_FIXED");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
@@ -1488,10 +1488,10 @@ int perfmon_stopCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -1578,12 +1578,12 @@ int perfmon_stopCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                             if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                             {
-                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                                 eventSet->events[i].threadCounter[thread_id].overflows++;
                             }
                             *current = counter_result;
                         }
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
                 case MBOX1:
@@ -1655,7 +1655,7 @@ int perfmon_stopCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                         HPMread(cpu_id, dev, counter1, &counter_result);
                         counter_result = field64(counter_result, 0, box_map[type].regWidth);
                     }
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_QBOXFIX);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_QBOXFIX");
                     eventSet->events[i].threadCounter[thread_id].counterData = counter_result;
                     eventSet->events[i].threadCounter[thread_id].startData = 0;
                     break;
@@ -1686,9 +1686,9 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
 
     HASEP_FREEZE_UNCORE;
@@ -1715,7 +1715,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     HASEP_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
@@ -1723,7 +1723,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     HASEP_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
@@ -1731,10 +1731,10 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -1743,7 +1743,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
 
                 case THERMAL:
                     CHECK_TEMP_READ_ERROR(thermal_read(cpu_id,(uint32_t*)&counter_result));
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_TEMP)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_TEMP");
                     *current = field64(counter_result, 0, box_map[type].regWidth);
                     break;
 
@@ -1756,7 +1756,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                     if (haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_WBOXFIX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_WBOXFIX");
                         if (counter_result < *current)
                         {
                             (*overflows)++;
@@ -1767,7 +1767,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
 
                 case BBOX0:
                 case BBOX1:
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_BBOX)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_BBOX");
                     has_uncore_read(cpu_id, index, event, current, overflows,
                                     0, ovf_offset, getCounterTypeOffset(index));
                     break;
@@ -1786,12 +1786,12 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                             if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                             {
-                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                                 eventSet->events[i].threadCounter[thread_id].overflows++;
                             }
                             *current = counter_result;
                         }
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
                 case MBOX1:
@@ -1801,7 +1801,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                 case MBOX5:
                 case MBOX6:
                 case MBOX7:
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     has_uncore_read(cpu_id, index, event, current, overflows,
                                     0, ovf_offset, getCounterTypeOffset(index)+1);
                     break;
@@ -1814,7 +1814,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                 case MBOX5FIX:
                 case MBOX6FIX:
                 case MBOX7FIX:
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOXFIX)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOXFIX");
                     has_uncore_read(cpu_id, index, event, current, overflows,
                                     0, ovf_offset, 0);
                     break;
@@ -1861,7 +1861,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
 
                 case QBOX0FIX:
                 case QBOX1FIX:
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_QBOXFIX)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_QBOXFIX");
                     if (eventSet->events[i].event.eventId == 0x00)
                     {
                         HPMread(cpu_id, dev, counter1, &counter_result);
@@ -1910,9 +1910,9 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         // Erratum HSW143
-        //VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS_WORKAROUND)
+        //VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS_WORKAROUND");
         //CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, (1ULL<<32)));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -1952,12 +1952,12 @@ int perfmon_finalizeCountersThread_haswell(int thread_id, PerfmonEventSet* event
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 break;
@@ -1977,19 +1977,19 @@ int perfmon_finalizeCountersThread_haswell(int thread_id, PerfmonEventSet* event
         if ((reg) && (((type == PMC)||(type == FIXED))||((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
             ovf_values_uncore = 0x0ULL;
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
             {
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             }
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
                 if ((type >= SBOX0) && (type <= SBOX3))
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
@@ -1999,26 +1999,26 @@ int perfmon_finalizeCountersThread_haswell(int thread_id, PerfmonEventSet* event
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_STATUS, LLU_CAST ovf_values_uncore, CLEAR_UNCORE_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_STATUS, LLU_CAST ovf_values_uncore, "CLEAR_UNCORE_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_STATUS, ovf_values_uncore));
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST 0x0ULL, CLEAR_UNCORE_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST 0x0ULL, "CLEAR_UNCORE_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, 0x0ULL));
         for (int i=UNCORE;i<NUM_UNITS;i++)
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if ((i >= SBOX0) && (i <= SBOX3))
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }
@@ -2027,9 +2027,9 @@ int perfmon_finalizeCountersThread_haswell(int thread_id, PerfmonEventSet* event
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_icelake.h
+++ b/src/includes/perfmon_icelake.h
@@ -71,12 +71,12 @@ int perfmon_init_icelake(int cpu_id)
         ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL);
         if (ret != 0)
         {
-            ERROR_PRINT(Cannot zero %s (0x%X), str(MSR_PEBS_ENABLE), MSR_PEBS_ENABLE);
+            ERROR_PRINT("Cannot zero MSR_PEBS_ENABLE (0x%X)", MSR_PEBS_ENABLE);
         }
         ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_FRONTEND, 0x0ULL);
         if (ret != 0)
         {
-            ERROR_PRINT(Cannot zero %s (0x%X), str(MSR_PEBS_FRONTEND), MSR_PEBS_FRONTEND);
+            ERROR_PRINT("Cannot zero MSR_PEBS_FRONTEND (0x%X)", MSR_PEBS_FRONTEND);
         }
     }
     if (!icl_did_cbox_check)
@@ -191,7 +191,7 @@ int icl_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE0);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE0");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -200,13 +200,13 @@ int icl_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE1);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE1");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -252,7 +252,7 @@ int icx_setup_mbox(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_MBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_MBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -276,7 +276,7 @@ int icx_setup_mboxfix(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     flags = (1ULL<<20)|(1ULL<<22);
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_MBOXFIX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_MBOXFIX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -317,7 +317,7 @@ int icx_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -335,7 +335,7 @@ int icx_uboxfix_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     flags = (1ULL<<22)|(1ULL<<20);
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UBOXFIX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UBOXFIX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -374,7 +374,7 @@ int icl_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -453,7 +453,7 @@ int icx_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (filter_flags0 != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, SETUP_CBOX_FILTER0);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, "SETUP_CBOX_FILTER0");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags0));
     }
     else
@@ -463,7 +463,7 @@ int icx_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -507,7 +507,7 @@ int icx_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UNCORE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -549,7 +549,7 @@ int icx_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UNCORE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UNCORE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -603,7 +603,7 @@ int icx_upi_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_QBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_QBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -645,7 +645,7 @@ int icx_irp_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_IRP);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_IRP");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -692,7 +692,7 @@ int icx_tc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_IIO);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_IIO");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -714,7 +714,7 @@ int perfmon_setupCounterThread_icelake(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
     }
@@ -919,7 +919,7 @@ int perfmon_setupCounterThread_icelake(
     }
     if ((fixed_flags > 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -958,12 +958,12 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
             switch (type)
             {
                 case FIXED:
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_FIXED);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_FIXED");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     flags |= (1ULL<<(index+32));  /* enable fixed counter */
                     break;
                 case PMC:
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_PMC);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_PMC");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     flags |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));  /* enable counter */
                     break;
@@ -972,7 +972,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                     {
                         tmp = 0x0ULL;
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1,(uint32_t*)&tmp));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, START_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "START_POWER");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -989,9 +989,9 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                     if (haveLock && ((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2)))
                     {
                         CHECK_MMIO_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, START_MDEV_RAW);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST tmp, "START_MDEV_RAW");
                         eventSet->events[i].threadCounter[thread_id].startData = tmp;//field64(tmp, 0, box_map[type].regWidth);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, START_MDEV);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, "START_MDEV");
                     }
                     break;
                 case MBOX0FIX:
@@ -1004,7 +1004,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case MBOX7FIX:
                     if (haveLock && ((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2)))
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_MBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_MBOXFIX");
                         CHECK_MMIO_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1025,14 +1025,14 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                     {
                         if ((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2))
                         {
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_MBOX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_MBOX");
                             CHECK_MMIO_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                         }
                         else if (cpuid_info.model == ICELAKE1 || cpuid_info.model == ICELAKE2)
                         {
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, READ_MBOX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, "READ_MBOX");
                         }
                     }
                     break;
@@ -1041,7 +1041,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, READ_MBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, "READ_MBOX");
                     }
                     break;
                 case BBOX0:
@@ -1050,7 +1050,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case BBOX3:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_BBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_BBOX");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1059,7 +1059,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case SBOX2:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_SBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_SBOX");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1068,28 +1068,28 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case QBOX2:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_QBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_QBOX");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
                 case UBOXFIX:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_UBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_UBOXFIX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
                 case UBOX:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_UBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_UBOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
                 case WBOX:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_WBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_WBOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1099,7 +1099,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                         tmp = 0x0ULL;
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, START_WBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, "START_WBOXFIX");
                     }
                     break;
                 case EUBOX0:
@@ -1110,7 +1110,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case EUBOX5:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_IIO);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_IIO");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1122,7 +1122,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case PBOX5:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_PBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_PBOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1142,7 +1142,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, READ_IIOPORT);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, "READ_IIOPORT");
                     }
                     break;
                 case IBOX0:
@@ -1153,7 +1153,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case IBOX5:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_IBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_IBOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1199,7 +1199,7 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
                 case CBOX39:
                     if (haveLock)
                     {
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_CBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_CBOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1213,12 +1213,12 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
     {
         if ((cpuid_info.model == ICELAKE1) || (cpuid_info.model == ICELAKE2 || cpuid_info.model == ROCKETLAKE))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29), UNFREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29), "UNFREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29)));
         }
         else if ((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<61), UNFREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<61), "UNFREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<61)));
         }
     }
@@ -1226,12 +1226,12 @@ int perfmon_startCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet
     {
         if (flags & (1ULL << 48))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, CLEAR_METRICS)
+            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, "CLEAR_METRICS");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_METRICS, 0x0ULL));
         }
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -1284,10 +1284,10 @@ int icx_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
     }
 
     CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &result));
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, READ_REG_1);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, "READ_REG_1");
     if (flags & FREEZE_FLAG_CLEAR_CTR)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, CLEAR_REG_1);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, "CLEAR_REG_1");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0U));
     }
     result = field64(result, 0, box_map[type].regWidth);
@@ -1311,10 +1311,10 @@ int icx_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV,
                                            global_status_reg,
                                            &ovf_values));
-            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, READ_GLOBAL_OVFL);
+            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, "READ_GLOBAL_OVFL");
             if (ovf_values & (1ULL<<global_offset))
             {
-                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), CLEAR_GLOBAL_OVFL);
+                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), "CLEAR_GLOBAL_OVFL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV,
                                                  global_status_reg,
                                                  (1<<global_offset)));
@@ -1332,11 +1332,11 @@ int icx_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev,
                                               box_map[type].statusRegister,
                                               &ovf_values));
-            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, READ_BOX_OVFL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, "READ_BOX_OVFL");
             if (ovf_values & (1ULL<<box_offset))
             {
                 (*overflows)++;
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), RESET_BOX_OVFL);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), "RESET_BOX_OVFL");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev,
                                                     box_map[type].statusRegister,
                                                     (1<<box_offset)));
@@ -1367,19 +1367,19 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
         if (cpuid_info.model == ICELAKE1 || cpuid_info.model == ICELAKE2 || cpuid_info.model == ROCKETLAKE)
         {
-            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL));
         }
         else if ((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<63), FREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<63), "FREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<63)));
         }
     }
@@ -1407,21 +1407,21 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_FIXED");
                     break;
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_PMC");
                     break;
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1429,18 +1429,18 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
 
                 case THERMAL:
                     CHECK_TEMP_READ_ERROR(thermal_read(cpu_id,(uint32_t*)&counter_result));
-                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, STOP_THERMAL);
+                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "STOP_THERMAL");
                     break;
 
                 case VOLTAGE:
                     CHECK_TEMP_READ_ERROR(voltage_read(cpu_id, &counter_result));
-                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, STOP_VOLTAGE);
+                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "STOP_VOLTAGE");
                     break;
 
                 case METRICS:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     counter_result= field64(counter_result, getCounterTypeOffset(index)*box_map[type].regWidth, box_map[type].regWidth);
-                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, STOP_METRICS);
+                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "STOP_METRICS");
                     break;
                 case MBOX0:
                 case MBOX1:
@@ -1461,17 +1461,17 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         {
                             CHECK_MMIO_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                             counter_result = field64(counter_result, 0, box_map[type].regWidth);
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_MBOX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_MBOX");
                         }
                         else if ((cpuid_info.model == ICELAKE1) || (cpuid_info.model == ICELAKE2))
                         {
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, PCI_IMC_DEVICE_0_CH_0, counter1, &counter_result));
                             counter_result = field64(counter_result, 0, box_map[type].regWidth);
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_MBOX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_MBOX");
                         }
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_MEM)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_MEM");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1488,7 +1488,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MMIO_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                         counter_result = field64(counter_result, 0, box_map[type].regWidth);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_MBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_MBOXFIX");
                     }
                     break;
                 case MBOX0TMP:
@@ -1497,10 +1497,10 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, PCI_IMC_DEVICE_0_CH_0, counter1, &counter_result));
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_MBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_MBOX");
                     }
                     break;
                 case MDEV0:
@@ -1513,10 +1513,10 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         counter_result = tmp;//field64(tmp, 0, box_map[type].regWidth);
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_MDEV)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_MDEV");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, STOP_MDEV);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, "STOP_MDEV");
                     }
                     break;
                 case UBOXFIX:
@@ -1524,7 +1524,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         ICX_CHECK_UNCORE_OVERFLOW(box_map[type].ovflOffset);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_UBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_UBOXFIX");
                     }
                     break;
                 case UBOX:
@@ -1532,7 +1532,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         ICX_CHECK_UNCORE_OVERFLOW(box_map[type].ovflOffset);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_UBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_UBOX");
                     }
                     break;
                 case EUBOX0:
@@ -1546,7 +1546,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows,
                                     FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_IIO);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_IIO");
                     }
                     break;
                 case EUBOX0FIX:
@@ -1565,7 +1565,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                         counter_result = field64(tmp, 0, box_map[type].regWidth);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_IIOPORT);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_IIOPORT");
                     }
                     break;
                 case IBOX0:
@@ -1579,7 +1579,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows,
                                     FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_IBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_IBOX");
                     }
                     break;
                 case WBOX:
@@ -1588,14 +1588,14 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows,
                                     FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_WBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_WBOX");
                     }
                     break;
                 case WBOX0FIX:
                     if (haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_WBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_WBOXFIX");
                     }
                     break;
                 case CBOX0:
@@ -1643,7 +1643,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows, 
                                         FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_CBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_CBOX");
                     }
                     break;
                 case BBOX0:
@@ -1655,7 +1655,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows, 
                                         FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_BBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_BBOX");
                     }
                     break;
                 case SBOX0:
@@ -1666,7 +1666,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows, 
                                         FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_SBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_SBOX");
                     }
                     break;
                 case QBOX0:
@@ -1677,7 +1677,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows, 
                                         FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_QBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_QBOX");
                     }
                     break;
                 case PBOX:
@@ -1691,7 +1691,7 @@ int perfmon_stopCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         icx_uncore_read(cpu_id, index, event, current, overflows, 
                                         FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_PBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_PBOX");
                     }
                     break;
                 default:
@@ -1720,20 +1720,20 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
         if (cpuid_info.model == ICELAKE1 || cpuid_info.model == ICELAKE2 || cpuid_info.model == ROCKETLAKE)
         {
-            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL));
         }
         else if (((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2)))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<63), FREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<63), "FREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<63)));
         }
     }
@@ -1761,21 +1761,21 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1784,18 +1784,18 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                 case THERMAL:
                     CHECK_TEMP_READ_ERROR(thermal_read(cpu_id,(uint32_t*)&counter_result));
                     eventSet->events[i].threadCounter[thread_id].counterData = field64(counter_result, 0, box_map[type].regWidth);
-                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_THERMAL);
+                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_THERMAL");
                     break;
 
                 case VOLTAGE:
                     CHECK_TEMP_READ_ERROR(voltage_read(cpu_id, &counter_result));
-                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_VOLTAGE);
+                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_VOLTAGE");
                     break;
 
                 case METRICS:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     counter_result= field64(counter_result, getCounterTypeOffset(index)*box_map[type].regWidth, box_map[type].regWidth);
-                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_METRICS);
+                    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_METRICS");
                     break;
 
                 case UBOXFIX:
@@ -1803,7 +1803,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         ICX_CHECK_UNCORE_OVERFLOW(box_map[type].ovflOffset);
-                        VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_UBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_UBOXFIX");
                     }
                     break;
                 case UBOX:
@@ -1811,7 +1811,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         ICX_CHECK_UNCORE_OVERFLOW(box_map[type].ovflOffset);
-                        VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_UBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_UBOX");
                     }
                     break;
                 case MBOX0:
@@ -1833,17 +1833,17 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         {
                             CHECK_MMIO_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                             counter_result = field64(counter_result, 0, box_map[type].regWidth);
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_MBOX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_MBOX");
                         }
                         else if ((cpuid_info.model == ICELAKE1) && (cpuid_info.model == ICELAKE2))
                         {
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                             counter_result = field64(counter_result, 0, box_map[type].regWidth);
-                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_MBOX);
+                            VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_MBOX");
                         }
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_MEM)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_MEM");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1852,10 +1852,10 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     if (haveLock && (cpuid_info.model == ICELAKE1 || cpuid_info.model == ICELAKE2 || cpuid_info.model == ROCKETLAKE))
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_MBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_MBOX");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1870,10 +1870,10 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         counter_result = tmp;//field64(tmp, 0, box_map[type].regWidth);
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_MDEV)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_MDEV");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, READ_MDEV);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST eventSet->events[i].threadCounter[thread_id].startData, "READ_MDEV");
                     }
                     break;
                 case MBOX0FIX:
@@ -1890,10 +1890,10 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                         counter_result = field64(counter_result, 0, box_map[type].regWidth);
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_MBOXFIX)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_MBOXFIX");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_MBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_MBOXFIX");
                     }
                     break;
                 case EUBOX0:
@@ -1906,7 +1906,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_IIO);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_IIO");
                     }
                     break;
                 case EUBOX0FIX:
@@ -1925,7 +1925,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                         counter_result = field64(tmp, 0, box_map[type].regWidth);
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_IIOPORT);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_IIOPORT");
                     }
                     break;
                 case IBOX0:
@@ -1938,7 +1938,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_IBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_IBOX");
                     }
                     break;
                 case WBOX:
@@ -1946,14 +1946,14 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_WBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_WBOX");
                     }
                     break;
                 case WBOX0FIX:
                     if (haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_WBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_WBOXFIX");
                     }
                     break;
 
@@ -2001,7 +2001,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_CBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_CBOX");
                     }
                     break;
                 case BBOX0:
@@ -2012,7 +2012,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_BBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_BBOX");
                     }
                     break;
                 case SBOX0:
@@ -2022,7 +2022,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_SBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX");
                     }
                     break;
                 case QBOX0:
@@ -2032,7 +2032,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_QBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_QBOX");
                     }
                     break;
                 case PBOX:
@@ -2045,7 +2045,7 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         icx_uncore_read(cpu_id, index, event, current, overflows, 0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_PBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_PBOX");
                     }
                     break;
                 default:
@@ -2058,18 +2058,18 @@ int perfmon_readCountersThread_icelake(int thread_id, PerfmonEventSet* eventSet)
     {
         if (cpuid_info.model == ICELAKE1 || cpuid_info.model == ICELAKE2 || cpuid_info.model == ROCKETLAKE)
         {
-            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29), UNFREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29), "UNFREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29)));
         }
         else if (((cpuid_info.model == ICELAKEX1) || (cpuid_info.model == ICELAKEX2)))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<61), UNFREEZE_UNCORE);
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<61), "UNFREEZE_UNCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_ICX_U_PMON_GLOBAL_CTRL, (1ULL<<61)));
         }
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -2113,24 +2113,24 @@ int perfmon_finalizeCountersThread_icelake(int thread_id, PerfmonEventSet* event
         if ((reg) && (((type == PMC)||(type == FIXED))||(type == METRICS)|| ((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, reg, &ovf_values_uncore));
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, SHOW_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, "SHOW_CTL");
             ovf_values_uncore = 0x0ULL;
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
             {
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             }
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
         }
         eventSet->events[i].threadCounter[thread_id].init = FALSE;
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_interlagos.h
+++ b/src/includes/perfmon_interlagos.h
@@ -78,7 +78,7 @@ int ilg_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -97,7 +97,7 @@ int ilg_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     flags |= ((uint64_t)(event->eventId>>8)<<32) + (event->umask<<8) + (event->eventId & ~(0xF00U));
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_UNCORE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -245,11 +245,11 @@ int perfmon_readCountersThread_interlagos(int thread_id, PerfmonEventSet* eventS
             {
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &tmp));
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST tmp, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST tmp, "READ_PMC");
                     break;
                 case UNCORE:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &tmp));
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST tmp, READ_UNCORE);
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST tmp, "READ_UNCORE");
                     break;
                 default:
                     break;
@@ -281,9 +281,9 @@ int perfmon_finalizeCountersThread_interlagos(int thread_id, PerfmonEventSet* ev
         uint32_t reg = counter_map[index].configRegister;
         if ((reg) && (((type == PMC)||(type == FIXED))||((type >= UNCORE) && (haveLock))))
         {
-            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST 0x0ULL, CLEAR_CTRL);
+            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST 0x0ULL, "CLEAR_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, 0x0ULL));
-            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
         }
         eventSet->events[i].threadCounter[thread_id].init = FALSE;

--- a/src/includes/perfmon_ivybridge.h
+++ b/src/includes/perfmon_ivybridge.h
@@ -167,7 +167,7 @@ int ivb_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -176,12 +176,12 @@ int ivb_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -218,15 +218,15 @@ int ivb_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_OPCODE:
                     filter = (event->options[j].value & 0x3FULL);
-                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, flags, SETUP_OPCODE_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, flags, "SETUP_OPCODE_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH, filter));
                     break;
                 case EVENT_OPTION_MATCH0:
                     filter = ((event->options[j].value & 0xFFFFFFC0ULL));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter, SETUP_ADDR0_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter, "SETUP_ADDR0_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, filter));
                     filter = (((event->options[j].value>>32) & 0x3FFFULL));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter, SETUP_ADDR1_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter, "SETUP_ADDR1_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, filter));
                     break;
                 default:
@@ -236,7 +236,7 @@ int ivb_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, reg, flags, SETUP_BBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, reg, flags, "SETUP_BBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -276,7 +276,7 @@ int ivb_pci_box_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         VERBOSEPRINTPCIREG(cpu_id, counter_map[index].device, counter_map[index].configRegister,
-                            flags, SETUP_BOX);
+                            flags, "SETUP_BOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device,
                                          counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
@@ -300,7 +300,7 @@ int ivb_mboxfix_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         VERBOSEPRINTPCIREG(cpu_id, counter_map[index].device,
-            counter_map[index].configRegister, flags, SETUP_MBOXFIX);
+            counter_map[index].configRegister, flags, "SETUP_MBOXFIX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, counter_map[index].device,
             counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
@@ -345,12 +345,12 @@ int ivb_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_QPI_PMON_MATCH_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_MATCH0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_MATCH0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MATCH1:
@@ -358,12 +358,12 @@ int ivb_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_QPI_PMON_MATCH_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_MATCH1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_MATCH1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK0:
@@ -371,12 +371,12 @@ int ivb_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_QPI_PMON_MASK_0;
                         filterval = event->options[j].value & 0x8003FFF8ULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_MASK0);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_MASK0");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 case EVENT_OPTION_MASK1:
@@ -384,12 +384,12 @@ int ivb_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                     {
                         filterreg = PCI_UNC_QPI_PMON_MASK_1;
                         filterval = event->options[j].value & 0x000F000FULL;
-                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, SETUP_SBOX_MASK1);
+                        VERBOSEPRINTPCIREG(cpu_id, filterdev, filterreg, filterval, "SETUP_SBOX_MASK1");
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, filterreg, filterval));
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                        DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                     }
                     break;
                 default:
@@ -399,7 +399,7 @@ int ivb_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_SBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_SBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -438,7 +438,7 @@ int ivb_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -506,18 +506,18 @@ int ivbep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         }
         if (filter0 != 0x0ULL)
         {
-            VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, filter0, SETUP_CBOX_FILTER0);
+            VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, filter0, "SETUP_CBOX_FILTER0");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, filter0));
         }
         if (filter1 != 0x0ULL)
         {
-            VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, filter1, SETUP_CBOX_FILTER1);
+            VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, filter1, "SETUP_CBOX_FILTER1");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, filter1));
         }
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -562,7 +562,7 @@ int ivb_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -580,7 +580,7 @@ int ivb_uboxfix_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     flags = (1ULL<<22)|(1ULL<<20);
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_UBOXFIX)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_UBOXFIX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -624,7 +624,7 @@ int ivb_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_MATCH0:
                     VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1,
-                                    event->options[j].value & 0xFFFFFFFFULL, SETUP_WBOX_FILTER);
+                                    event->options[j].value & 0xFFFFFFFFULL, "SETUP_WBOX_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV,
                                     box_map[type].filterRegister1,
                                     event->options[j].value & 0xFFFFFFFFULL));
@@ -636,7 +636,7 @@ int ivb_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_WBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -676,7 +676,7 @@ int ivb_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_IBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_IBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -705,7 +705,7 @@ int ivb_uncore_freeze(int cpu_id, PerfmonEventSet* eventSet)
     }
     if (MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, freeze_reg, LLU_CAST (1ULL<<31), FREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, freeze_reg, LLU_CAST (1ULL<<31), "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, freeze_reg, (1ULL<<31)));
     }
     return 0;
@@ -735,9 +735,9 @@ int ivb_uncore_unfreeze(int cpu_id, PerfmonEventSet* eventSet)
     }
     if (MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, ovf_reg, LLU_CAST 0x0ULL, CLEAR_UNCORE_OVF)
+        VERBOSEPRINTREG(cpu_id, ovf_reg, LLU_CAST 0x0ULL, "CLEAR_UNCORE_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, ovf_reg, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, unfreeze_reg, LLU_CAST (1ULL<<29), UNFREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, unfreeze_reg, LLU_CAST (1ULL<<29), "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, unfreeze_reg, (1ULL<<29)));
     }
     return 0;
@@ -759,7 +759,7 @@ int perfmon_setupCounterThread_ivybridge(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
@@ -878,13 +878,13 @@ int perfmon_setupCounterThread_ivybridge(
     {
         if (haveLock && TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
         {
-            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
             HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
         }
     }
     if (fixed_flags > 0x0)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -934,7 +934,7 @@ int perfmon_startCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventS
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&tmp));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST field64(tmp, 0, box_map[type].regWidth), START_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST field64(tmp, 0, box_map[type].regWidth), "START_POWER");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -970,7 +970,7 @@ int perfmon_startCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventS
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST fixed_flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST fixed_flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, fixed_flags));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|fixed_flags));
     }
@@ -999,7 +999,7 @@ uint64_t ivb_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event, i
     }
 
     CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, tmp, UNCORE_READ);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, tmp, "UNCORE_READ");
 
     if (flags & FREEZE_FLAG_CLEAR_CTR)
     {
@@ -1010,7 +1010,7 @@ uint64_t ivb_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event, i
         result = (tmp<<32);
         tmp = 0x0ULL;
         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter2, &tmp));
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, tmp, UNCORE_READ);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, tmp, "UNCORE_READ");
         result += (tmp & 0xFFFFFFFF);
         if (flags & FREEZE_FLAG_CLEAR_CTR)
         {
@@ -1101,7 +1101,7 @@ int perfmon_stopCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
@@ -1139,7 +1139,7 @@ int perfmon_stopCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                             (*overflows)++;
                         }
                     }
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
@@ -1152,17 +1152,17 @@ int perfmon_stopCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                             (*overflows)++;
                         }
                     }
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -1179,7 +1179,7 @@ int perfmon_stopCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                     if (haveLock && HPMcheck(dev, cpu_id))
                     {
                         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_SBOX_FIXED)
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX_FIXED");
                         switch (extractBitField(counter_result,3,0))
                         {
                             case 0x2:
@@ -1204,7 +1204,7 @@ int perfmon_stopCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                                 counter_result = 0x0ULL;
                                 break;
                         }
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_SBOX_FIXED_REAL)
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX_FIXED_REAL");
                         eventSet->events[i].threadCounter[thread_id].startData = 0;
                     }
                     break;
@@ -1223,7 +1223,7 @@ int perfmon_stopCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                             uint64_t tmp = 0x0;
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, READ_MBOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "READ_MBOX");
                         }
                     }
                     break;
@@ -1373,7 +1373,7 @@ int perfmon_readCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                             (*overflows)++;
                         }
                     }
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
@@ -1386,17 +1386,17 @@ int perfmon_readCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                             (*overflows)++;
                         }
                     }
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -1413,7 +1413,7 @@ int perfmon_readCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                     if (haveLock && HPMcheck(dev, cpu_id))
                     {
                         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_SBOX_FIXED)
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX_FIXED");
                         if (eventSet->events[i].event.eventId == 0x00)
                         {
                             switch (extractBitField(counter_result,3,0))
@@ -1445,7 +1445,7 @@ int perfmon_readCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                         {
                             counter_result = extractBitField(counter_result,1,4);
                         }
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_SBOX_FIXED_REAL)
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX_FIXED_REAL");
                         eventSet->events[i].threadCounter[thread_id].startData = 0;
                     }
                     break;
@@ -1464,11 +1464,11 @@ int perfmon_readCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                             if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                             {
-                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                                 eventSet->events[i].threadCounter[thread_id].overflows++;
                             }
                             *current = counter_result;
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                         }
                     }
                     break;
@@ -1614,12 +1614,12 @@ int perfmon_finalizeCountersThread_ivybridge(int thread_id, PerfmonEventSet* eve
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 break;
@@ -1631,17 +1631,17 @@ int perfmon_finalizeCountersThread_ivybridge(int thread_id, PerfmonEventSet* eve
         }
         if ((reg) && (((type == PMC)||(type == FIXED))||((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if (type >= SBOX0 && type <= SBOX3)
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (type >= SBOX0 && type <= SBOX3)
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
                 if (type >= SBOX0 && type <= SBOX3)
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
@@ -1653,34 +1653,34 @@ int perfmon_finalizeCountersThread_ivybridge(int thread_id, PerfmonEventSet* eve
     {
         if (cpuid_info.model == IVYBRIDGE_EP)
         {
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_U_PMON_GLOBAL_STATUS, LLU_CAST 0x0ULL, CLEAR_UNCORE_OVF)
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_U_PMON_GLOBAL_STATUS, LLU_CAST 0x0ULL, "CLEAR_UNCORE_OVF");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_U_PMON_GLOBAL_STATUS, 0x0ULL));
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_U_PMON_GLOBAL_CTL, LLU_CAST 0x0ULL, CLEAR_UNCORE_CTRL)
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_U_PMON_GLOBAL_CTL, LLU_CAST 0x0ULL, "CLEAR_UNCORE_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_U_PMON_GLOBAL_CTL, 0x0ULL));
         }
         else if (cpuid_info.model == IVYBRIDGE)
         {
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_PERF_GLOBAL_OVF_CTRL, LLU_CAST 0x0ULL, CLEAR_UNCORE_OVF)
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_PERF_GLOBAL_OVF_CTRL, LLU_CAST 0x0ULL, "CLEAR_UNCORE_OVF");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_PERF_GLOBAL_OVF_CTRL, 0x0ULL));
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_UNCORE_CTRL)
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_UNCORE_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_PERF_GLOBAL_CTRL, 0x0ULL));
         }
         for (int i=UNCORE;i<NUM_UNITS;i++)
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (i >= SBOX0 && i <= SBOX3)
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }
@@ -1689,9 +1689,9 @@ int perfmon_finalizeCountersThread_ivybridge(int thread_id, PerfmonEventSet* eve
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_k10.h
+++ b/src/includes/perfmon_k10.h
@@ -77,7 +77,7 @@ int k10_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -125,12 +125,12 @@ int perfmon_startCountersThread_k10(int thread_id, PerfmonEventSet* eventSet)
             uint32_t counter = counter_map[index].counterRegister;
             eventSet->events[i].threadCounter[thread_id].startData = 0;
             eventSet->events[i].threadCounter[thread_id].counterData = 0;
-            VERBOSEPRINTREG(cpu_id, counter, 0x0ULL, CLEAR_PMC);
+            VERBOSEPRINTREG(cpu_id, counter, 0x0ULL, "CLEAR_PMC");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter, 0x0ULL));
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
-            VERBOSEPRINTREG(cpu_id, reg, flags, READ_PMC_CTRL);
+            VERBOSEPRINTREG(cpu_id, reg, flags, "READ_PMC_CTRL");
             flags |= (1ULL<<22);  /* enable flag */
-            VERBOSEPRINTREG(cpu_id, reg, flags, START_PMC);
+            VERBOSEPRINTREG(cpu_id, reg, flags, "START_PMC");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
         }
     }
@@ -157,12 +157,12 @@ int perfmon_stopCountersThread_k10(int thread_id, PerfmonEventSet* eventSet)
             uint32_t reg = counter_map[index].configRegister;
             uint32_t counter = counter_map[index].counterRegister;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
-            VERBOSEPRINTREG(cpu_id, reg, flags, READ_PMC_CTRL);
+            VERBOSEPRINTREG(cpu_id, reg, flags, "READ_PMC_CTRL");
             flags &= ~(1ULL<<22);  /* clear enable flag */
-            VERBOSEPRINTREG(cpu_id, reg, flags, STOP_PMC);
+            VERBOSEPRINTREG(cpu_id, reg, flags, "STOP_PMC");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &tmp));
-            VERBOSEPRINTREG(cpu_id, counter, tmp, READ_PMC);
+            VERBOSEPRINTREG(cpu_id, counter, tmp, "READ_PMC");
             if (tmp < eventSet->events[i].threadCounter[thread_id].counterData)
             {
                 eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -191,7 +191,7 @@ int perfmon_readCountersThread_k10(int thread_id, PerfmonEventSet* eventSet)
             RegisterIndex index = eventSet->events[i].index;
             uint32_t counter = counter_map[index].counterRegister;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &tmp));
-            VERBOSEPRINTREG(cpu_id, counter, tmp, READ_PMC);
+            VERBOSEPRINTREG(cpu_id, counter, tmp, "READ_PMC");
             if (tmp < eventSet->events[i].threadCounter[thread_id].counterData)
             {
                 eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -218,9 +218,9 @@ int perfmon_finalizeCountersThread_k10(int thread_id, PerfmonEventSet* eventSet)
         uint32_t reg = counter_map[index].configRegister;
         if (reg)
         {
-            VERBOSEPRINTREG(cpu_id, reg, 0x0ULL, CLEAR_CTRL);
+            VERBOSEPRINTREG(cpu_id, reg, 0x0ULL, "CLEAR_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, 0x0ULL));
-            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
         }
         eventSet->events[i].threadCounter[thread_id].init = FALSE;

--- a/src/includes/perfmon_kabini.h
+++ b/src/includes/perfmon_kabini.h
@@ -80,7 +80,7 @@ int k16_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -99,7 +99,7 @@ int k16_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     flags |= ((uint64_t)(event->eventId>>8)<<32) + (event->umask<<8) + (event->eventId & ~(0xF00U));
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_UNCORE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -144,7 +144,7 @@ int k16_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -312,7 +312,7 @@ int perfmon_readCountersThread_kabini(int thread_id, PerfmonEventSet* eventSet)
                 ((type == CBOX0) && (haveTLock)))
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, counter_result, CLEAR_CTRL);
+                VERBOSEPRINTREG(cpu_id, counter, counter_result, "CLEAR_CTRL");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -351,9 +351,9 @@ int perfmon_finalizeCountersThread_kabini(int thread_id, PerfmonEventSet* eventS
             ((type == UNCORE) && (haveSLock)) ||
             ((type == CBOX0) && (haveTLock)))
         {
-            VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, CLEAR_CTRL);
+            VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, "CLEAR_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, 0x0ULL));
-            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
             eventSet->events[i].threadCounter[thread_id].init = FALSE;
         }

--- a/src/includes/perfmon_knl.h
+++ b/src/includes/perfmon_knl.h
@@ -150,13 +150,13 @@ int knl_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
             {
                 offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
             }
-            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , offcore_flags));
         }
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -196,7 +196,7 @@ int knl_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_UBOX)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -250,7 +250,7 @@ int knl_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_WBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -333,7 +333,7 @@ int knl_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (filter_flags0 != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, SETUP_CBOX_FILTER0);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, "SETUP_CBOX_FILTER0");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags0));
     }
     else
@@ -342,7 +342,7 @@ int knl_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (filter_flags1 != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, SETUP_CBOX_FILTER1);
+        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, "SETUP_CBOX_FILTER1");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags1));
     }
     else
@@ -354,26 +354,26 @@ int knl_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags0));
         filter_flags0 |= (1ULL<<18)|(1ULL<<19)|(1ULL<<20);
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, SETUP_CBOX_DEF_FILTER_STATE);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, "SETUP_CBOX_DEF_FILTER_STATE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags0));
     }
     if (set_match1_all)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter1, &filter_flags1));
         filter_flags1 |= (1ULL<<4)|(1ULL<<5);
-        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, SETUP_CBOX_COUNT_ALL_CACHE_EVENTS);
+        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, "SETUP_CBOX_COUNT_ALL_CACHE_EVENTS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags1));
     }
     if (set_opcode_all)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter1, &filter_flags1));
         filter_flags1 |= (1ULL<<3);
-        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, SETUP_CBOX_COUNT_ALL_OPCODES);
+        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, "SETUP_CBOX_COUNT_ALL_OPCODES");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags1));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -419,7 +419,7 @@ int knl_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_BOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_BOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -444,15 +444,15 @@ int perfmon_setupCountersThread_knl(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, 0x0ULL, FREEZE_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, 0x0ULL, "FREEZE_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, 0x0ULL));
     }
 
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_CTRL, 0x0ULL, "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_MIC2_U_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_MIC2_U_GLOBAL_CTRL, (1ULL<<63)));
     }
@@ -490,7 +490,7 @@ int perfmon_setupCountersThread_knl(
                 if (haveLock)
                 {
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, (1ULL<<22)|(1ULL<<20)));
-                    VERBOSEPRINTREG(cpu_id, reg, (1ULL<<22)|(1ULL<<20), SETUP_UBOXFIX);
+                    VERBOSEPRINTREG(cpu_id, reg, (1ULL<<22)|(1ULL<<20), "SETUP_UBOXFIX");
                 }
                 break;
 
@@ -595,7 +595,7 @@ int perfmon_setupCountersThread_knl(
                 if (haveLock)
                 {
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x1ULL));
-                    VERBOSEPRINTREG(cpu_id, reg, 0x1ULL, SETUP_MBOXFIX);
+                    VERBOSEPRINTREG(cpu_id, reg, 0x1ULL, "SETUP_MBOXFIX");
                 }
                 break;
 
@@ -607,13 +607,13 @@ int perfmon_setupCountersThread_knl(
     {
         if (haveLock && TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
         {
-            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+            VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
             HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
         }
     }
     if (fixed_flags > 0x0)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -622,14 +622,14 @@ int perfmon_setupCountersThread_knl(
 #define KNL_FREEZE_UNCORE \
     if (haveLock && MEASURE_UNCORE(eventSet)) \
     { \
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<63), FREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<63), "FREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<63))); \
     }
 
 #define KNL_UNFREEZE_UNCORE \
     if (haveLock && MEASURE_UNCORE(eventSet)) \
     { \
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<61), UNFREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, LLU_CAST (1ULL<<61), "UNFREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<61))); \
     }
 
@@ -647,16 +647,16 @@ int perfmon_setupCountersThread_knl(
             PciDeviceIndex dev = counter_map[index].device; \
             if (HPMcheck(dev, cpu_id) && TESTTYPE(eventSet, type)) \
             { \
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR_MANUAL); \
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR_MANUAL"); \
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL)); \
                 if (counter_map[index].counterRegister2 != 0x0) \
                 { \
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR_MANUAL); \
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR_MANUAL"); \
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL)); \
                 } \
             } \
         } \
-        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_CTRL, LLU_CAST (1ULL<<61), UNFREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_CTRL, LLU_CAST (1ULL<<61), "UNFREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_MIC2_U_GLOBAL_CTRL, (1ULL<<61))); \
     }
 
@@ -751,7 +751,7 @@ int perfmon_startCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_OR_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_OR_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -775,21 +775,21 @@ int knl_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
     }
 
     CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &result));
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, READ_REG_1);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, "READ_REG_1");
     if (flags & FREEZE_FLAG_CLEAR_CTR)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, CLEAR_PCI_REG_1);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, "CLEAR_PCI_REG_1");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0U));
     }
     if (counter2 != 0x0)
     {
         result <<= 32;
         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter2, &tmp));
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp, READ_REG_2);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp, "READ_REG_2");
         result += tmp;
         if (flags & FREEZE_FLAG_CLEAR_CTR)
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST 0x0U, CLEAR_PCI_REG_2);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST 0x0U, "CLEAR_PCI_REG_2");
             CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter2, 0x0U));
         }
     }
@@ -804,10 +804,10 @@ int knl_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV,
                                            MSR_PERF_GLOBAL_STATUS,
                                            &ovf_values));
-            VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_STATUS, LLU_CAST ovf_values, READ_GLOBAL_OVFL);
+            VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_STATUS, LLU_CAST ovf_values, "READ_GLOBAL_OVFL");
             if (ovf_values & (1<<global_offset))
             {
-                VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_STATUS, LLU_CAST (1<<global_offset), CLEAR_GLOBAL_OVFL);
+                VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_STATUS, LLU_CAST (1<<global_offset), "CLEAR_GLOBAL_OVFL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV,
                                                  MSR_MIC2_U_GLOBAL_STATUS,
                                                  (1<<global_offset)));
@@ -825,11 +825,11 @@ int knl_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev,
                                               box_map[type].statusRegister,
                                               &ovf_values));
-            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, READ_BOX_OVFL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, "READ_BOX_OVFL");
             if (ovf_values & (1<<box_offset))
             {
                 (*overflows)++;
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), RESET_BOX_OVFL);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), "RESET_BOX_OVFL");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev,
                                                     box_map[type].statusRegister,
                                                     (1<<box_offset)));
@@ -869,7 +869,7 @@ int perfmon_stopCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_OR_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_OR_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -898,12 +898,12 @@ int perfmon_stopCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     KNL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     KNL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case POWER:
@@ -1019,9 +1019,9 @@ int perfmon_stopCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
                     {
                         uint64_t tmp = 0x0ULL;
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_FIXED_BOX_1);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_FIXED_BOX_1");
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter2, &tmp));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp , READ_FIXED_BOX_1);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter2, LLU_CAST tmp , "READ_FIXED_BOX_1");
                         counter_result = (counter_result<<32)|tmp;
                         counter_result = field64(counter_result, 0, box_map[type].regWidth);
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
@@ -1055,7 +1055,7 @@ int perfmon_readCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &pmc_flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_OR_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_OR_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     KNL_FREEZE_UNCORE;
@@ -1082,12 +1082,12 @@ int perfmon_readCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     KNL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     KNL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case POWER:
@@ -1259,12 +1259,12 @@ int perfmon_finalizeCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
                 {
                     if (event->umask == 0x1)
                     {
-                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                     }
                     else if (event->umask == 0x2)
                     {
-                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                     }
                 }
@@ -1277,7 +1277,7 @@ int perfmon_finalizeCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
         }
         if ((reg) && (((type == PMC)||(type == FIXED))||((type >= UNCORE) && (haveLock))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
         }
         eventSet->events[i].threadCounter[thread_id].init = FALSE;
@@ -1287,17 +1287,17 @@ int perfmon_finalizeCountersThread_knl(int thread_id, PerfmonEventSet* eventSet)
     {
         uint64_t ovf_values_uncore = 0x0ULL;
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV,MSR_MIC2_U_GLOBAL_STATUS, &ovf_values_uncore));
-        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_STATUS, LLU_CAST ovf_values_uncore, CLEAR_UNCORE_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_STATUS, LLU_CAST ovf_values_uncore, "CLEAR_UNCORE_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_MIC2_U_GLOBAL_STATUS, ovf_values_uncore));
-        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_CTRL, LLU_CAST (1ULL<<59), CLEAR_UNCORE_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_MIC2_U_GLOBAL_CTRL, LLU_CAST (1ULL<<59), "CLEAR_UNCORE_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_MIC2_U_GLOBAL_CTRL, (1ULL<<59)));
     }
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
     }
     return 0;

--- a/src/includes/perfmon_nehalem.h
+++ b/src/includes/perfmon_nehalem.h
@@ -206,7 +206,7 @@ int neh_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
              (cpuid_info.model == NEHALEM_LYNNFIELD) ||
              (cpuid_info.model == NEHALEM_LYNNFIELD_M))
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_ONLY_ERROR, "Register documented in SDM but ADDR_OPCODE_MATCH event not documented for Nehalem architectures");
+            DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Register documented in SDM but ADDR_OPCODE_MATCH event not documented for Nehalem architectures");
         }
         VERBOSEPRINTREG(cpu_id, MSR_UNCORE_ADDR_OPCODE_MATCH, LLU_CAST mask_flags, "SETUP_UNCORE_MATCH");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_ADDR_OPCODE_MATCH, mask_flags));

--- a/src/includes/perfmon_nehalem.h
+++ b/src/includes/perfmon_nehalem.h
@@ -124,7 +124,7 @@ int neh_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     if ((event->eventId == 0xBB) &&
@@ -134,12 +134,12 @@ int neh_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -206,14 +206,14 @@ int neh_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
              (cpuid_info.model == NEHALEM_LYNNFIELD) ||
              (cpuid_info.model == NEHALEM_LYNNFIELD_M))
         {
-            DEBUG_PLAIN_PRINT(DEBUGLEV_ONLY_ERROR, Register documented in SDM but ADDR_OPCODE_MATCH event not documented for Nehalem architectures);
+            DEBUG_PLAIN_PRINT(DEBUGLEV_ONLY_ERROR, "Register documented in SDM but ADDR_OPCODE_MATCH event not documented for Nehalem architectures");
         }
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_ADDR_OPCODE_MATCH, LLU_CAST mask_flags, SETUP_UNCORE_MATCH);
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_ADDR_OPCODE_MATCH, LLU_CAST mask_flags, "SETUP_UNCORE_MATCH");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_ADDR_OPCODE_MATCH, mask_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_UNCORE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -269,7 +269,7 @@ int perfmon_setupCounterThread_nehalem(int thread_id, PerfmonEventSet* eventSet)
                     }
                     else
                     {
-                        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_FIXED_CTR_CTRL, LLU_CAST 0x1ULL, SETUP_UPMCFIX);
+                        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_FIXED_CTR_CTRL, LLU_CAST 0x1ULL, "SETUP_UPMCFIX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_FIXED_CTR_CTRL, 0x1ULL));
                     }
                 }
@@ -280,7 +280,7 @@ int perfmon_setupCounterThread_nehalem(int thread_id, PerfmonEventSet* eventSet)
     }
     if (fixed_flags != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -344,13 +344,13 @@ int perfmon_startCountersThread_nehalem(int thread_id, PerfmonEventSet* eventSet
 
     if (haveLock && (uflags != 0x0ULL) && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST uflags, UNFREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST uflags, "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, uflags));
     }
 
     if ((flags != 0x0ULL) && (MEASURE_CORE(eventSet)))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
     }
@@ -394,13 +394,13 @@ int perfmon_stopCountersThread_nehalem(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -420,19 +420,19 @@ int perfmon_stopCountersThread_nehalem(int thread_id, PerfmonEventSet* eventSet)
             {
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                    VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_PMC");
                     NEH_CHECK_OVERFLOW(index - cpuid_info.perf_num_fixed_ctr);
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                    VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_FIXED");
                     NEH_CHECK_OVERFLOW(index + 32);
                     break;
                 case UNCORE:
                     if(haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_UNCORE);
+                        VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_UNCORE");
                         if (index < NUM_COUNTERS_UNCORE_NEHALEM-1)
                         {
                             NEH_CHECK_UNCORE_OVERFLOW(index - NUM_COUNTERS_CORE_NEHALEM);
@@ -468,14 +468,14 @@ int perfmon_readCountersThread_nehalem(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &pmc_flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, &uncore_flags));
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -495,19 +495,19 @@ int perfmon_readCountersThread_nehalem(int thread_id, PerfmonEventSet* eventSet)
             {
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                    VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_PMC");
                     NEH_CHECK_OVERFLOW(index - cpuid_info.perf_num_fixed_ctr);
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                    VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_FIXED");
                     NEH_CHECK_OVERFLOW(index + 32);
                     break;
                 case UNCORE:
                     if(haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_UNCORE);
+                        VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_UNCORE");
                         if (index < NUM_COUNTERS_UNCORE_NEHALEM-1)
                         {
                             NEH_CHECK_UNCORE_OVERFLOW(index - NUM_COUNTERS_CORE_NEHALEM);
@@ -527,12 +527,12 @@ int perfmon_readCountersThread_nehalem(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, pmc_flags, UNFREEZE_PMC_AND_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, pmc_flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, pmc_flags));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, uncore_flags, UNFREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, uncore_flags, "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, uncore_flags));
     }
     return 0;
@@ -570,19 +570,19 @@ int perfmon_finalizeCountersThread_nehalem(int thread_id, PerfmonEventSet* event
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB) &&
                          ((cpuid_info.model == NEHALEM_WESTMERE) || (cpuid_info.model == NEHALEM_WESTMERE_M)))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0x35) &&
                          ((cpuid_info.model == NEHALEM_WESTMERE) || (cpuid_info.model == NEHALEM_WESTMERE_M)))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_UNCORE_ADDR_OPCODE_MATCH, 0x0ULL, CLEAR_UNCORE_MATCH);
+                    VERBOSEPRINTREG(cpu_id, MSR_UNCORE_ADDR_OPCODE_MATCH, 0x0ULL, "CLEAR_UNCORE_MATCH");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_ADDR_OPCODE_MATCH, 0x0ULL));
                 }
                 break;
@@ -594,13 +594,13 @@ int perfmon_finalizeCountersThread_nehalem(int thread_id, PerfmonEventSet* event
         }
         if ((reg) && (((type == PMC)||(type == FIXED))||((type >= UNCORE) && (haveLock))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
             }
         }
@@ -609,32 +609,32 @@ int perfmon_finalizeCountersThread_nehalem(int thread_id, PerfmonEventSet* event
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core, CLEAR_OVF_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core, "CLEAR_OVF_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, CLEAR_PMC_AND_FIXED_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "CLEAR_PMC_AND_FIXED_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_OVF_CTRL, 0x0ULL, CLEAR_UNCORE_OVF);
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_OVF_CTRL, 0x0ULL, "CLEAR_UNCORE_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_OVF_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL, CLEAR_UNCORE_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL, "CLEAR_UNCORE_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, 0x0ULL));
         for (int i=UNCORE;i<NUM_UNITS;i++)
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }

--- a/src/includes/perfmon_nehalemEX.h
+++ b/src/includes/perfmon_nehalemEX.h
@@ -126,13 +126,13 @@ int nex_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
-        VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_PMC");
         currentConfig[cpu_id][index] = flags;
     }
 
@@ -169,12 +169,12 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 case EVENT_OPTION_MATCH0:
                     subflags2 = (event->options[j].value & 0x3FFFFFFFFULL);
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ADDR_MATCH], subflags2));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MATCH], subflags2, SETUP_MBOX_ADDR_MATCH);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MATCH], subflags2, "SETUP_MBOX_ADDR_MATCH");
                     break;
                 case EVENT_OPTION_MASK0:
                     subflags2 = ((event->options[j].value & 0x1FFFFFFC0ULL)>>6);
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ADDR_MASK], subflags2));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MASK], subflags2, SETUP_MBOX_ADDR_MASK);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MASK], subflags2, "SETUP_MBOX_ADDR_MASK");
                     break;
                 default:
                     break;
@@ -196,25 +196,25 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], &subflags1));
                     subflags1 |= (event->umask & 0xFULL)<<7;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, SETUP_MBOX_DSP);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, "SETUP_MBOX_DSP");
                     break;
                 case 0x01:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], &subflags1));
                     subflags1 |= (event->umask & 0x7ULL)<<4;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, SETUP_MBOX_ISS);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, "SETUP_MBOX_ISS");
                     break;
                 case 0x05:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], &subflags1));
                     subflags1 |= (event->umask & 0x1ULL)<<6;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, SETUP_MBOX_PGT);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, "SETUP_MBOX_PGT");
                     break;
                 case 0x06:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][MAP], &subflags1));
                     subflags1 |= (event->umask & 0x7ULL)<<6;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][MAP], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][MAP], subflags1, SETUP_MBOX_MAP);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][MAP], subflags1, "SETUP_MBOX_MAP");
                     break;
             }
             break;
@@ -232,16 +232,16 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags2 |= (event->cmask & 0x7ULL)<<7;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PLD], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, SETUP_MBOX_PLD);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, "SETUP_MBOX_PLD");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags2));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags2, SETUP_MBOX_ISS);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags2, "SETUP_MBOX_ISS");
             break;
         case 0x03:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], &subflags1));
             subflags1 |= (event->umask & 0xFULL)<<7;
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, SETUP_MBOX_DSP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, "SETUP_MBOX_DSP");
             break;
         case 0x04:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -263,14 +263,14 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PLD], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, SETUP_MBOX_PLD);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, "SETUP_MBOX_PLD");
             break;
         case 0x05:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], &subflags1));
             subflags1 |= (event->umask & 0xFULL);
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, SETUP_MBOX_ISS);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, "SETUP_MBOX_ISS");
             break;
         case 0x06:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -285,7 +285,7 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x07:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -300,7 +300,7 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x08:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -315,7 +315,7 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x09:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -330,28 +330,28 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x0A:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], &subflags1));
             subflags1 |= (event->umask & 0x1ULL)<<10;
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, SETUP_MBOX_ISS);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, "SETUP_MBOX_ISS");
             break;
         case 0x0B:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], &subflags1));
             subflags1 |= (event->umask & 0x1ULL);
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, SETUP_MBOX_PGT);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, "SETUP_MBOX_PGT");
             break;
         case 0x0C:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], &subflags1));
             subflags1 |= (event->umask & 0x1ULL)<<11;
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, SETUP_MBOX_PGT);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, "SETUP_MBOX_PGT");
             break;
         case 0x0D:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -367,7 +367,7 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<4;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][THR], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, SETUP_MBOX_THR);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, "SETUP_MBOX_THR");
             break;
         case 0x0E:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -383,13 +383,13 @@ int nex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<4;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][THR], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, SETUP_MBOX_THR);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, "SETUP_MBOX_THR");
             break;
     }
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_MBOX)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_MBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -483,7 +483,7 @@ int nex_rbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_RBOX)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_RBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -510,11 +510,11 @@ int nex_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
             {
                 case EVENT_OPTION_MATCH0:
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, event->options[j].value & 0xFFFFFFFFFFFFFFFULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, LLU_CAST event->options[j].value & 0xFFFFFFFFFFFFFFFULL, SETUP_BBOX_MATCH);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, LLU_CAST event->options[j].value & 0xFFFFFFFFFFFFFFFULL, "SETUP_BBOX_MATCH");
                     break;
                 case EVENT_OPTION_MASK0:
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, event->options[j].value & 0xFFFFFFFFFFFFFFFULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, LLU_CAST event->options[j].value & 0xFFFFFFFFFFFFFFFULL, SETUP_BBOX_MASK);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, LLU_CAST event->options[j].value & 0xFFFFFFFFFFFFFFFULL, "SETUP_BBOX_MASK");
                     break;
                 default:
                     break;
@@ -524,7 +524,7 @@ int nex_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-        VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_BBOX);
+        VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_BBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -566,7 +566,7 @@ int nex_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-        VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_CBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -607,7 +607,7 @@ int nex_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-        VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_WBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -645,12 +645,12 @@ int nex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 
                 if (type == SBOX0)
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, 0x0ULL, CLEAR_MM_CFG);
+                    VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, 0x0ULL, "CLEAR_MM_CFG");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S0_PMON_MM_CFG, 0x0ULL));
                 }
                 else
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, 0x0ULL, CLEAR_MM_CFG);
+                    VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, 0x0ULL, "CLEAR_MM_CFG");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S1_PMON_MM_CFG, 0x0ULL));
                 }
             }
@@ -672,14 +672,14 @@ int nex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     if (event->eventId == 0x0)
                     {
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, event->options[j].value));
-                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, LLU_CAST event->options[j].value, SETUP_SBOX_MATCH);
+                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, LLU_CAST event->options[j].value, "SETUP_SBOX_MATCH");
                     }
                     break;
                 case EVENT_OPTION_MASK0:
                     if (event->eventId == 0x0)
                     {
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, event->options[j].value));
-                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, LLU_CAST event->options[j].value, SETUP_SBOX_MASK);
+                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, LLU_CAST event->options[j].value, "SETUP_SBOX_MASK");
                     }
                     break;
                 default:
@@ -690,12 +690,12 @@ int nex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             if (type == SBOX0)
             {
-                VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, (1ULL<<63), SET_MM_CFG);
+                VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, (1ULL<<63), "SET_MM_CFG");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S0_PMON_MM_CFG, (1ULL<<63)));
             }
             else
             {
-                VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, (1ULL<<63), SET_MM_CFG);
+                VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, (1ULL<<63), "SET_MM_CFG");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S1_PMON_MM_CFG, (1ULL<<63)));
             }
         }
@@ -703,7 +703,7 @@ int nex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-        VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_SBOX);
+        VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_SBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -715,7 +715,7 @@ int nex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         uint64_t tmp = 0x0ULL; \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, &tmp)); \
         tmp &= ~(1ULL<<28); \
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST tmp, FREEZE_UNCORE) \
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST tmp, "FREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, tmp)); \
     }
 
@@ -735,13 +735,13 @@ int perfmon_setupCounterThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE)
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL, "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL));
     }
     if (haveLock && TESTTYPE(eventSet, MBOX0))
@@ -862,7 +862,7 @@ int perfmon_setupCounterThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
                     flags = 0x1ULL;
                     RegisterType newtype = WBOX;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-                    VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_WBOXFIX)
+                    VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_WBOXFIX");
                     SETTYPE(eventSet, newtype);
                 }
                 break;
@@ -881,7 +881,7 @@ int perfmon_setupCounterThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
                         }
                     }
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-                    VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_UBOX);
+                    VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_UBOX");
                     ubox_flags = 0x1ULL;
                 }
                 break;
@@ -893,12 +893,12 @@ int perfmon_setupCounterThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
 
     if (fixed_flags != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     if (ubox_flags != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST ubox_flags, ACTIVATE_UBOX);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST ubox_flags, "ACTIVATE_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, ubox_flags));
     }
     return 0;
@@ -910,7 +910,7 @@ int perfmon_setupCounterThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
         uint64_t tmp = 0x0ULL; \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, &tmp)); \
         tmp |= (1ULL<<29); \
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST tmp, RESET_ALL_UNCORE_COUNTERS); \
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST tmp, "RESET_ALL_UNCORE_COUNTERS"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, tmp)); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, 0x0U)); \
     }
@@ -921,14 +921,14 @@ int perfmon_setupCounterThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
         uint64_t tmp = 0x0ULL; \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, &tmp)); \
         tmp |= (1ULL<<28); \
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST tmp, UNFREEZE_UNCORE); \
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST tmp, "UNFREEZE_UNCORE"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, tmp)); \
     }
 
 #define NEX_UNFREEZE_BOX(id, flags) \
     if (haveLock && TESTTYPE(eventSet, id)) \
     { \
-        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST flags, UNFREEZE_BOX); \
+        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST flags, "UNFREEZE_BOX"); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[id].ctrlRegister, flags)); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[id].ovflRegister, flags)); \
     }
@@ -1002,7 +1002,7 @@ int perfmon_startCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eventS
     /* Finally enable counters */
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, GLOBAL_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, "GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, core_ctrl_flags));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|core_ctrl_flags));
     }
@@ -1046,7 +1046,7 @@ int perfmon_stopCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, FREEZE_PMC_AND_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     NEX_FREEZE_UNCORE;
@@ -1068,19 +1068,19 @@ int perfmon_stopCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter_map[index].counterRegister, &counter_result));
                     NEX_CHECK_OVERFLOW(PMC, index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST counter_result, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter_map[index].counterRegister, &counter_result));
                     NEX_CHECK_OVERFLOW(PMC, index+32);
-                    VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST counter_result, READ_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST counter_result, "READ_FIXED");
                     break;
                 default:
                     if (haveLock && TESTTYPE(eventSet, counter_map[index].type))
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter_map[index].counterRegister, &counter_result));
                         NEX_CHECK_UNCORE_OVERFLOW(counter_map[index].type, getCounterTypeOffset(index));
-                        VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST counter_result, READ_UNCORE);
+                        VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST counter_result, "READ_UNCORE");
                     }
                     break;
             }
@@ -1126,19 +1126,19 @@ int perfmon_readCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eventSe
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
                     NEX_CHECK_OVERFLOW(PMC, index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
                     NEX_CHECK_OVERFLOW(PMC, index+32);
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                     break;
                 default:
                     if (haveLock && TESTTYPE(eventSet, counter_map[index].type))
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
                         NEX_CHECK_UNCORE_OVERFLOW(counter_map[index].type, getCounterTypeOffset(index));
-                        VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_UNCORE);
+                        VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_UNCORE");
                     }
                     break;
             }
@@ -1186,12 +1186,12 @@ int perfmon_finalizeCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eve
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (event->eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (event->eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 break;
@@ -1202,31 +1202,31 @@ int perfmon_finalizeCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eve
             case MBOX1:
                 if (haveLock && ((event->cfgBits == 0x02) || (event->cfgBits == 0x04)))
                 {
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, CLEAR_MATCH0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, "CLEAR_MATCH0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, 0x0ULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, CLEAR_MASK0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, "CLEAR_MASK0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, 0x0ULL));
                 }
                 break;
             case SBOX0:
                 if (haveLock && (event->eventId == 0x00))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, 0x0ULL, CLEAR_MM_CFG);
+                    VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, 0x0ULL, "CLEAR_MM_CFG");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S0_PMON_MM_CFG, 0x0ULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, CLEAR_MATCH0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, "CLEAR_MATCH0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, 0x0ULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, CLEAR_MASK0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, "CLEAR_MASK0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, 0x0ULL));
                 }
                 break;
             case SBOX1:
                 if (haveLock && (event->eventId == 0x00))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, 0x0ULL, CLEAR_MM_CFG);
+                    VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, 0x0ULL, "CLEAR_MM_CFG");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S1_PMON_MM_CFG, 0x0ULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, CLEAR_MATCH0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, "CLEAR_MATCH0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, 0x0ULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, CLEAR_MASK0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, "CLEAR_MASK0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, 0x0ULL));
                 }
                 break;
@@ -1239,9 +1239,9 @@ int perfmon_finalizeCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eve
                                  (event->eventId == 0x05) ||
                                  (event->eventId == 0x06)))
                 {
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, CLEAR_MATCH0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, 0x0ULL, "CLEAR_MATCH0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, 0x0ULL));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, CLEAR_MASK0);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, 0x0ULL, "CLEAR_MASK0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, 0x0ULL));
                 }
                 break;
@@ -1250,13 +1250,13 @@ int perfmon_finalizeCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eve
         }
         if ((reg) && (((dev == MSR_DEV) && (type < UNCORE)) || (((haveLock) && (type > UNCORE)))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
             }
         }
@@ -1265,32 +1265,32 @@ int perfmon_finalizeCountersThread_nehalemEX(int thread_id, PerfmonEventSet* eve
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core, CLEAR_OVF_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core, "CLEAR_OVF_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, CLEAR_PMC_AND_FIXED_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "CLEAR_PMC_AND_FIXED_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_OVF_CTRL, 0x0ULL, CLEAR_UNCORE_OVF);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_OVF_CTRL, 0x0ULL, "CLEAR_UNCORE_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_OVF_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL, CLEAR_UNCORE_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL, "CLEAR_UNCORE_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL));
         for (int i=UNCORE;i<NUM_UNITS;i++)
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }

--- a/src/includes/perfmon_perfevent.h
+++ b/src/includes/perfmon_perfevent.h
@@ -104,7 +104,7 @@ int perfevent_paranoid_value()
     if (fd == NULL)
     {
         errno = EPERM;
-        ERROR_PRINT(Linux kernel has no perf_event support. Cannot access /proc/sys/kernel/perf_event_paranoid);
+        ERROR_PRINT("Linux kernel has no perf_event support. Cannot access /proc/sys/kernel/perf_event_paranoid");
         return paranoid;
     }
     size_t read = fread(buff, sizeof(char), 100, fd);
@@ -132,7 +132,7 @@ int perfevent_apple_m1_pmc_type_select(int cpu_id, enum apple_m1_pmc_type *type)
     fd = fopen(bdata(fname), "r");
     if (fd == NULL)
     {
-        ERROR_PRINT(Failed to detect PMU type for Apple M1);
+        ERROR_PRINT("Failed to detect PMU type for Apple M1");
         bdestroy(fname);
         return errno;
     }
@@ -152,7 +152,7 @@ int perfevent_apple_m1_pmc_type_select(int cpu_id, enum apple_m1_pmc_type *type)
     }
     else
     {
-        ERROR_PRINT(Cannot read %s, bdata(fname));
+        ERROR_PRINT("Cannot read %s", bdata(fname));
     }
     bdestroy(fname);
     return -1;
@@ -166,7 +166,7 @@ int perfmon_init_perfevent(int cpu_id)
     if (getuid() != 0 && perf_event_paranoid > 2)
     {
         errno = EPERM;
-        ERROR_PRINT(Cannot use performance monitoring with perf_event_paranoid = %d, perf_event_paranoid);
+        ERROR_PRINT("Cannot use performance monitoring with perf_event_paranoid = %d", perf_event_paranoid);
         return -(cpu_id+1);
     }
 
@@ -725,7 +725,7 @@ int perf_uncore_setup(struct perf_event_attr *attr, RegisterType type, PerfmonEv
         return EPERM;
     }
     attr->type = 0;
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Get information for uncore counters from folder(s): %s, translate_types[type]);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Get information for uncore counters from folder(s): %s", translate_types[type]);
     perf_folder = bfromcstr(translate_types[type]);
     folders = bsplit(perf_folder, ' ');
     bdestroy(perf_folder);
@@ -748,7 +748,7 @@ int perf_uncore_setup(struct perf_event_attr *attr, RegisterType type, PerfmonEv
     {
         if ((type == UBOX)||(type == UBOXFIX))
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Get information for uncore counters from folder /sys/bus/event_source/devices/uncore_arb);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Get information for uncore counters from folder /sys/bus/event_source/devices/uncore_arb");
             perf_type = read_perf_event_type("/sys/bus/event_source/devices/uncore_arb");
         }
     }
@@ -828,12 +828,12 @@ int perf_uncore_setup(struct perf_event_attr *attr, RegisterType type, PerfmonEv
             if (type >= CBOX0 && type <= CBOX59 && cpuid_info.isIntel && num_formats > 1
                 && (cpuid_info.model == ICELAKEX1 || cpuid_info.model == ICELAKEX2 || cpuid_info.model == SAPPHIRERAPIDS))
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Applying special umask handling for CBOXes of Intel ICX and SPR chips);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Applying special umask handling for CBOXes of Intel ICX and SPR chips");
                 for(int j = 0; j < event->numberOfOptions; j++)
                 {
                     if (event->options[j].type == EVENT_OPTION_MATCH0)
                     {
-                        DEBUG_PRINT(DEBUGLEV_DEVELOP, 0x%lX (0x%lX | (0x%lX << (%d - %d))), umask | (event->options[j].value << (formats[0].end - formats[0].start)), umask, event->options[j].value, formats[0].end, formats[0].start);
+                        DEBUG_PRINT(DEBUGLEV_DEVELOP, "0x%lX (0x%lX | (0x%lX << (%d - %d)))", umask | (event->options[j].value << (formats[0].end - formats[0].start)), umask, event->options[j].value, formats[0].end, formats[0].start);
                         umask |= (event->options[j].value << (formats[0].end - formats[0].start + 1));
                         break;
                     }
@@ -841,11 +841,11 @@ int perf_uncore_setup(struct perf_event_attr *attr, RegisterType type, PerfmonEv
             }
             for (int i = 0; i < num_formats && umask != 0x0; i++)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Format %s from %d-%d with value 0x%lX, perfEventOptionNames[EVENT_OPTION_GENERIC_UMASK], formats[i].start, formats[i].end, umask);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Format %s from %d-%d with value 0x%lX", perfEventOptionNames[EVENT_OPTION_GENERIC_UMASK], formats[i].start, formats[i].end, umask);
                 switch(formats[i].reg)
                 {
                     case CONFIG:
-                        DEBUG_PRINT(DEBUGLEV_DEVELOP, Adding 0x%lX to 0x%X, create_mask(umask, formats[i].start, formats[i].end), attr->config);
+                        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding 0x%lX to 0x%X", create_mask(umask, formats[i].start, formats[i].end), attr->config);
                         attr->config |= create_mask(umask, formats[i].start, formats[i].end);
                         break;
                     case CONFIG1:
@@ -943,17 +943,17 @@ int perf_uncore_setup(struct perf_event_attr *attr, RegisterType type, PerfmonEv
         }
         if (!got_cid)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, AMD Zen4 L3: activate counting for all cores);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "AMD Zen4 L3: activate counting for all cores");
             attr->config |= (1ULL<<47);
         }
         if (!got_tid)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, AMD Zen4 L3: activate counting for all SMT threads);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "AMD Zen4 L3: activate counting for all SMT threads");
             attr->config |= (0x3ULL<<56);
         }
         if (!got_slices)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, AMD Zen4 L3: activate counting for all L3 slices);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "AMD Zen4 L3: activate counting for all L3 slices");
             attr->config |= (1ULL<<46);
         }
     }
@@ -987,10 +987,10 @@ int perfmon_setupCountersThread_perfevent(
     {
         if (allpid == -1)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, PID of application required. Use LIKWID_PERF_PID env variable or likwid-perfctr options);
+            DEBUG_PRINT(DEBUGLEV_INFO, "PID of application required. Use LIKWID_PERF_PID env variable or likwid-perfctr options");
             return -EPERM;
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Using PID %d for perf_event measurements, allpid);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Using PID %d for perf_event measurements", allpid);
     }
 
     if (getenv("LIKWID_PERF_FLAGS") != NULL)
@@ -1035,7 +1035,7 @@ int perfmon_setupCountersThread_perfevent(
                 {
                     continue;
                 }
-                VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_FIXED);
+                VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_FIXED");
                 break;
             case PERF:
                 ret = perf_perf_setup(&attr, index, event);
@@ -1043,7 +1043,7 @@ int perfmon_setupCountersThread_perfevent(
                 {
                     continue;
                 }
-                VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_PERF);
+                VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_PERF");
                 break;
             case METRICS:
                 ret = perf_metrics_setup(&attr, index, event);
@@ -1051,7 +1051,7 @@ int perfmon_setupCountersThread_perfevent(
                 {
                     continue;
                 }
-                VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_METRICS);
+                VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_METRICS");
                 break;
             case PMC:
                 pmc_lock = 1;
@@ -1074,18 +1074,18 @@ int perfmon_setupCountersThread_perfevent(
                 else if (cpuid_info.vendor == APPLE_M1 && cpuid_info.model == APPLE_M1_STUDIO)
                 {
                     enum apple_m1_pmc_type ptype = M1_UNKNOWN;
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Getting real perf_event type for HWThread %d, cpu_id);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Getting real perf_event type for HWThread %d", cpu_id);
                     ret = perfevent_apple_m1_pmc_type_select(cpu_id, &ptype);
                     if (ret == 0)
                     {
                         switch (ptype)
                         {
                             case M1_ICESTORM:
-                                DEBUG_PRINT(DEBUGLEV_DEVELOP, HWThread %d is an icestorm core, cpu_id);
+                                DEBUG_PRINT(DEBUGLEV_DEVELOP, "HWThread %d is an icestorm core", cpu_id);
                                 type = IPMC;
                                 break;
                             case M1_FIRESTORM:
-                                DEBUG_PRINT(DEBUGLEV_DEVELOP, HWThread %d is an firestorm core, cpu_id);
+                                DEBUG_PRINT(DEBUGLEV_DEVELOP, "HWThread %d is an firestorm core", cpu_id);
                                 type = FPMC;
                                 break;
                             default:
@@ -1095,7 +1095,7 @@ int perfmon_setupCountersThread_perfevent(
                     }
                     else
                     {
-                        ERROR_PRINT(Failed getting real perf_event type for HWThread %d, cpu_id);
+                        ERROR_PRINT("Failed getting real perf_event type for HWThread %d", cpu_id);
                         pmc_lock = 0;
                     }
                 }
@@ -1103,14 +1103,14 @@ int perfmon_setupCountersThread_perfevent(
                 if (pmc_lock)
                 {
                     ret = perf_pmc_setup(&attr, index, type, event);
-                    VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_PMC);
+                    VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_PMC");
                 }
                 break;
             case POWER:
                 if (cpuid_info.isIntel && socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
                 {
                     has_lock = 1;
-                    VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_POWER);
+                    VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_POWER");
                     ret = perf_uncore_setup(&attr, type, event);
                 }
                 else if ((cpuid_info.family == ZEN_FAMILY || cpuid_info.family == ZEN3_FAMILY))
@@ -1118,19 +1118,19 @@ int perfmon_setupCountersThread_perfevent(
                     if (event->eventId == 0x01 && core_lock[affinity_thread2core_lookup[cpu_id]] == cpu_id)
                     {
                         has_lock = 1;
-                        VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_POWER);
+                        VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_POWER");
                         ret = perf_uncore_setup(&attr, type, event);
                     }
                     else if (event->eventId == 0x02 && socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
                     {
                         has_lock = 1;
-                        VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_POWER);
+                        VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_POWER");
                         ret = perf_uncore_setup(&attr, type, event);
                     }
                     else if (event->eventId == 0x03 && sharedl3_lock[affinity_thread2sharedl3_lookup[cpu_id]] == cpu_id)
                     {
                         has_lock = 1;
-                        VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_POWER);
+                        VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_POWER");
                         ret = perf_uncore_setup(&attr, type, event);
                     }
                 }
@@ -1425,14 +1425,14 @@ int perfmon_setupCountersThread_perfevent(
                 }
                 if ((cpuid_info.family == ARMV8_FAMILY) && (cpuid_info.part == NVIDIA_GRACE) && cpuid_topology.numSockets > 1)
                 {
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Updating uncore type for socket %d on Nvidia Grace, affinity_thread2socket_lookup[cpu_id]);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Updating uncore type for socket %d on Nvidia Grace", affinity_thread2socket_lookup[cpu_id]);
                     type += affinity_thread2socket_lookup[cpu_id];
                 }
                 if (has_lock)
                 {
                     ret = perf_uncore_setup(&attr, type, event);
                     is_uncore = 1;
-                    VERBOSEPRINTREG(cpu_id, index, attr.config, SETUP_UNCORE);
+                    VERBOSEPRINTREG(cpu_id, index, attr.config, "SETUP_UNCORE");
                 }
                 break;
 #endif
@@ -1449,27 +1449,27 @@ int perfmon_setupCountersThread_perfevent(
 
             if (!is_uncore)
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, perf_event_open: cpu_id=%d pid=%d flags=%d, cpu_id, curpid, allflags);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "perf_event_open: cpu_id=%d pid=%d flags=%d", cpu_id, curpid, allflags);
                 cpu_event_fds[cpu_id][index] = perf_event_open(&attr, curpid, cpu_id, -1, allflags);
             }
             else if ((perf_disable_uncore == 0) && (has_lock))
             {
                 if (perf_event_paranoid > 0 && getuid() != 0)
                 {
-                    DEBUG_PRINT(DEBUGLEV_INFO, Cannot measure Uncore with perf_event_paranoid value = %d, perf_event_paranoid);
+                    DEBUG_PRINT(DEBUGLEV_INFO, "Cannot measure Uncore with perf_event_paranoid value = %d", perf_event_paranoid);
                     perf_disable_uncore = 1;
                 }
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, perf_event_open: cpu_id=%d pid=%d flags=%d type=%d config=0x%llX disabled=%d inherit=%d exclusive=%d config1=0x%llX config2=0x%llX, cpu_id, curpid, allflags, attr.type, attr.config, attr.disabled, attr.inherit, attr.exclusive, attr.config1, attr.config2);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "perf_event_open: cpu_id=%d pid=%d flags=%d type=%d config=0x%llX disabled=%d inherit=%d exclusive=%d config1=0x%llX config2=0x%llX", cpu_id, curpid, allflags, attr.type, attr.config, attr.disabled, attr.inherit, attr.exclusive, attr.config1, attr.config2);
                 cpu_event_fds[cpu_id][index] = perf_event_open(&attr, curpid, cpu_id, -1, allflags);
             }
             else
             {
-                DEBUG_PRINT(DEBUGLEV_INFO, Unknown perf_event_paranoid value = %d, perf_event_paranoid);
+                DEBUG_PRINT(DEBUGLEV_INFO, "Unknown perf_event_paranoid value = %d", perf_event_paranoid);
             }
             if (cpu_event_fds[cpu_id][index] < 0)
             {
-                ERROR_PRINT(Setup of event %s on CPU %d failed: %s, event->name, cpu_id, strerror(errno));
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, open error: cpu_id=%d pid=%d flags=%d type=%d config=0x%llX disabled=%d inherit=%d exclusive=%d config1=0x%llX config2=0x%llX, cpu_id, curpid, allflags, attr.type, attr.config, attr.disabled, attr.inherit, attr.exclusive, attr.config1, attr.config2);
+                ERROR_PRINT("Setup of event %s on CPU %d failed: %s", event->name, cpu_id, strerror(errno));
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "open error: cpu_id=%d pid=%d flags=%d type=%d config=0x%llX disabled=%d inherit=%d exclusive=%d config1=0x%llX config2=0x%llX", cpu_id, curpid, allflags, attr.type, attr.config, attr.disabled, attr.inherit, attr.exclusive, attr.config1, attr.config2);
             }
             if (group_fd < 0)
             {
@@ -1482,7 +1482,7 @@ int perfmon_setupCountersThread_perfevent(
         {
             if (is_uncore && perf_disable_uncore == 0 && perf_event_paranoid > 0 && getuid() != 0)
             {
-                DEBUG_PRINT(DEBUGLEV_INFO, Cannot measure Uncore with perf_event_paranoid value = %d, perf_event_paranoid);
+                DEBUG_PRINT(DEBUGLEV_INFO, "Cannot measure Uncore with perf_event_paranoid value = %d", perf_event_paranoid);
                 perf_disable_uncore = 1;
             }
         }
@@ -1505,7 +1505,7 @@ int perfmon_startCountersThread_perfevent(int thread_id, PerfmonEventSet* eventS
             RegisterIndex index = eventSet->events[i].index;
             if (cpu_event_fds[cpu_id][index] < 0)
                 continue;
-            VERBOSEPRINTREG(cpu_id, 0x0, 0x0, RESET_COUNTER);
+            VERBOSEPRINTREG(cpu_id, 0x0, 0x0, "RESET_COUNTER");
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_RESET, 0);
             PerfmonCounter *c = &eventSet->events[i].threadCounter[thread_id];
             c->startData = 0x0ULL;
@@ -1516,9 +1516,7 @@ int perfmon_startCountersThread_perfevent(int thread_id, PerfmonEventSet* eventS
                         &eventSet->events[i].threadCounter[thread_id].startData,
                         sizeof(long long));
             }
-            VERBOSEPRINTREG(cpu_id, 0x0,
-                            c->startData,
-                            START_COUNTER);
+            VERBOSEPRINTREG(cpu_id, 0x0, c->startData, "START_COUNTER");
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_ENABLE, 0);
         }
     }
@@ -1541,11 +1539,11 @@ int perfmon_stopCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
             RegisterIndex index = eventSet->events[i].index;
             if (cpu_event_fds[cpu_id][index] < 0)
                 continue;
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, FREEZE_COUNTER);
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, "FREEZE_COUNTER");
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_DISABLE, 0);
             tmp = 0x0LL;
             ret = read(cpu_event_fds[cpu_id][index], &tmp, sizeof(long long));
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp, READ_COUNTER);
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp, "READ_COUNTER");
             if (ret == sizeof(long long))
             {
 #if defined(__ARM_ARCH_8A)
@@ -1576,7 +1574,7 @@ int perfmon_stopCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
 
             }
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_RESET, 0);
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, RESET_COUNTER);
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, "RESET_COUNTER");
         }
     }
     return 0;
@@ -1598,11 +1596,11 @@ int perfmon_readCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
             RegisterIndex index = eventSet->events[i].index;
             if (cpu_event_fds[cpu_id][index] < 0)
                 continue;
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, FREEZE_COUNTER);
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, "FREEZE_COUNTER");
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_DISABLE, 0);
             tmp = 0x0LL;
             ret = read(cpu_event_fds[cpu_id][index], &tmp, sizeof(long long));
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp, READ_COUNTER);
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], tmp, "READ_COUNTER");
             if (ret == sizeof(long long))
             {
 #if defined(__ARM_ARCH_8A)
@@ -1631,7 +1629,7 @@ int perfmon_readCountersThread_perfevent(int thread_id, PerfmonEventSet* eventSe
 #endif
                 eventSet->events[i].threadCounter[thread_id].counterData = tmp;
             }
-            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, UNFREEZE_COUNTER);
+            VERBOSEPRINTREG(cpu_id, cpu_event_fds[cpu_id][index], 0x0, "UNFREEZE_COUNTER");
             ioctl(cpu_event_fds[cpu_id][index], PERF_EVENT_IOC_ENABLE, 0);
         }
     }

--- a/src/includes/perfmon_phi.h
+++ b/src/includes/perfmon_phi.h
@@ -77,7 +77,7 @@ int phi_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }

--- a/src/includes/perfmon_pm.h
+++ b/src/includes/perfmon_pm.h
@@ -77,7 +77,7 @@ int pm_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -121,7 +121,7 @@ int perfmon_startCountersThread_pm(int thread_id, PerfmonEventSet* eventSet)
             RegisterIndex index = eventSet->events[i].index;
             eventSet->events[i].threadCounter[thread_id].startData = 0;
             eventSet->events[i].threadCounter[thread_id].counterData = 0;
-            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST 0x0ULL, SETUP_PMC_CTR);
+            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, LLU_CAST 0x0ULL, "SETUP_PMC_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister , 0x0ULL));
         }
     }
@@ -133,7 +133,7 @@ int perfmon_startCountersThread_pm(int thread_id, PerfmonEventSet* eventSet)
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERFEVTSEL0, &flags));
         flags |= (1<<22);
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERFEVTSEL0, flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, LLU_CAST flags, UNFREEZE_PMC);
+        VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, LLU_CAST flags, "UNFREEZE_PMC");
     }
     return 0;
 }
@@ -145,7 +145,7 @@ int perfmon_stopCountersThread_pm(int thread_id, PerfmonEventSet* eventSet)
 
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERFEVTSEL0, &counter_result));
     counter_result &= ~(1<<22);
-    VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, counter_result, FREEZE_PMC);
+    VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, counter_result, "FREEZE_PMC");
     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERFEVTSEL0, counter_result));
 
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -160,7 +160,7 @@ int perfmon_stopCountersThread_pm(int thread_id, PerfmonEventSet* eventSet)
             counter_result = 0x0ULL;
             RegisterIndex index = eventSet->events[i].index;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter_map[index].counterRegister, &counter_result));
-            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, counter_result, READ_PMC);
+            VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, counter_result, "READ_PMC");
             if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
             {
                 eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -179,7 +179,7 @@ int perfmon_readCountersThread_pm(int thread_id, PerfmonEventSet* eventSet)
 
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERFEVTSEL0, &pmc_flags));
     pmc_flags &= ~(1<<22);
-    VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, pmc_flags & ~(1<<22), FREEZE_PMC);
+    VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, pmc_flags & ~(1<<22), "FREEZE_PMC");
     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERFEVTSEL0, pmc_flags & ~(1<<22)));
 
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -203,7 +203,7 @@ int perfmon_readCountersThread_pm(int thread_id, PerfmonEventSet* eventSet)
         }
     }
 
-    VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, pmc_flags, UNFREEZE_PMC);
+    VERBOSEPRINTREG(cpu_id, MSR_PERFEVTSEL0, pmc_flags, "UNFREEZE_PMC");
     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERFEVTSEL0, pmc_flags));
     return 0;
 }
@@ -224,9 +224,9 @@ int perfmon_finalizeCountersThread_pm(int thread_id, PerfmonEventSet* eventSet)
         if ((reg) && ((type == PMC)||(type == FIXED)))
         {
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
         }
         eventSet->events[i].threadCounter[thread_id].init = FALSE;
     }

--- a/src/includes/perfmon_sandybridge.h
+++ b/src/includes/perfmon_sandybridge.h
@@ -166,7 +166,7 @@ int snb_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -175,12 +175,12 @@ int snb_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -222,7 +222,7 @@ int snb_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, SETUP_MBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, "SETUP_MBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -266,7 +266,7 @@ uint32_t snb_cbox_filter(PerfmonEvent *event)
                 }
                 else
                 {
-                    ERROR_PRINT(Invalid value 0x%llx for opcode option, LLU_CAST event->options[j].value);
+                    ERROR_PRINT("Invalid value 0x%llx for opcode option", LLU_CAST event->options[j].value);
                 }
                 break;
             case EVENT_OPTION_STATE:
@@ -277,7 +277,7 @@ uint32_t snb_cbox_filter(PerfmonEvent *event)
                 }
                 else
                 {
-                    ERROR_PRINT(Invalid value 0x%llx for state option, LLU_CAST event->options[j].value);
+                    ERROR_PRINT("Invalid value 0x%llx for state option", LLU_CAST event->options[j].value);
                 }
                 break;
             case EVENT_OPTION_NID:
@@ -292,7 +292,7 @@ uint32_t snb_cbox_filter(PerfmonEvent *event)
                 }
                 else
                 {
-                    ERROR_PRINT(Invalid value 0x%llx for node id option, LLU_CAST event->options[j].value);
+                    ERROR_PRINT("Invalid value 0x%llx for node id option", LLU_CAST event->options[j].value);
                 }
                 break;
             case EVENT_OPTION_TID:
@@ -302,7 +302,7 @@ uint32_t snb_cbox_filter(PerfmonEvent *event)
                 }
                 else
                 {
-                    ERROR_PRINT(Invalid value 0x%llx for thread id option, LLU_CAST event->options[j].value);
+                    ERROR_PRINT("Invalid value 0x%llx for thread id option", LLU_CAST event->options[j].value);
                 }
                 break;
             default:
@@ -347,7 +347,7 @@ int snb_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -373,7 +373,7 @@ int snbep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         uint32_t filter_reg = box_map[counter_map[index].type].filterRegister1;
         if (optflags != 0x0U)
         {
-            VERBOSEPRINTREG(cpu_id, filter_reg, LLU_CAST optflags, SETUP_CBOX_FILTER);
+            VERBOSEPRINTREG(cpu_id, filter_reg, LLU_CAST optflags, "SETUP_CBOX_FILTER");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter_reg, optflags));
         }
     }
@@ -400,7 +400,7 @@ int snbep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -439,7 +439,7 @@ int snb_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_UBOX)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -478,16 +478,16 @@ int snb_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 break;
             case EVENT_OPTION_OPCODE:
                 VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH,
-                                    LLU_CAST (event->options[j].value & 0x3FULL), SETUP_BBOX_OPCODE);
+                                    LLU_CAST (event->options[j].value & 0x3FULL), "SETUP_BBOX_OPCODE");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_OPCODEMATCH,
                                     (event->options[j].value & 0x3FULL)));
                 break;
             case EVENT_OPTION_MATCH0:
                 match = event->options[j].value & 0xFFFFFFC0ULL;
-                VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, LLU_CAST match, SETUP_BBOX_MATCH0);
+                VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, LLU_CAST match, "SETUP_BBOX_MATCH0");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH0, match));
                 match = (event->options[j].value >> 32) & 0x3FFFULL;
-                VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, LLU_CAST match, SETUP_BBOX_MATCH1);
+                VERBOSEPRINTPCIREG(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, LLU_CAST match, "SETUP_BBOX_MATCH1");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, PCI_UNC_HA_PMON_ADDRMATCH1, match));
                 break;
             default:
@@ -496,7 +496,7 @@ int snb_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, SETUP_BBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, "SETUP_BBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev,  counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -539,7 +539,7 @@ int snb_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 flags |= (1ULL<<30);
                 break;
             case EVENT_OPTION_OCCUPANCY_FILTER:
-                VERBOSEPRINTREG(cpu_id, MSR_UNC_PCU_PMON_BOX_FILTER, LLU_CAST event->options[j].value & 0xFFFFFFFFULL, SETUP_WBOX_FILTER);
+                VERBOSEPRINTREG(cpu_id, MSR_UNC_PCU_PMON_BOX_FILTER, LLU_CAST event->options[j].value & 0xFFFFFFFFULL, "SETUP_WBOX_FILTER");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_PCU_PMON_BOX_FILTER, event->options[j].value & 0xFFFFFFFFULL));
             default:
                 break;
@@ -547,7 +547,7 @@ int snb_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_WBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -588,52 +588,52 @@ int snb_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
                 if (HPMcheck(filterdev, cpu_id))
                 {
                     VERBOSEPRINTPCIREG(cpu_id, filterdev, PCI_UNC_QPI_PMON_MATCH_0,
-                                    event->options[j].value & 0x8003FFF8ULL, SETUP_SBOX_MATCH0);
+                                    event->options[j].value & 0x8003FFF8ULL, "SETUP_SBOX_MATCH0");
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, filterdev, PCI_UNC_QPI_PMON_MATCH_0,
                                     event->options[j].value & 0x8003FFF8ULL));
                 }
                 else
                 {
-                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                 }
                 break;
             case EVENT_OPTION_MATCH1:
                 if (HPMcheck(filterdev, cpu_id))
                 {
                     VERBOSEPRINTPCIREG(cpu_id, filterdev, PCI_UNC_QPI_PMON_MATCH_1,
-                                    event->options[j].value & 0x000F000FULL, SETUP_SBOX_MATCH1);
+                                    event->options[j].value & 0x000F000FULL, "SETUP_SBOX_MATCH1");
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, filterdev, PCI_UNC_QPI_PMON_MATCH_1,
                                     event->options[j].value & 0x000F000FULL));
                 }
                 else
                 {
-                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                 }
                 break;
             case EVENT_OPTION_MASK0:
                 if (HPMcheck(filterdev, cpu_id))
                 {
                     VERBOSEPRINTPCIREG(cpu_id, filterdev, PCI_UNC_QPI_PMON_MASK_0,
-                                    event->options[j].value & 0x8003FFF8ULL, SETUP_SBOX_MASK0);
+                                    event->options[j].value & 0x8003FFF8ULL, "SETUP_SBOX_MASK0");
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, filterdev, PCI_UNC_QPI_PMON_MASK_0,
                                     event->options[j].value & 0x8003FFF8ULL));
                 }
                 else
                 {
-                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                 }
                 break;
             case EVENT_OPTION_MASK1:
                 if (HPMcheck(filterdev, cpu_id))
                 {
                     VERBOSEPRINTPCIREG(cpu_id, filterdev, PCI_UNC_QPI_PMON_MASK_1,
-                                    event->options[j].value & 0x000F000FULL, SETUP_SBOX_MASK1);
+                                    event->options[j].value & 0x000F000FULL, "SETUP_SBOX_MASK1");
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, filterdev, PCI_UNC_QPI_PMON_MASK_1,
                                     event->options[j].value & 0x000F000FULL));
                 }
                 else
                 {
-                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Filtering for counter %s cannot be applied. PCI device not available, counter_map[index].key);
+                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Filtering for counter %s cannot be applied. PCI device not available", counter_map[index].key);
                 }
                 break;
             default:
@@ -642,7 +642,7 @@ int snb_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event, PciDevi
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, SETUP_SBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, "SETUP_SBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev,  counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -686,7 +686,7 @@ int snb_rbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, SETUP_RBOX)
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, "SETUP_RBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -728,7 +728,7 @@ int snb_pbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, SETUP_PBOX)
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -740,14 +740,14 @@ int snb_pbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 #define SNB_FREEZE_AND_RESET_CTL_BOX(id) \
     if (haveLock && TESTTYPE(eventSet, id)) \
     { \
-        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, 0x10101U, FREEZE_AND_RESET_CTL_BOX_##id) \
+        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, 0x10101U, "FREEZE_AND_RESET_CTL_BOX_" #id); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[id].ctrlRegister, 0x10101ULL)); \
     }
 
 #define SNB_FREEZE_BOX(id) \
     if (haveLock && TESTTYPE(eventSet, id)) \
     { \
-        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, 0x10100U, FREEZE_AND_RESET_CTL_BOX_##id) \
+        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, 0x10100U, "FREEZE_AND_RESET_CTL_BOX_" #id); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[id].ctrlRegister, 0x10100ULL)); \
     }
 
@@ -758,7 +758,7 @@ int snb_pbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         TESTTYPE(eventSet, id) && \
         (HPMcheck(box_map[id].device, cpu_id) == 0)) \
     { \
-        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x10101ULL, FREEZE_AND_RESET_CTL_PCI_BOX_##id); \
+        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x10101ULL, "FREEZE_AND_RESET_CTL_PCI_BOX_" #id); \
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x10101ULL)); \
     }
 
@@ -767,7 +767,7 @@ int snb_pbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         TESTTYPE(eventSet, id) && \
         (HPMcheck(box_map[id].device, cpu_id) == 0)) \
     { \
-        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x10100ULL, FREEZE_PCI_BOX_##id) \
+        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x10100ULL, "FREEZE_PCI_BOX_" #id); \
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x10100ULL)); \
     }
 
@@ -776,7 +776,7 @@ int snb_pbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (haveLock && TESTTYPE(eventSet, MBOX##number##FIX) && \
                     (HPMcheck(PCI_IMC_DEVICE_0_CH_##number, cpu_id))) \
     { \
-        VERBOSEPRINTPCIREG(cpu_id, PCI_IMC_DEVICE_0_CH_##number, PCI_UNC_MC_PMON_FIXED_CTL, 0x0ULL, FREEZE_MBOXFIX##number) \
+        VERBOSEPRINTPCIREG(cpu_id, PCI_IMC_DEVICE_0_CH_##number, PCI_UNC_MC_PMON_FIXED_CTL, 0x0ULL, "FREEZE_MBOXFIX" #number); \
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, PCI_IMC_DEVICE_0_CH_##number,  PCI_UNC_MC_PMON_FIXED_CTL, 0x0ULL)); \
     }
 
@@ -834,7 +834,7 @@ int perfmon_setupCounterThread_sandybridge(
     }
     else if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE && sandy_cbox_setup == snb_cbox_setup)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNC_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<31), FREEZE_UNCORE)
+        VERBOSEPRINTREG(cpu_id, MSR_UNC_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<31), "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_PERF_GLOBAL_CTRL, (1ULL<<31)));
     }
 
@@ -906,12 +906,12 @@ int perfmon_setupCounterThread_sandybridge(
             case UBOXFIX:
                 if (cpuid_info.model == SANDYBRIDGE_EP)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST (1ULL<<22), SETUP_UBOXFIX)
+                    VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST (1ULL<<22), "SETUP_UBOXFIX");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, (1ULL<<22)));
                 }
                 else
                 {
-                    VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST (1ULL<<20)|(1ULL<<22), SETUP_UBOXFIX)
+                    VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST (1ULL<<20)|(1ULL<<22), "SETUP_UBOXFIX");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, (1ULL<<20)|(1ULL<<22)));
                 }
                 break;
@@ -952,7 +952,7 @@ int perfmon_setupCounterThread_sandybridge(
     
     if (fixed_flags > 0x0)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -963,13 +963,13 @@ int perfmon_setupCounterThread_sandybridge(
 // UNFREEZE(_AND_RESET_CTR) uses the central box registers to unfreeze and reset the counter registers
 #define SNB_UNFREEZE_BOX(id) \
     if (haveLock && TESTTYPE(eventSet, id)) { \
-        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_BOX_##id) \
+        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_BOX_" #id); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[id].ctrlRegister, 0x0ULL)); \
     }
 
 #define SNB_UNFREEZE_AND_RESET_CTR_BOX(id) \
     if (haveLock && TESTTYPE(eventSet, id)) { \
-        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST 0x2ULL, UNFREEZE_BOX_##id) \
+        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST 0x2ULL, "UNFREEZE_BOX_" #id); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[id].ctrlRegister, 0x2ULL)); \
     }
 
@@ -979,7 +979,7 @@ int perfmon_setupCounterThread_sandybridge(
         uint64_t tmp = 0x0ULL; \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &tmp)); \
         tmp |= (1ULL<<22); \
-        VERBOSEPRINTREG(cpu_id, reg, LLU_CAST tmp, ENABLE_BOX_##id) \
+        VERBOSEPRINTREG(cpu_id, reg, LLU_CAST tmp, "ENABLE_BOX_" #id); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, tmp)); \
     }
 
@@ -988,7 +988,7 @@ int perfmon_setupCounterThread_sandybridge(
         uint64_t tmp = 0x0ULL; \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, box_map[id].ctrlRegister, &tmp)); \
         tmp |= (1ULL<<22)|(1ULL<<17); \
-        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST tmp, ENABLE_AND_RESET_CTR_BOX_##id) \
+        VERBOSEPRINTREG(cpu_id, box_map[id].ctrlRegister, LLU_CAST tmp, "ENABLE_AND_RESET_CTR_BOX_" #id); \
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[id].ctrlRegister, tmp)); \
     }
 
@@ -996,13 +996,13 @@ int perfmon_setupCounterThread_sandybridge(
 #define SNB_UNFREEZE_PCI_BOX(id) \
     if (haveLock && TESTTYPE(eventSet, id) && (HPMcheck(box_map[id].device, cpu_id))) \
     { \
-        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_PCI_BOX_##id) \
+        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_PCI_BOX_" #id); \
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x0ULL)); \
     }
 #define SNB_UNFREEZE_AND_RESET_CTR_PCI_BOX(id) \
     if (haveLock && TESTTYPE(eventSet, id) && (HPMcheck(box_map[id].device, cpu_id))) \
     { \
-        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, LLU_CAST 0x2ULL, UNFREEZE_AND_RESET_CTR_PCI_BOX_##id) \
+        VERBOSEPRINTPCIREG(cpu_id, box_map[id].device, box_map[id].ctrlRegister, LLU_CAST 0x2ULL, "UNFREEZE_AND_RESET_CTR_PCI_BOX_" #id); \
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, box_map[id].device, box_map[id].ctrlRegister, 0x2ULL)); \
     }
 
@@ -1012,7 +1012,7 @@ int perfmon_setupCounterThread_sandybridge(
                     (HPMcheck(PCI_IMC_DEVICE_0_CH_##number, cpu_id))) \
     { \
         VERBOSEPRINTPCIREG(cpu_id, PCI_IMC_DEVICE_0_CH_##number, \
-                PCI_UNC_MC_PMON_FIXED_CTL, LLU_CAST (1ULL<<22)|(1ULL<<19), UNFREEZE_AND_RESET_CTR_MBOX##number##FIX) \
+                PCI_UNC_MC_PMON_FIXED_CTL, LLU_CAST (1ULL<<22)|(1ULL<<19), "UNFREEZE_AND_RESET_CTR_MBOX" #number "FIX"); \
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, PCI_IMC_DEVICE_0_CH_##number, PCI_UNC_MC_PMON_FIXED_CTL, (1ULL<<22)|(1ULL<<19))); \
     }
 #define SNB_UNFREEZE_MBOXFIX(number) \
@@ -1020,7 +1020,7 @@ int perfmon_setupCounterThread_sandybridge(
                     (HPMcheck(PCI_IMC_DEVICE_0_CH_##number, cpu_id))) \
     { \
         VERBOSEPRINTPCIREG(cpu_id, PCI_IMC_DEVICE_0_CH_##number, \
-                PCI_UNC_MC_PMON_FIXED_CTL, LLU_CAST (1ULL<<22), UNFREEZE_MBOXFIX##id) \
+                PCI_UNC_MC_PMON_FIXED_CTL, LLU_CAST (1ULL<<22), "UNFREEZE_MBOXFIX" #number); \
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, PCI_IMC_DEVICE_0_CH_##number,  PCI_UNC_MC_PMON_FIXED_CTL, (1ULL<<22))); \
     }
 
@@ -1090,7 +1090,7 @@ int perfmon_startCountersThread_sandybridge(int thread_id, PerfmonEventSet* even
                             uint64_t tmp = 0x0;
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, READ_MBOX);
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "READ_MBOX");
                         }
                     }
                     break;
@@ -1180,9 +1180,9 @@ int perfmon_startCountersThread_sandybridge(int thread_id, PerfmonEventSet* even
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_OR_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_OR_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE_EP)
@@ -1213,7 +1213,7 @@ int perfmon_startCountersThread_sandybridge(int thread_id, PerfmonEventSet* even
     }
     else if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE && sandy_cbox_setup == snb_cbox_setup)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<29), UNFREEZE_UNCORE)
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<29), "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, (1ULL<<29)));
     }
     return 0;
@@ -1224,7 +1224,7 @@ int perfmon_startCountersThread_sandybridge(int thread_id, PerfmonEventSet* even
     if (haveLock && TESTTYPE(eventSet, id)) \
     { \
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg1, &counter_result)); \
-        VERBOSEPRINTREG(cpu_id, reg1, LLU_CAST counter_result, READ_BOX_##id) \
+        VERBOSEPRINTREG(cpu_id, reg1, LLU_CAST counter_result, "READ_BOX_" #id); \
     }
 
 // Read PCI counter registers and combine them to a single value
@@ -1236,7 +1236,7 @@ int perfmon_startCountersThread_sandybridge(int thread_id, PerfmonEventSet* even
         counter_result = (tmp<<32); \
         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, reg2, &tmp)); \
         counter_result += tmp; \
-        VERBOSEPRINTPCIREG(cpu_id, dev, reg1, LLU_CAST counter_result, READ_PCI_BOX_##id) \
+        VERBOSEPRINTPCIREG(cpu_id, dev, reg1, LLU_CAST counter_result, "READ_PCI_BOX_" #id); \
     }
 
 // Check counter result for overflows. We do not handle overflows directly, that is done in the getResults function in perfmon.c
@@ -1261,7 +1261,7 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE_EP)
@@ -1293,7 +1293,7 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
     }
     else if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE && sandy_cbox_setup == snb_cbox_setup)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<31), FREEZE_UNCORE)
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<31), "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, (1ULL<<31)));
     }
 
@@ -1328,7 +1328,7 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                                                         (1ULL<<(index - cpuid_info.perf_num_fixed_ctr))));
                         }
                     }
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, STOP_PMC);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_PMC");
                     break;
 
                 case FIXED:
@@ -1343,17 +1343,17 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<(index+32))));
                         }
                     }
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, STOP_FIXED);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_FIXED");
                     break;
 
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, STOP_POWER);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -1375,11 +1375,11 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = counter_result;
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
 
@@ -1462,7 +1462,7 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                             counter_result = extractBitField(counter_result, 1, 4);
                         }
                         eventSet->events[i].threadCounter[thread_id].startData = 0;
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, STOP_SBOXFIX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_SBOXFIX");
                     }
                     break;
 
@@ -1501,12 +1501,12 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
 
                 case UBOX:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, STOP_UBOX);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_UBOX");
                     SNB_CHECK_OVERFLOW;
                     break;
                 case UBOXFIX:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, STOP_UBOXFIX);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_UBOXFIX");
                     SNB_CHECK_OVERFLOW;
                     break;
 
@@ -1567,9 +1567,9 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &pmc_flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST pmc_flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST pmc_flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
     if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE_EP)
     {
@@ -1605,7 +1605,7 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
     }
     else if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE && sandy_cbox_setup == snb_cbox_setup)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<31), FREEZE_UNCORE)
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<31), "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, (1ULL<<31)));
     }
 
@@ -1629,7 +1629,7 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
             {
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, READ_PMC);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "READ_PMC");
                     if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                     {
                         uint64_t ovf_values = 0x0ULL;
@@ -1645,7 +1645,7 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, READ_FIXED);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "READ_FIXED");
                     if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                     {
                         uint64_t ovf_values = 0x0ULL;
@@ -1666,10 +1666,10 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, READ_POWER);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "READ_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -1687,11 +1687,11 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                         *current = counter_result;
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
 
@@ -1732,7 +1732,7 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                     if (haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, STOP_UBOX);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_UBOX");
                         SNB_CHECK_OVERFLOW;
                     }
 
@@ -1820,7 +1820,7 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                         counter_result = extractBitField(counter_result, 1, 4);
                     }
                     eventSet->events[i].threadCounter[thread_id].startData = 0x0ULL;
-                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, READ_SBOXFIX);
+                    VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "READ_SBOXFIX");
                     break;
 
                 case WBOX:
@@ -1891,13 +1891,13 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
     }
     else if (MEASURE_UNCORE(eventSet) && cpuid_info.model == SANDYBRIDGE && sandy_cbox_setup == snb_cbox_setup)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<29), UNFREEZE_UNCORE)
+        VERBOSEPRINTREG(cpu_id, MSR_UNCORE_PERF_GLOBAL_CTRL, LLU_CAST (1ULL<<29), "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNCORE_PERF_GLOBAL_CTRL, (1ULL<<29)));
     }
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST pmc_flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST pmc_flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, pmc_flags));
     }
 
@@ -1936,12 +1936,12 @@ int perfmon_finalizeCountersThread_sandybridge(int thread_id, PerfmonEventSet* e
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 break;
@@ -1954,17 +1954,17 @@ int perfmon_finalizeCountersThread_sandybridge(int thread_id, PerfmonEventSet* e
         if ((reg) &&
             (((type == PMC)||(type == FIXED)) || ((type >= UNCORE && type < NUM_UNITS) && (haveLock) && (HPMcheck(dev, cpu_id)))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if (type >= SBOX0 && type <= SBOX3)
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (type >= SBOX0 && type <= SBOX3)
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
                 if (type >= SBOX0 && type <= SBOX3)
                     CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
@@ -1979,18 +1979,18 @@ int perfmon_finalizeCountersThread_sandybridge(int thread_id, PerfmonEventSet* e
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (i >= SBOX0 && i <= SBOX3)
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2 != 0x0)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }
@@ -1999,9 +1999,9 @@ int perfmon_finalizeCountersThread_sandybridge(int thread_id, PerfmonEventSet* e
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_sapphirerapids.h
+++ b/src/includes/perfmon_sapphirerapids.h
@@ -64,12 +64,12 @@ int perfmon_init_sapphirerapids(int cpu_id)
         ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL);
         if (ret != 0)
         {
-            ERROR_PRINT(Cannot zero %s (0x%X), str(MSR_PEBS_ENABLE), MSR_PEBS_ENABLE);
+            ERROR_PRINT("Cannot zero MSR_PEBS_ENABLE (0x%X)", MSR_PEBS_ENABLE);
         }
         ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_FRONTEND, 0x0ULL);
         if (ret != 0)
         {
-            ERROR_PRINT(Cannot zero %s (0x%X), str(MSR_PEBS_FRONTEND), MSR_PEBS_FRONTEND);
+            ERROR_PRINT("Cannot zero MSR_PEBS_FRONTEND (0x%X)", MSR_PEBS_FRONTEND);
         }
     }
     return 0;
@@ -101,7 +101,7 @@ uint64_t spr_fixed_start(int thread_id, RegisterIndex index, PerfmonEvent *event
     int cpu_id = groupSet->threads[thread_id].processorId;
     uint64_t counter1 = counter_map[index].counterRegister;
     PciDeviceIndex dev = counter_map[index].device;
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_FIXED);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_FIXED");
     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
     data[thread_id].startData = 0x0ULL;
     data[thread_id].counterData = 0x0ULL;
@@ -171,7 +171,7 @@ uint64_t spr_pmc_setup(int thread_id, RegisterIndex index, PerfmonEvent *event, 
 /*        {*/
 /*            offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);*/
 /*        }*/
-/*        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE0);*/
+/*        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE0");*/
 /*        CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));*/
 /*    }*/
 /*    else if (event->eventId == 0xBB)*/
@@ -180,13 +180,13 @@ uint64_t spr_pmc_setup(int thread_id, RegisterIndex index, PerfmonEvent *event, 
 /*        {*/
 /*            offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);*/
 /*        }*/
-/*        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE1);*/
+/*        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE1");*/
 /*        CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));*/
 /*    }*/
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -198,7 +198,7 @@ uint64_t spr_pmc_start(int thread_id, RegisterIndex index, PerfmonEvent* event, 
     int cpu_id = groupSet->threads[thread_id].processorId;
     uint64_t counter1 = counter_map[index].counterRegister;
     PciDeviceIndex dev = counter_map[index].device;
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_PMC);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_PMC");
     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
     data[thread_id].startData = 0x0ULL;
     data[thread_id].counterData = 0x0ULL;
@@ -218,7 +218,7 @@ uint64_t spr_power_start(int thread_id, RegisterIndex index, PerfmonEvent* event
         RegisterType type = counter_map[index].type;
         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1,(uint32_t*)&tmp));
         data[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST data[thread_id].startData, START_POWER)
+        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST data[thread_id].startData, "START_POWER");
     }
     return 0;
 }
@@ -264,7 +264,7 @@ int spr_setup_uncore(int thread_id, RegisterIndex index, PerfmonEvent *event)
                         uint64_t reg = box_map[counter_map[index].type].filterRegister1;
                         uint64_t val = event->options[j].value & 0x3FF;
                         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, val));
-                        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX_FILTER);
+                        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX_FILTER");
                         flags |= (1ULL << 16);
                     }
                 case EVENT_OPTION_MATCH0:
@@ -280,11 +280,11 @@ int spr_setup_uncore(int thread_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UNCORE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UNCORE");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
         HPMread(cpu_id, dev, counter_map[index].configRegister, &flags);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, VALIDATE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "VALIDATE_UNCORE");
     }
     return 0;
 }
@@ -296,7 +296,7 @@ int spr_start_uncore(int thread_id, RegisterIndex index, PerfmonEvent* event, Pe
     int cpu_id = groupSet->threads[thread_id].processorId;
     uint64_t counter1 = counter_map[index].counterRegister;
     PciDeviceIndex dev = counter_map[index].device;
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_UNCORE);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_UNCORE");
     data[thread_id].startData = 0x0ULL;
     data[thread_id].counterData = 0x0ULL;
     return HPMwrite(cpu_id, dev, counter1, 0x0ULL);
@@ -310,7 +310,7 @@ int spr_stop_uncore(int thread_id, RegisterIndex index, PerfmonEvent* event, Per
     PciDeviceIndex dev = counter_map[index].device;
     int err = HPMread(cpu_id, dev, counter1, &counter_result);
     //counter_result = field64(counter_result, 0, box_map[type].regWidth);
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_UNCORE);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_UNCORE");
     data[thread_id].counterData = counter_result;
     return err;
 }
@@ -322,7 +322,7 @@ int spr_read_uncore(int thread_id, RegisterIndex index, PerfmonEvent* event, Per
     uint64_t counter1 = counter_map[index].counterRegister;
     PciDeviceIndex dev = counter_map[index].device;
     int err = HPMread(cpu_id, dev, counter1, &counter_result);
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, READ_UNCORE);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_UNCORE");
     data[thread_id].counterData = counter_result;
     return err;
 }
@@ -346,11 +346,11 @@ int spr_setup_uncore_fixed(int thread_id, RegisterIndex index, PerfmonEvent *eve
     flags = (1ULL<<20)|(1ULL<<22);
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UNCORE_FIXED);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UNCORE_FIXED");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
         HPMread(cpu_id, dev, counter_map[index].configRegister, &flags);
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, VALIDATE_UNCORE_FIXED);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "VALIDATE_UNCORE_FIXED");
     }
     return 0;
 }
@@ -360,7 +360,7 @@ int spr_start_uncore_fixed(int thread_id, RegisterIndex index, PerfmonEvent* eve
     int cpu_id = groupSet->threads[thread_id].processorId;
     uint64_t counter1 = counter_map[index].counterRegister;
     PciDeviceIndex dev = counter_map[index].device;
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, CLEAR_UNCORE_FIXED);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "CLEAR_UNCORE_FIXED");
     data[thread_id].startData = data[thread_id].counterData = 0x0;
     return HPMwrite(cpu_id, dev, counter1, 0x0ULL);
 }
@@ -376,7 +376,7 @@ int spr_stop_uncore_fixed(int thread_id, RegisterIndex index, PerfmonEvent* even
     {
         return err;
     }
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, STOP_UNCORE_FIXED);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "STOP_UNCORE_FIXED");
     data[thread_id].counterData = flags;
     return 0;
 }
@@ -392,7 +392,7 @@ int spr_read_uncore_fixed(int thread_id, RegisterIndex index, PerfmonEvent* even
     {
         return err;
     }
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, READ_UNCORE_FIXED);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "READ_UNCORE_FIXED");
     data[thread_id].counterData = flags;
     return 0;
 }
@@ -421,7 +421,7 @@ int spr_start_uncore_freerun(int thread_id, RegisterIndex index, PerfmonEvent* e
     uint64_t counter1 = counter_map[index].counterRegister;
     PciDeviceIndex dev = counter_map[index].device;
     data[thread_id].startData = data[thread_id].counterData = 0x0;
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, START_UNCORE_FREERUN);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "START_UNCORE_FREERUN");
     int err = HPMread(cpu_id, dev, counter1, &flags);
     if (err == 0)
     {
@@ -436,7 +436,7 @@ int spr_stop_uncore_freerun(int thread_id, RegisterIndex index, PerfmonEvent* ev
     uint64_t counter1 = counter_map[index].counterRegister;
     PciDeviceIndex dev = counter_map[index].device;
     uint64_t flags = 0x0;
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, STOP_UNCORE_FREERUN);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0ULL, "STOP_UNCORE_FREERUN");
     int err = HPMread(cpu_id, dev, counter1, &flags);
     if (err == 0)
     {
@@ -463,13 +463,13 @@ int perfmon_setupCounterThread_sapphirerapids(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -798,7 +798,7 @@ int perfmon_setupCounterThread_sapphirerapids(
                     err = spr_setup_uncore(thread_id, index, event);
                     if (err < 0)
                     {
-                        ERROR_PRINT(Failed to setup register 0x%X, reg);
+                        ERROR_PRINT("Failed to setup register 0x%X", reg);
                     }
                 }
                 break;
@@ -806,7 +806,7 @@ int perfmon_setupCounterThread_sapphirerapids(
     }
     if ((fixed_flags > 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -1173,12 +1173,12 @@ int perfmon_startCountersThread_sapphirerapids(int thread_id, PerfmonEventSet* e
     {
         if (flags & (1ULL << 48))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, CLEAR_METRICS)
+            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, "CLEAR_METRICS");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_METRICS, 0x0ULL));
         }
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
@@ -1187,11 +1187,11 @@ int perfmon_startCountersThread_sapphirerapids(int thread_id, PerfmonEventSet* e
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, UNFREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, "UNFREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, 0x0ULL);
     }
     return 0;
@@ -1205,7 +1205,7 @@ uint32_t spr_fixed_stop(int thread_id, RegisterIndex index, PerfmonEvent* event,
     int cpu_id = groupSet->threads[thread_id].processorId;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     SPR_CHECK_CORE_OVERFLOW(index+32);
-    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_FIXED)
+    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_FIXED");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1217,7 +1217,7 @@ uint32_t spr_pmc_stop(int thread_id, RegisterIndex index, PerfmonEvent* event, P
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     SPR_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_PMC)
+    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_PMC");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1230,10 +1230,10 @@ uint32_t spr_power_stop(int thread_id, RegisterIndex index, PerfmonEvent* event,
         uint64_t counter_result = 0x0ULL;
         uint64_t counter1 = counter_map[index].counterRegister;
         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
         if (counter_result < data[thread_id].counterData)
         {
-            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
             data[thread_id].overflows++;
         }
         data[thread_id].counterData = counter_result;
@@ -1247,7 +1247,7 @@ uint32_t spr_thermal_stop(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t counter_result = 0x0ULL;
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_TEMP_READ_ERROR(thermal_read(cpu_id,(uint32_t*)&counter_result));
-    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, STOP_THERMAL);
+    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "STOP_THERMAL");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1258,7 +1258,7 @@ uint32_t spr_voltage_stop(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t counter_result = 0x0ULL;
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_TEMP_READ_ERROR(voltage_read(cpu_id, &counter_result));
-    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, STOP_VOLTAGE);
+    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "STOP_VOLTAGE");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1273,7 +1273,7 @@ uint32_t spr_metrics_stop(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t width = box_map[type].regWidth;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     counter_result= field64(counter_result, offset, width);
-    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, STOP_METRICS);
+    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "STOP_METRICS");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1285,7 +1285,7 @@ uint32_t spr_mboxfix_stop(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     SPR_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_MBOXFIX);
+    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_MBOXFIX");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1306,7 +1306,7 @@ int perfmon_stopCountersThread_sapphirerapids(int thread_id, PerfmonEventSet* ev
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
@@ -1315,11 +1315,11 @@ int perfmon_stopCountersThread_sapphirerapids(int thread_id, PerfmonEventSet* ev
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), FREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), "FREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, (1ULL<<0));
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
 
@@ -1687,7 +1687,7 @@ uint32_t spr_fixed_read(int thread_id, RegisterIndex index, PerfmonEvent* event,
     int cpu_id = groupSet->threads[thread_id].processorId;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     SPR_CHECK_CORE_OVERFLOW(index+32);
-    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1699,7 +1699,7 @@ uint32_t spr_pmc_read(int thread_id, RegisterIndex index, PerfmonEvent* event, P
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     SPR_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1712,10 +1712,10 @@ uint32_t spr_power_read(int thread_id, RegisterIndex index, PerfmonEvent* event,
         uint64_t counter_result = 0x0ULL;
         uint64_t counter1 = counter_map[index].counterRegister;
         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_POWER)
+        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_POWER");
         if (counter_result < data[thread_id].counterData)
         {
-            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
             data[thread_id].overflows++;
         }
         data[thread_id].counterData = counter_result;
@@ -1729,7 +1729,7 @@ uint32_t spr_thermal_read(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t counter_result = 0x0ULL;
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_TEMP_READ_ERROR(thermal_read(cpu_id,(uint32_t*)&counter_result));
-    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_THERMAL);
+    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_THERMAL");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1740,7 +1740,7 @@ uint32_t spr_voltage_read(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t counter_result = 0x0ULL;
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_TEMP_READ_ERROR(voltage_read(cpu_id, &counter_result));
-    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_VOLTAGE);
+    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_VOLTAGE");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1755,7 +1755,7 @@ uint32_t spr_metrics_read(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t width = box_map[type].regWidth;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     counter_result= field64(counter_result, offset, width);
-    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, READ_METRICS);
+    VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, counter1, LLU_CAST counter_result, "READ_METRICS");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1767,7 +1767,7 @@ uint32_t spr_mboxfix_read(int thread_id, RegisterIndex index, PerfmonEvent* even
     uint64_t counter1 = counter_map[index].counterRegister;
     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
     SPR_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_MBOXFIX);
+    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_MBOXFIX");
     data[thread_id].counterData = counter_result;
     return 0;
 }
@@ -1790,9 +1790,9 @@ int perfmon_readCountersThread_sapphirerapids(int thread_id, PerfmonEventSet* ev
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
@@ -1800,11 +1800,11 @@ int perfmon_readCountersThread_sapphirerapids(int thread_id, PerfmonEventSet* ev
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), FREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), "FREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, (1ULL<<0));
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -2166,16 +2166,16 @@ int perfmon_readCountersThread_sapphirerapids(int thread_id, PerfmonEventSet* ev
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, UNFREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, 0x0ULL));
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -2222,17 +2222,17 @@ int perfmon_finalizeCountersThread_sapphirerapids(int thread_id, PerfmonEventSet
         }
         if ((reg) && (((type == PMC)||(type == FIXED))||(type == METRICS)|| ((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
             {
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             }
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (box_map[type].filterRegister1 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL));
             }
         }
@@ -2240,9 +2240,9 @@ int perfmon_finalizeCountersThread_sapphirerapids(int thread_id, PerfmonEventSet
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_sierraforrest.h
+++ b/src/includes/perfmon_sierraforrest.h
@@ -229,13 +229,13 @@ int perfmon_setupCounterThread_sierraforrest(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -276,7 +276,7 @@ int perfmon_setupCounterThread_sierraforrest(
     }
     if ((fixed_flags > 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -345,23 +345,23 @@ int perfmon_startCountersThread_sierraforrest(int thread_id, PerfmonEventSet* ev
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, UNFREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, "UNFREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, 0x0ULL);
     }
     if (MEASURE_CORE(eventSet))
     {
         if (flags & (1ULL << 48))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, CLEAR_METRICS)
+            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, "CLEAR_METRICS");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_METRICS, 0x0ULL));
         }
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -383,7 +383,7 @@ int perfmon_stopCountersThread_sierraforrest(int thread_id, PerfmonEventSet* eve
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
@@ -392,11 +392,11 @@ int perfmon_stopCountersThread_sierraforrest(int thread_id, PerfmonEventSet* eve
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), FREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), "FREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, (1ULL<<0));
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
 
@@ -462,9 +462,9 @@ int perfmon_readCountersThread_sierraforrest(int thread_id, PerfmonEventSet* eve
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
@@ -472,11 +472,11 @@ int perfmon_readCountersThread_sierraforrest(int thread_id, PerfmonEventSet* eve
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), FREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST (1ULL<<0), "FREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, (1ULL<<0));
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), FREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST (1ULL<<0), "FREEZE_UNCORE");
         HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, (1ULL<<0));
     }
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -525,16 +525,16 @@ int perfmon_readCountersThread_sierraforrest(int thread_id, PerfmonEventSet* eve
         {
             if (TESTTYPE(eventSet, i) && box_map[i].device != MSR_DEV)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, UNFREEZE_UNIT);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, LLU_CAST 0x0ULL, "UNFREEZE_UNIT");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
             }
         }
-        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, UNFREEZE_UNCORE);
+        VERBOSEPRINTPCIREG(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, LLU_CAST 0x0ULL, "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_UBOX_DEVICE, FAKE_UNC_GLOBAL_CTRL, 0x0ULL));
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -583,17 +583,17 @@ int perfmon_finalizeCountersThread_sierraforrest(int thread_id, PerfmonEventSet*
         }
         if ((reg) && (((type == PMC)||(type == FIXED))||(type == METRICS)|| ((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
             {
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             }
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (box_map[type].filterRegister1 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, box_map[type].filterRegister1, 0x0ULL));
             }
         }
@@ -601,9 +601,9 @@ int perfmon_finalizeCountersThread_sierraforrest(int thread_id, PerfmonEventSet*
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_silvermont.h
+++ b/src/includes/perfmon_silvermont.h
@@ -147,13 +147,13 @@ int svm_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
             {
                 offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
             }
-            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+            VERBOSEPRINTREG(cpu_id, reg, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , offcore_flags));
         }
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -202,7 +202,7 @@ int perfmon_setupCountersThread_silvermont(
     }
     if (fixed_flags > 0x0)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -267,7 +267,7 @@ int perfmon_startCountersThread_silvermont(int thread_id, PerfmonEventSet* event
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_OR_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_OR_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -288,7 +288,7 @@ int perfmon_stopCountersThread_silvermont(int thread_id, PerfmonEventSet* eventS
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_OR_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_OR_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -373,7 +373,7 @@ int perfmon_readCountersThread_silvermont(int thread_id, PerfmonEventSet* eventS
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &pmc_flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_OR_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_OR_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -483,12 +483,12 @@ int perfmon_finalizeCountersThread_silvermont(int thread_id, PerfmonEventSet* ev
                 {
                     if (event->umask == 0x1)
                     {
-                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                     }
                     else if (event->umask == 0x2)
                     {
-                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                     }
                 }
@@ -501,13 +501,13 @@ int perfmon_finalizeCountersThread_silvermont(int thread_id, PerfmonEventSet* ev
         }
         if ((reg) && ((dev == MSR_DEV) || (haveLock)))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
             }
         }

--- a/src/includes/perfmon_skylake.h
+++ b/src/includes/perfmon_skylake.h
@@ -111,12 +111,12 @@ int perfmon_init_skylake(int cpu_id)
         ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL);
         if (ret != 0)
         {
-            ERROR_PRINT(Cannot zero %s (0x%X), str(MSR_PEBS_ENABLE), MSR_PEBS_ENABLE);
+            ERROR_PRINT("Cannot zero MSR_PEBS_ENABLE (0x%X)", MSR_PEBS_ENABLE);
         }
         ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_FRONTEND, 0x0ULL);
         if (ret != 0)
         {
-            ERROR_PRINT(Cannot zero %s (0x%X), str(MSR_PEBS_FRONTEND), MSR_PEBS_FRONTEND);
+            ERROR_PRINT("Cannot zero MSR_PEBS_FRONTEND (0x%X)", MSR_PEBS_FRONTEND);
         }
     }
     if (socket_lock[affinity_thread2socket_lookup[cpu_id]] == cpu_id)
@@ -242,7 +242,7 @@ int skl_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE0);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE0");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -251,25 +251,25 @@ int skl_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE1);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE1");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if ((event->eventId == 0xC6) &&
         (event->cmask != 0))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_V4_PEBS_FRONTEND, LLU_CAST event->cmask, SETUP_PMC_FRONTEND);
+        VERBOSEPRINTREG(cpu_id, MSR_V4_PEBS_FRONTEND, LLU_CAST event->cmask, "SETUP_PMC_FRONTEND");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_PEBS_FRONTEND, event->cmask));
     }
     if ((event->eventId == 0xCD) &&
         (cpuid_info.model == SKYLAKEX) &&
         (event->cmask != 0))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, LLU_CAST event->cmask, SETUP_PMC_LATENCY);
+        VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, LLU_CAST event->cmask, "SETUP_PMC_LATENCY");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_LD_LAT, event->cmask));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -310,7 +310,7 @@ int skl_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -328,7 +328,7 @@ int skl_uboxfix_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     flags = (1ULL<<22)|(1ULL<<20);
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UBOXFIX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UBOXFIX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -367,7 +367,7 @@ int skl_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -446,12 +446,12 @@ int skx_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (opc_match && !match1)
     {
         filter_flags1 |= 0x33ULL;
-        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, SETUP_CBOX_ADD_OPCODE_MATCH1);
+        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, "SETUP_CBOX_ADD_OPCODE_MATCH1");
     }
 
     if (filter_flags0 != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, SETUP_CBOX_FILTER0);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, "SETUP_CBOX_FILTER0");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags0));
     }
     else
@@ -460,12 +460,12 @@ int skx_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (filter_flags1 != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, SETUP_CBOX_FILTER1);
+        VERBOSEPRINTREG(cpu_id, filter1, filter_flags1, "SETUP_CBOX_FILTER1");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags1));
     }
     else
     {
-        VERBOSEPRINTREG(cpu_id, filter1, 0x3BULL, SETUP_CBOX_DEF_FILTER_STATE);
+        VERBOSEPRINTREG(cpu_id, filter1, 0x3BULL, "SETUP_CBOX_DEF_FILTER_STATE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, 0x3BULL));
     }
 
@@ -473,12 +473,12 @@ int skx_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags0));
         filter_flags0 |= (0x3FF << 17);
-        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, SETUP_CBOX_DEF_FILTER_STATE);
+        VERBOSEPRINTREG(cpu_id, filter0, filter_flags0, "SETUP_CBOX_DEF_FILTER_STATE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags0));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -524,7 +524,7 @@ int skx_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_MBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_MBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -549,7 +549,7 @@ int skx_mboxfix_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     flags = (1ULL<<20)|(1ULL<<22);
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, SETUP_MBOX);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].configRegister, flags, "SETUP_MBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -598,7 +598,7 @@ int skx_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_OCCUPANCY_FILTER:
                     clean_filter = 0;
-                    VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), SETUP_WBOX_FILTER);
+                    VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), "SETUP_WBOX_FILTER");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter, (event->options[j].value & 0xFFFFFFFFULL)));
                     break;
                 case EVENT_OPTION_OCCUPANCY_EDGE:
@@ -615,12 +615,12 @@ int skx_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (clean_filter)
     {
-        VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), CLEAN_WBOX_FILTER);
+        VERBOSEPRINTREG(cpu_id, filter, (event->options[j].value & 0xFFFFFFFFULL), "CLEAN_WBOX_FILTER");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter, 0x0ULL));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_WBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -675,7 +675,7 @@ int skx_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_SBOX_BOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_SBOX_BOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -721,7 +721,7 @@ int skx_uncorebox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_UNCORE_BOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_UNCORE_BOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -773,7 +773,7 @@ int skx_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_IBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_IBOX");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -786,13 +786,13 @@ int skx_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     { \
         if (IS_SKYLAKE_CLIENT(cpuid_info.model)) \
         { \
-            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_UNCORE) \
+            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_UNCORE"); \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, 0x0ULL)); \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_STATUS, 0x0ULL)); \
         } \
         else if (cpuid_info.model == SKYLAKEX) \
         { \
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<63), FREEZE_UNCORE) \
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<63), "FREEZE_UNCORE"); \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<63))); \
         } \
     }
@@ -802,12 +802,12 @@ int skx_ibox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     { \
         if (IS_SKYLAKE_CLIENT(cpuid_info.model)) \
         { \
-            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29), UNFREEZE_UNCORE) \
+            VERBOSEPRINTREG(cpu_id, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29), "UNFREEZE_UNCORE"); \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_UNC_PERF_GLOBAL_CTRL, uflags|(1ULL<<29))); \
         } \
         else if (cpuid_info.model == SKYLAKEX) \
         { \
-            VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<61), UNFREEZE_UNCORE) \
+            VERBOSEPRINTREG(cpu_id, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<61), "UNFREEZE_UNCORE"); \
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_UNC_V3_U_PMON_GLOBAL_CTL, (1ULL<<61))); \
         } \
     }
@@ -824,7 +824,7 @@ int perfmon_setupCounterThread_skylake(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL));
@@ -893,7 +893,7 @@ int perfmon_setupCounterThread_skylake(
                 {
                     uint64_t uflags = 0x0ULL;
                     uflags |= (1ULL<<20)|(1ULL<<22);
-                    VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, uflags, SETUP_UBOXFIX)
+                    VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, uflags, "SETUP_UBOXFIX");
                     HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, uflags);
                 }
                 break;
@@ -989,7 +989,7 @@ int perfmon_setupCounterThread_skylake(
     }
     if ((fixed_flags > 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -1037,28 +1037,28 @@ int perfmon_startCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet
                     tmp = 0x0ULL;
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                     eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, READ_PERF)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "READ_PERF");
                     break;
                 case POWER:
                     if (haveLock)
                     {
                         tmp = 0x0ULL;
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1,(uint32_t*)&tmp));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, START_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "START_POWER");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
                 case UBOXFIX:
                     if (haveLock)
                     {
-                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_UBOXFIX)
+                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_UBOXFIX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
                 case UBOX:
                     if (haveLock)
                     {
-                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_UBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_UBOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1096,7 +1096,7 @@ int perfmon_startCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet
                     }
                     else if (haveLock && cpuid_info.model == SKYLAKEX)
                     {
-                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_CBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_CBOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1105,14 +1105,14 @@ int perfmon_startCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet
                     {
                         if (!cpuid_info.supportClientmem)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_BOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_BOX");
                             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                         }
                         else
                         {
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                             eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, READ_MBOX)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "READ_MBOX");
                         }
                     }
                     break;
@@ -1156,7 +1156,7 @@ int perfmon_startCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet
                 case IBOX5FIX:
                     if (haveLock)
                     {
-                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, CLEAR_BOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "CLEAR_BOX");
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0ULL));
                     }
                     break;
@@ -1164,7 +1164,7 @@ int perfmon_startCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet
                     if (haveLock)
                     {
                         tmp = 0x0ULL;
-                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, START_WBOXFIX)
+                        VERBOSEPRINTREG(cpu_id, counter1, 0x0ULL, "START_WBOXFIX");
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &tmp));
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
@@ -1180,9 +1180,9 @@ int perfmon_startCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -1239,10 +1239,10 @@ int skl_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
     int haveLock = has_uncore_lock(cpu_id);
 
     CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &result));
-    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, READ_REG_1);
+    VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST result, "READ_REG_1");
     if (flags & FREEZE_FLAG_CLEAR_CTR)
     {
-        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, CLEAR_REG_1);
+        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST 0x0U, "CLEAR_REG_1");
         CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev, counter1, 0x0U));
     }
     //printf("%s: %lu\n", counter_map[index].key, result);
@@ -1263,10 +1263,10 @@ int skl_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV,
                                            global_status_reg,
                                            &ovf_values));
-            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, READ_GLOBAL_OVFL);
+            VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST ovf_values, "READ_GLOBAL_OVFL");
             if (ovf_values & (1ULL<<global_offset))
             {
-                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), CLEAR_GLOBAL_OVFL);
+                VERBOSEPRINTREG(cpu_id, global_status_reg, LLU_CAST (1<<global_offset), "CLEAR_GLOBAL_OVFL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV,
                                                  global_status_reg,
                                                  (1<<global_offset)));
@@ -1284,11 +1284,11 @@ int skl_uncore_read(int cpu_id, RegisterIndex index, PerfmonEvent *event,
             CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev,
                                               box_map[type].statusRegister,
                                               &ovf_values));
-            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, READ_BOX_OVFL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST ovf_values, "READ_BOX_OVFL");
             if (ovf_values & (1ULL<<box_offset))
             {
                 (*overflows)++;
-                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), RESET_BOX_OVFL);
+                VERBOSEPRINTPCIREG(cpu_id, dev, box_map[type].statusRegister, LLU_CAST (1<<box_offset), "RESET_BOX_OVFL");
                 CHECK_PCI_WRITE_ERROR(HPMwrite(cpu_id, dev,
                                                     box_map[type].statusRegister,
                                                     (1<<box_offset)));
@@ -1313,7 +1313,7 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     SKL_UNCORE_FREEZE;
@@ -1340,27 +1340,27 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case PERF:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PERF)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PERF");
                     break;
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1398,7 +1398,7 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                     if (haveLock)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
-                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, STOP_UNC_FIXED_CTR);
+                        VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "STOP_UNC_FIXED_CTR");
                     }
                     break;
                 case CBOX0:
@@ -1434,14 +1434,14 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         SKL_CHECK_UNCORE_OVERFLOW(box_map[type].ovflOffset);
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_CBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_CBOX");
                     }
                     else if (haveLock && cpuid_info.model == SKYLAKEX)
                     {
                         skl_uncore_read(cpu_id, index, event, current, overflows,
                                     FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_CBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_CBOX");
                     }
                     break;
                 case MBOX0:
@@ -1459,11 +1459,11 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, PCI_IMC_DEVICE_0_CH_0, counter1, &counter_result));
                             if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                             {
-                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                                 eventSet->events[i].threadCounter[thread_id].overflows++;
                             }
                         }
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
                 case MBOX1:
@@ -1476,7 +1476,7 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                         skl_uncore_read(cpu_id, index, event, current, overflows,
                                         0, ovf_offset, getCounterTypeOffset(index)+1);
                         counter_result = *current;
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
                 case MBOX0FIX:
@@ -1519,7 +1519,7 @@ int perfmon_stopCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                         skl_uncore_read(cpu_id, index, event, current, overflows,
                                         FREEZE_FLAG_CLEAR_CTR, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_BBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_BBOX");
                     }
                     break;
                 default:
@@ -1555,9 +1555,9 @@ int perfmon_readCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
 
     SKL_UNCORE_FREEZE;
@@ -1584,28 +1584,28 @@ int perfmon_readCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case PERF:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PERF)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PERF");
                     break;
 
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -1699,11 +1699,11 @@ int perfmon_readCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                             if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                             {
-                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_CLIENTMEM)
+                                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_CLIENTMEM");
                                 eventSet->events[i].threadCounter[thread_id].overflows++;
                             }
                         }
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_MBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_MBOX");
                     }
                     break;
                 case MBOX1:
@@ -1757,7 +1757,7 @@ int perfmon_readCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
                         skl_uncore_read(cpu_id, index, event, current, overflows,
                                         0, ovf_offset, getCounterTypeOffset(index));
                         counter_result = *current;
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_BBOX)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_BBOX");
                     }
                     break;
                 default:
@@ -1771,7 +1771,7 @@ int perfmon_readCountersThread_skylake(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -1808,22 +1808,22 @@ int perfmon_finalizeCountersThread_skylake(int thread_id, PerfmonEventSet* event
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_PMC_OFFCORE0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_PMC_OFFCORE0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_PMC_OFFCORE1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_PMC_OFFCORE1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 else if (eventSet->events[i].event.eventId == 0xCD)
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, 0x0ULL, CLEAR_PMC_LATENCY);
+                    VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, 0x0ULL, "CLEAR_PMC_LATENCY");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_LD_LAT, 0x0ULL));
                 }
                 else if (eventSet->events[i].event.eventId == 0xC6)
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_V4_PEBS_FRONTEND, 0x0ULL, CLEAR_PMC_FRONTEND);
+                    VERBOSEPRINTREG(cpu_id, MSR_V4_PEBS_FRONTEND, 0x0ULL, "CLEAR_PMC_FRONTEND");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_PEBS_FRONTEND, 0x0ULL));
                 }
                 break;
@@ -1836,15 +1836,15 @@ int perfmon_finalizeCountersThread_skylake(int thread_id, PerfmonEventSet* event
         if ((reg) && (((type == PMC)||(type == FIXED))|| ((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, reg, &ovf_values_uncore));
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, SHOW_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, "SHOW_CTL");
             ovf_values_uncore = 0x0ULL;
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
             {
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             }
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
         }
         eventSet->events[i].threadCounter[thread_id].init = FALSE;
@@ -1858,24 +1858,24 @@ int perfmon_finalizeCountersThread_skylake(int thread_id, PerfmonEventSet* event
             status_reg = MSR_UNC_V3_U_PMON_GLOBAL_STATUS;
             ctrl_reg = MSR_UNC_V3_U_PMON_GLOBAL_CTL;
         }
-        VERBOSEPRINTREG(cpu_id, status_reg, LLU_CAST 0x0ULL, CLEAR_UNCORE_STATUS)
+        VERBOSEPRINTREG(cpu_id, status_reg, LLU_CAST 0x0ULL, "CLEAR_UNCORE_STATUS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, status_reg, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, ctrl_reg, LLU_CAST 0x0ULL, CLEAR_UNCORE_CTRL)
+        VERBOSEPRINTREG(cpu_id, ctrl_reg, LLU_CAST 0x0ULL, "CLEAR_UNCORE_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, ctrl_reg, 0x0ULL));
         for (int i=UNCORE;i<NUM_UNITS;i++)
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }
@@ -1884,9 +1884,9 @@ int perfmon_finalizeCountersThread_skylake(int thread_id, PerfmonEventSet* event
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_tigerlake.h
+++ b/src/includes/perfmon_tigerlake.h
@@ -43,12 +43,12 @@ int perfmon_init_tigerlake(int cpu_id)
     ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL);
     if (ret != 0)
     {
-        ERROR_PRINT(Cannot zero MSR_PEBS_ENABLE (0x%X), MSR_PEBS_ENABLE);
+        ERROR_PRINT("Cannot zero MSR_PEBS_ENABLE (0x%X)", MSR_PEBS_ENABLE);
     }
     ret = HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_FRONTEND, 0x0ULL);
     if (ret != 0)
     {
-        ERROR_PRINT(Cannot zero MSR_PEBS_FRONTEND (0x%X), MSR_PEBS_FRONTEND);
+        ERROR_PRINT("Cannot zero MSR_PEBS_FRONTEND (0x%X)", MSR_PEBS_FRONTEND);
     }
     return 0;
 }
@@ -125,12 +125,12 @@ int tgl_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (event->eventId == 0xCD)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, LLU_CAST flags, SETUP_LD_LAT)
+        VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, LLU_CAST flags, "SETUP_LD_LAT");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_LD_LAT, event->cfgBits));
     }
     else if (event->eventId == 0xC6)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PEBS_FRONTEND, LLU_CAST flags, SETUP_FRONTEND)
+        VERBOSEPRINTREG(cpu_id, MSR_PEBS_FRONTEND, LLU_CAST flags, "SETUP_FRONTEND");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_FRONTEND, event->cfgBits));
     }
     else if (event->cfgBits != 0x0)
@@ -140,7 +140,7 @@ int tgl_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -163,7 +163,7 @@ int perfmon_setupCounterThread_tigerlake(
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, 0xC00000070000000F));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_ENABLE, 0x0ULL));
@@ -202,7 +202,7 @@ int perfmon_setupCounterThread_tigerlake(
     }
     if ((fixed_flags > 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     return 0;
@@ -255,7 +255,7 @@ int perfmon_startCountersThread_tigerlake(int thread_id, PerfmonEventSet* eventS
                     {
                         tmp = 0x0ULL;
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1,(uint32_t*)&tmp));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, START_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST tmp, "START_POWER");
                         eventSet->events[i].threadCounter[thread_id].startData = field64(tmp, 0, box_map[type].regWidth);
                     }
                     break;
@@ -277,12 +277,12 @@ int perfmon_startCountersThread_tigerlake(int thread_id, PerfmonEventSet* eventS
     {
         if (flags & (1ULL << 48))
         {
-            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, CLEAR_METRICS)
+            VERBOSEPRINTREG(cpu_id, MSR_PERF_METRICS, 0x0ULL, "CLEAR_METRICS");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_METRICS, 0x0ULL));
         }
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, CLEAR_PMC_AND_FIXED_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST (1ULL<<63)|(1ULL<<62)|flags, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -303,7 +303,7 @@ int perfmon_stopCountersThread_tigerlake(int thread_id, PerfmonEventSet* eventSe
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -329,23 +329,23 @@ int perfmon_stopCountersThread_tigerlake(int thread_id, PerfmonEventSet* eventSe
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, STOP_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "STOP_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -400,9 +400,9 @@ int perfmon_readCountersThread_tigerlake(int thread_id, PerfmonEventSet* eventSe
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
 
     for (int i=0;i < eventSet->numberOfEvents;i++)
@@ -427,23 +427,23 @@ int perfmon_readCountersThread_tigerlake(int thread_id, PerfmonEventSet* eventSe
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
 
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     SKL_CHECK_CORE_OVERFLOW(index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
 
                 case POWER:
                     if (haveLock)
                     {
                         CHECK_POWER_READ_ERROR(power_read(cpu_id, counter1, (uint32_t*)&counter_result));
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_POWER)
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_POWER");
                         if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                         {
-                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, OVERFLOW_POWER)
+                            VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "OVERFLOW_POWER");
                             eventSet->events[i].threadCounter[thread_id].overflows++;
                         }
                     }
@@ -472,7 +472,7 @@ int perfmon_readCountersThread_tigerlake(int thread_id, PerfmonEventSet* eventSe
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, flags));
     }
 
@@ -512,12 +512,12 @@ int perfmon_finalizeCountersThread_tigerlake(int thread_id, PerfmonEventSet* eve
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if (eventSet->events[i].event.eventId == 0xCD)
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, 0x0ULL, CLEAR_PMC_LATENCY);
+                    VERBOSEPRINTREG(cpu_id, MSR_PEBS_LD_LAT, 0x0ULL, "CLEAR_PMC_LATENCY");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PEBS_LD_LAT, 0x0ULL));
                 }
                 else if (eventSet->events[i].event.eventId == 0xC6)
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_V4_PEBS_FRONTEND, 0x0ULL, CLEAR_PMC_FRONTEND);
+                    VERBOSEPRINTREG(cpu_id, MSR_V4_PEBS_FRONTEND, 0x0ULL, "CLEAR_PMC_FRONTEND");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_V4_PEBS_FRONTEND, 0x0ULL));
                 }
                 break;
@@ -530,15 +530,15 @@ int perfmon_finalizeCountersThread_tigerlake(int thread_id, PerfmonEventSet* eve
         if ((reg) && (((type == PMC)||(type == FIXED))||(type == METRICS)|| ((type >= UNCORE && type < NUM_UNITS) && (haveLock))))
         {
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, dev, reg, &ovf_values_uncore));
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, SHOW_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, ovf_values_uncore, "SHOW_CTL");
             ovf_values_uncore = 0x0ULL;
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             if ((type >= SBOX0) && (type <= SBOX3))
             {
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
             }
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
         }
         eventSet->events[i].threadCounter[thread_id].init = FALSE;
@@ -546,9 +546,9 @@ int perfmon_finalizeCountersThread_tigerlake(int thread_id, PerfmonEventSet* eve
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/perfmon_westmereEX.h
+++ b/src/includes/perfmon_westmereEX.h
@@ -124,7 +124,7 @@ int wex_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, offcore_flags));
     }
     else if (event->eventId == 0xBB)
@@ -133,12 +133,12 @@ int wex_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
         {
             offcore_flags = (1ULL<<event->cfgBits)|(1ULL<<event->cmask);
         }
-        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, SETUP_PMC_OFFCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, LLU_CAST offcore_flags, "SETUP_PMC_OFFCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, offcore_flags));
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -166,11 +166,11 @@ int wex_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
             {
                 case EVENT_OPTION_MATCH0:
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1, event->options[j].value));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, event->options[j].value, SETUP_BBOX_MATCH);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, event->options[j].value, "SETUP_BBOX_MATCH");
                     break;
                 case EVENT_OPTION_MASK0:
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2, event->options[j].value));
-                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, event->options[j].value, SETUP_BBOX_MASK);
+                    VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister2, event->options[j].value, "SETUP_BBOX_MASK");
                     break;
                 default:
                     break;
@@ -180,7 +180,7 @@ int wex_bbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_BBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_BBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -222,7 +222,7 @@ int wex_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
-        VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_CBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -263,7 +263,7 @@ int wex_wbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-        VERBOSEPRINTREG(cpu_id, reg, flags, SETUP_WBOX);
+        VERBOSEPRINTREG(cpu_id, reg, flags, "SETUP_WBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -303,7 +303,7 @@ int wex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     if (event->eventId == 0x0)
                     {
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister1,event->options[j].value));
-                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, event->options[j].value, SETUP_SBOX_MATCH);
+                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, event->options[j].value, "SETUP_SBOX_MATCH");
                         write_mm_cfg = 1;
                     }
                     break;
@@ -311,7 +311,7 @@ int wex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     if (event->eventId == 0x0)
                     {
                         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[type].filterRegister2,event->options[j].value));
-                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, event->options[j].value, SETUP_SBOX_MASK);
+                        VERBOSEPRINTREG(cpu_id, box_map[type].filterRegister1, event->options[j].value, "SETUP_SBOX_MASK");
                         write_mm_cfg = 1;
                     }
                     break;
@@ -324,19 +324,19 @@ int wex_sbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     {
         if (type == SBOX0)
         {
-            VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, (1ULL<<63), SETUP_SBOX_MATCH_CTRL);
+            VERBOSEPRINTREG(cpu_id, MSR_S0_PMON_MM_CFG, (1ULL<<63), "SETUP_SBOX_MATCH_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S0_PMON_MM_CFG ,(1ULL<<63)));
         }
         else if (type == SBOX1)
         {
-            VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, (1ULL<<63), SETUP_SBOX_MATCH_CTRL);
+            VERBOSEPRINTREG(cpu_id, MSR_S1_PMON_MM_CFG, (1ULL<<63), "SETUP_SBOX_MATCH_CTRL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_S1_PMON_MM_CFG ,(1ULL<<63)));
         }
     }
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_SBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_SBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -370,7 +370,7 @@ int wex_ubox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, UBOX_CTRL);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "UBOX_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister , flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -406,12 +406,12 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 case EVENT_OPTION_MATCH0:
                     subflags2 = (event->options[j].value & 0x3FFFFFFFFULL);
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ADDR_MATCH], subflags2));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MATCH], subflags2, SETUP_MBOX_ADDR_MATCH);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MATCH], subflags2, "SETUP_MBOX_ADDR_MATCH");
                     break;
                 case EVENT_OPTION_MASK0:
                     subflags2 = ((event->options[j].value & 0x1FFFFFFC0ULL)>>6);
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ADDR_MASK], subflags2));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MASK], subflags2, SETUP_MBOX_ADDR_MASK);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ADDR_MASK], subflags2, "SETUP_MBOX_ADDR_MASK");
                     break;
                 default:
                     break;
@@ -433,25 +433,25 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], &subflags1));
                     subflags1 |= (event->umask & 0xFULL)<<7;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, SETUP_MBOX_DSP);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, "SETUP_MBOX_DSP");
                     break;
                 case 0x01:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], &subflags1));
                     subflags1 |= (event->umask & 0x7ULL)<<4;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, SETUP_MBOX_ISS);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, "SETUP_MBOX_ISS");
                     break;
                 case 0x05:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], &subflags1));
                     subflags1 |= (event->umask & 0x1ULL)<<6;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, SETUP_MBOX_PGT);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, "SETUP_MBOX_PGT");
                     break;
                 case 0x06:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][MAP], &subflags1));
                     subflags1 |= (event->umask & 0x7ULL)<<6;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][MAP], subflags1));
-                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][MAP], subflags1, SETUP_MBOX_MAP);
+                    VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][MAP], subflags1, "SETUP_MBOX_MAP");
                     break;
             }
             break;
@@ -469,16 +469,16 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags2 |= (event->cmask & 0x7ULL)<<7;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PLD], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, SETUP_MBOX_PLD);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, "SETUP_MBOX_PLD");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags2));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags2, SETUP_MBOX_ISS);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags2, "SETUP_MBOX_ISS");
             break;
         case 0x03:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], &subflags1));
             subflags1 |= (event->umask & 0xFULL)<<7;
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][DSP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, SETUP_MBOX_DSP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][DSP], subflags1, "SETUP_MBOX_DSP");
             break;
         case 0x04:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -500,14 +500,14 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PLD], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, SETUP_MBOX_PLD);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PLD], subflags1, "SETUP_MBOX_PLD");
             break;
         case 0x05:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], &subflags1));
             subflags1 |= (event->umask & 0xFULL);
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, SETUP_MBOX_ISS);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, "SETUP_MBOX_ISS");
             break;
         case 0x06:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -522,7 +522,7 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x07:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -537,7 +537,7 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x08:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -552,7 +552,7 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x09:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -567,28 +567,28 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<9;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ZDP], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, SETUP_MBOX_ZDP);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ZDP], subflags1, "SETUP_MBOX_ZDP");
             break;
         case 0x0A:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], &subflags1));
             subflags1 |= (event->umask & 0x1ULL)<<10;
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][ISS], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, SETUP_MBOX_ISS);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][ISS], subflags1, "SETUP_MBOX_ISS");
             break;
         case 0x0B:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], &subflags1));
             subflags1 |= (event->umask & 0x1ULL);
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, SETUP_MBOX_PGT);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, "SETUP_MBOX_PGT");
             break;
         case 0x0C:
             flags |= (event->eventId & 0x1FULL)<<9;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], &subflags1));
             subflags1 |= (event->umask & 0x1ULL)<<11;
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][PGT], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, SETUP_MBOX_PGT);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][PGT], subflags1, "SETUP_MBOX_PGT");
             break;
         case 0x0D:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -604,7 +604,7 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<4;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][THR], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, SETUP_MBOX_THR);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, "SETUP_MBOX_THR");
             break;
         case 0x0E:
             flags |= (event->eventId & 0x1FULL)<<9;
@@ -620,13 +620,13 @@ int wex_mbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 subflags1 |= (event->cmask & 0x7ULL)<<4;
             }
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, nex_wex_mbox_regs[number][THR], subflags1));
-            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, SETUP_MBOX_THR);
+            VERBOSEPRINTREG(cpu_id, nex_wex_mbox_regs[number][THR], subflags1, "SETUP_MBOX_THR");
             break;
     }
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_MBOX)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_MBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -719,7 +719,7 @@ int wex_rbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
     if (flags != currentConfig[cpu_id][index])
     {
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, SETUP_RBOX)
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, flags, "SETUP_RBOX");
         currentConfig[cpu_id][index] = flags;
     }
     return 0;
@@ -738,7 +738,7 @@ int wex_uncore_freeze(int cpu_id, PerfmonEventSet* eventSet, int flags)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, &freeze_flags));
         freeze_flags &= ~(1ULL<<28);
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST freeze_flags, FREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST freeze_flags, "FREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, freeze_flags));
     }
     if (flags != FREEZE_FLAG_ONLYFREEZE)
@@ -748,7 +748,7 @@ int wex_uncore_freeze(int cpu_id, PerfmonEventSet* eventSet, int flags)
             uint64_t clear_flags = 0x0ULL;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, &clear_flags));
             clear_flags |= 29;
-            VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST freeze_flags, CLEAR_UNCORE_CTR);
+            VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST freeze_flags, "CLEAR_UNCORE_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, freeze_flags));
         }
         else if (flags & FREEZE_FLAG_CLEAR_CTL)
@@ -762,7 +762,7 @@ int wex_uncore_freeze(int cpu_id, PerfmonEventSet* eventSet, int flags)
                     ret = HPMwrite(cpu_id, MSR_DEV, reg, 0x0ULL);
                     if (ret != 0)
                         continue;
-                    VERBOSEPRINTREG(cpu_id, reg, 0x0ULL, CLEAR_UNCORE_CTL);
+                    VERBOSEPRINTREG(cpu_id, reg, 0x0ULL, "CLEAR_UNCORE_CTL");
                 }
             }
         }
@@ -786,7 +786,7 @@ int wex_uncore_unfreeze(int cpu_id, PerfmonEventSet* eventSet, int flags)
             uint64_t clear_flags = 0x0ULL;
             CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, &clear_flags));
             clear_flags |= 29;
-            VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST clear_flags, CLEAR_UNCORE_CTR);
+            VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST clear_flags, "CLEAR_UNCORE_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, clear_flags));
         }
         else if (flags & FREEZE_FLAG_CLEAR_CTL)
@@ -797,7 +797,7 @@ int wex_uncore_unfreeze(int cpu_id, PerfmonEventSet* eventSet, int flags)
                 if (reg != 0x0ULL)
                 {
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, 0x0ULL));
-                    VERBOSEPRINTREG(cpu_id, reg, 0x0ULL, CLEAR_UNCORE_CTL);
+                    VERBOSEPRINTREG(cpu_id, reg, 0x0ULL, "CLEAR_UNCORE_CTL");
                 }
             }
         }
@@ -806,7 +806,7 @@ int wex_uncore_unfreeze(int cpu_id, PerfmonEventSet* eventSet, int flags)
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, &unfreeze_flags));
         unfreeze_flags |= (1ULL<<28);
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST unfreeze_flags, UNFREEZE_UNCORE);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST unfreeze_flags, "UNFREEZE_UNCORE");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, unfreeze_flags));
     }
     return 0;
@@ -957,7 +957,7 @@ int perfmon_setupCounterThread_westmereEX(int thread_id, PerfmonEventSet* eventS
                     flags = 0x1;
                     RegisterType newtype = WBOX;
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg , flags));
-                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, WBOX0FIX_CTRL);
+                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "WBOX0FIX_CTRL");
                     SETTYPE(eventSet, newtype);
                 }
                 break;
@@ -989,9 +989,9 @@ int perfmon_setupCounterThread_westmereEX(int thread_id, PerfmonEventSet* eventS
         {
             if ((uflags[i] != 0x0ULL) && (i != WBOX0FIX))
             {
-                VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, box_map[i].ctrlRegister, uflags[i], CLEAR_CTL);
+                VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, box_map[i].ctrlRegister, uflags[i], "CLEAR_CTL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[i].ctrlRegister, uflags[i]));
-                VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, box_map[i].ovflRegister, uflags[i], CLEAR_OVF_CTL);
+                VERBOSEPRINTPCIREG(cpu_id, MSR_DEV, box_map[i].ovflRegister, uflags[i], "CLEAR_OVF_CTL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, box_map[i].ovflRegister, uflags[i]));
             }
         }
@@ -999,12 +999,12 @@ int perfmon_setupCounterThread_westmereEX(int thread_id, PerfmonEventSet* eventS
 
     if (fixed_flags != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, SETUP_FIXED);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_FIXED_CTR_CTRL, LLU_CAST fixed_flags, "SETUP_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_FIXED_CTR_CTRL, fixed_flags));
     }
     if (ubox_flags != 0x0ULL)
     {
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST ubox_flags, ACTIVATE_UBOX);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, LLU_CAST ubox_flags, "ACTIVATE_UBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, ubox_flags));
     }
     return 0;
@@ -1069,7 +1069,7 @@ int perfmon_startCountersThread_westmereEX(int thread_id, PerfmonEventSet* event
     /* Finally enable counters */
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, GLOBAL_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, "GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, core_ctrl_flags));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, (1ULL<<63)|(1ULL<<62)|core_ctrl_flags));
     }
@@ -1153,7 +1153,7 @@ int perfmon_stopCountersThread_westmereEX(int thread_id, PerfmonEventSet* eventS
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, GLOBAL_CTRL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST 0x0ULL, "GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
     }
     wex_uncore_freeze(cpu_id, eventSet, FREEZE_FLAG_CLEAR_CTL);
@@ -1175,19 +1175,19 @@ int perfmon_stopCountersThread_westmereEX(int thread_id, PerfmonEventSet* eventS
                 case PMC:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     WEX_CHECK_OVERFLOW(PMC, index-cpuid_info.perf_num_fixed_ctr);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC);
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
                     break;
                 case FIXED:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     WEX_CHECK_OVERFLOW(PMC, index+32);
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED);
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
                     break;
                 default:
                     if(haveLock && TESTTYPE(eventSet, type))
                     {
                         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                         WEX_CHECK_UNCORE_OVERFLOW(type, index);
-                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_UNCORE);
+                        VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_UNCORE");
                     }
                     break;
             }
@@ -1213,9 +1213,9 @@ int perfmon_readCountersThread_westmereEX(int thread_id, PerfmonEventSet* eventS
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, &core_ctrl_flags));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, SAFE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, "SAFE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, RESET_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "RESET_PMC_FLAGS");
     }
     wex_uncore_freeze(cpu_id, eventSet, FREEZE_FLAG_ONLYFREEZE);
 
@@ -1237,20 +1237,20 @@ int perfmon_readCountersThread_westmereEX(int thread_id, PerfmonEventSet* eventS
                 {
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                     WEX_CHECK_UNCORE_OVERFLOW(counter_map[index].type, getCounterTypeOffset(index));
-                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_UNCORE);
+                    VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_UNCORE");
                 }
             }
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                 WEX_CHECK_OVERFLOW(PMC, index+32);
-                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_FIXED");
             }
             else if (type == PMC)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter1, &counter_result));
                 WEX_CHECK_OVERFLOW(PMC, index-cpuid_info.perf_num_fixed_ctr);
-                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, READ_PMC);
+                VERBOSEPRINTREG(cpu_id, counter1, LLU_CAST counter_result, "READ_PMC");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = field64(counter_result, 0, box_map[type].regWidth);
         }
@@ -1259,7 +1259,7 @@ int perfmon_readCountersThread_westmereEX(int thread_id, PerfmonEventSet* eventS
     wex_uncore_unfreeze(cpu_id, eventSet, FREEZE_FLAG_ONLYFREEZE);
     if ((MEASURE_CORE(eventSet)) && (core_ctrl_flags != 0x0ULL))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, RESTORE_PMC_FLAGS)
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, LLU_CAST core_ctrl_flags, "RESTORE_PMC_FLAGS");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, core_ctrl_flags));
     }
     return 0;
@@ -1298,12 +1298,12 @@ int perfmon_finalizeCountersThread_westmereEX(int thread_id, PerfmonEventSet* ev
                 ovf_values_core |= (1ULL<<(index-cpuid_info.perf_num_fixed_ctr));
                 if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xB7))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, CLEAR_OFFCORE_RESP0);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP0, 0x0ULL, "CLEAR_OFFCORE_RESP0");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP0, 0x0ULL));
                 }
                 else if ((haveTileLock) && (eventSet->events[i].event.eventId == 0xBB))
                 {
-                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, CLEAR_OFFCORE_RESP1);
+                    VERBOSEPRINTREG(cpu_id, MSR_OFFCORE_RESP1, 0x0ULL, "CLEAR_OFFCORE_RESP1");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_OFFCORE_RESP1, 0x0ULL));
                 }
                 break;
@@ -1315,13 +1315,13 @@ int perfmon_finalizeCountersThread_westmereEX(int thread_id, PerfmonEventSet* ev
         }
         if ((reg) && (((dev == MSR_DEV) && (type < UNCORE)) || (((haveLock) && (type > UNCORE)))))
         {
-            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, CLEAR_CTL);
+            VERBOSEPRINTPCIREG(cpu_id, dev, reg, 0x0ULL, "CLEAR_CTL");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, reg, 0x0ULL));
-            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+            VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
             CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister, 0x0ULL));
             if (counter_map[index].counterRegister2 != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTPCIREG(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, dev, counter_map[index].counterRegister2, 0x0ULL));
             }
         }
@@ -1329,31 +1329,31 @@ int perfmon_finalizeCountersThread_westmereEX(int thread_id, PerfmonEventSet* ev
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, CLEAR_PMC_AND_FIXED_CTL);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_CTRL, 0x0ULL, "CLEAR_PMC_AND_FIXED_CTL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core, CLEAR_PMC_AND_FIXED_OVERFLOW);
+        VERBOSEPRINTREG(cpu_id, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core, "CLEAR_PMC_AND_FIXED_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_PERF_GLOBAL_OVF_CTRL, ovf_values_core));
     }
     if (haveLock && MEASURE_UNCORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL, CLEAR_UNCORE_CTL);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL, "CLEAR_UNCORE_CTL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_CTRL, 0x0ULL));
-        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_OVF_CTRL, 0x0ULL, CLEAR_UNCORE_OVERFLOW);
+        VERBOSEPRINTREG(cpu_id, MSR_U_PMON_GLOBAL_OVF_CTRL, 0x0ULL, "CLEAR_UNCORE_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_U_PMON_GLOBAL_OVF_CTRL, 0x0ULL));
         for (int i=UNCORE;i<NUM_UNITS;i++)
         {
             if (TESTTYPE(eventSet, i) && box_map[i].ctrlRegister != 0x0)
             {
-                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, CLEAR_UNCORE_BOX_CTRL);
+                VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL, "CLEAR_UNCORE_BOX_CTRL");
                 HPMwrite(cpu_id, box_map[i].device, box_map[i].ctrlRegister, 0x0ULL);
                 if (box_map[i].filterRegister1)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister1, 0x0ULL);
                 }
                 if (box_map[i].filterRegister2)
                 {
-                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, CLEAR_FILTER);
+                    VERBOSEPRINTPCIREG(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL, "CLEAR_FILTER");
                     HPMwrite(cpu_id, box_map[i].device, box_map[i].filterRegister2, 0x0ULL);
                 }
             }

--- a/src/includes/perfmon_zen.h
+++ b/src/includes/perfmon_zen.h
@@ -55,7 +55,7 @@ int k17_fixed_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     {
         case 0x1:
             flags |= (1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT);
-            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, SETUP_FIXC0);
+            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, "SETUP_FIXC0");
             break;
         case 0x2:
         case 0x3:
@@ -102,7 +102,7 @@ int k17_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -147,7 +147,7 @@ int k17_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
         flags |= AMD_K17_L3_SLICE_MASK << AMD_K17_L3_SLICE_SHIFT;
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -166,7 +166,7 @@ int k17_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     flags |= ((uint64_t)(event->eventId>>8)<<32) + (event->umask<<8) + (event->eventId & ~(0xF00U));
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_MBOX0);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_MBOX0");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -212,9 +212,9 @@ int perfmon_setupCounterThread_zen(int thread_id, PerfmonEventSet* eventSet)
     {
         uint64_t tmp = 0x0ULL;
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, &tmp));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, READ_HW_CONFIG);
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "READ_HW_CONFIG");
         tmp |= fixed_flags;
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, WRITE_HW_CONFIG)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "WRITE_HW_CONFIG");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, tmp));
     }
     return 0;
@@ -266,12 +266,12 @@ int perfmon_startCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
                 ((type == MBOX0) && (haveDLock)) ||
                 ((type == CBOX0) && (haveL3Lock)))
             {
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, RESET_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, "RESET_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter, 0x0ULL));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, READ_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "READ_CTRL");
                 flags |= (1ULL << AMD_K17_ENABLE_BIT);  /* enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, START_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "START_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
             }
             else if (type == POWER)
@@ -282,13 +282,13 @@ int perfmon_startCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
                     continue;
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_POWER");
             }
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = eventSet->events[i].threadCounter[thread_id].startData;
         }
@@ -342,14 +342,14 @@ int perfmon_stopCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
                 flags &= ~(1ULL<<22);  /* clear enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, STOP_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "STOP_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "READ_CTR");
                 if (field64(counter_result, 0, box_map[type].regWidth) < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, OVERFLOW);
+                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "OVERFLOW");
                 }
             }
             else if (type == POWER)
@@ -363,10 +363,10 @@ int perfmon_stopCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                 }
 
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_POWER");
             }
             else if (type == FIXED)
             {
@@ -375,9 +375,9 @@ int perfmon_stopCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                 }
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = counter_result;
         }
@@ -430,7 +430,7 @@ int perfmon_readCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
                 ((type == CBOX0) && (haveL3Lock)))
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_CTR");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -444,10 +444,10 @@ int perfmon_readCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
                 if (counter == MSR_AMD17_RAPL_CORE_STATUS && (!haveCLock))
                     continue;
                 CHECK_POWER_READ_ERROR(power_read(cpu_id, counter, (uint32_t*)&counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_POWER)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_POWER");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -455,10 +455,10 @@ int perfmon_readCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -503,12 +503,12 @@ int perfmon_finalizeCountersThread_zen(int thread_id, PerfmonEventSet* eventSet)
         {
             if (counter_map[index].configRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, CLEAR_CTRL);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, "CLEAR_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, 0x0ULL));
             }
             if (counter_map[index].counterRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
             }
             eventSet->events[i].threadCounter[thread_id].init = FALSE;

--- a/src/includes/perfmon_zen2.h
+++ b/src/includes/perfmon_zen2.h
@@ -54,7 +54,7 @@ int zen2_fixed_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     {
         case 0x1:
             flags |= (1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT);
-            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, SETUP_FIXC0);
+            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, "SETUP_FIXC0");
             break;
         case 0x2:
         case 0x3:
@@ -101,7 +101,7 @@ int zen2_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -146,7 +146,7 @@ int zen2_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
         flags |= AMD_K17_L3_SLICE_MASK << AMD_K17_L3_SLICE_SHIFT;
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -171,7 +171,7 @@ int zen2_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_DF);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_DF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -217,9 +217,9 @@ int perfmon_setupCounterThread_zen2(int thread_id, PerfmonEventSet* eventSet)
     {
         uint64_t tmp = 0x0ULL;
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, &tmp));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, READ_HW_CONFIG);
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "READ_HW_CONFIG");
         tmp |= fixed_flags;
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, WRITE_HW_CONFIG)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "WRITE_HW_CONFIG");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, tmp));
     }
     return 0;
@@ -271,12 +271,12 @@ int perfmon_startCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
                 ((type == MBOX0) && (haveSLock)) ||
                 ((type == CBOX0) && (haveL3Lock)))
             {
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, RESET_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, "RESET_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter, 0x0ULL));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, READ_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "READ_CTRL");
                 flags |= (1ULL << AMD_K17_ENABLE_BIT);  /* enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, START_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "START_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
             }
             else if (type == POWER)
@@ -287,13 +287,13 @@ int perfmon_startCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
                     continue;
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_POWER");
             }
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = eventSet->events[i].threadCounter[thread_id].startData;
         }
@@ -347,14 +347,14 @@ int perfmon_stopCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
                 flags &= ~(1ULL<<AMD_K17_ENABLE_BIT);  /* clear enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, STOP_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "STOP_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "READ_CTR");
                 if (field64(counter_result, 0, box_map[type].regWidth) < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, OVERFLOW);
+                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "OVERFLOW");
                 }
             }
             else if (type == POWER)
@@ -368,10 +368,10 @@ int perfmon_stopCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                 }
 
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_POWER");
             }
             else if (type == FIXED)
             {
@@ -380,9 +380,9 @@ int perfmon_stopCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                 }
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = counter_result;
         }
@@ -435,7 +435,7 @@ int perfmon_readCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
                 ((type == CBOX0) && (haveL3Lock)))
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_CTR");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -449,10 +449,10 @@ int perfmon_readCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
                 if (counter == MSR_AMD17_RAPL_CORE_STATUS && (!haveCLock))
                     continue;
                 CHECK_POWER_READ_ERROR(power_read(cpu_id, counter, (uint32_t*)&counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_POWER)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_POWER");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -460,10 +460,10 @@ int perfmon_readCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet)
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -509,12 +509,12 @@ int perfmon_finalizeCountersThread_zen2(int thread_id, PerfmonEventSet* eventSet
         {
             if (counter_map[index].configRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, CLEAR_CTRL);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, "CLEAR_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, 0x0ULL));
             }
             if (counter_map[index].counterRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
             }
             eventSet->events[i].threadCounter[thread_id].init = FALSE;

--- a/src/includes/perfmon_zen3.h
+++ b/src/includes/perfmon_zen3.h
@@ -57,7 +57,7 @@ int zen3_fixed_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     {
         case 0x1:
             flags |= (1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT);
-            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, SETUP_FIXC0);
+            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, "SETUP_FIXC0");
             break;
         case 0x2:
         case 0x3:
@@ -104,7 +104,7 @@ int zen3_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -157,7 +157,7 @@ int zen3_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -182,7 +182,7 @@ int zen3_uncore_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_DF);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_DF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -228,9 +228,9 @@ int perfmon_setupCounterThread_zen3(int thread_id, PerfmonEventSet* eventSet)
     {
         uint64_t tmp = 0x0ULL;
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, &tmp));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, READ_HW_CONFIG);
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "READ_HW_CONFIG");
         tmp |= fixed_flags;
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, WRITE_HW_CONFIG)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "WRITE_HW_CONFIG");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, tmp));
     }
     return 0;
@@ -282,12 +282,12 @@ int perfmon_startCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
                 ((type == MBOX0) && (haveSLock)) ||
                 ((type == CBOX0) && (haveL3Lock)))
             {
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, RESET_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, "RESET_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter, 0x0ULL));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, READ_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "READ_CTRL");
                 flags |= (1ULL << AMD_K17_ENABLE_BIT);  /* enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, START_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "START_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
             }
             else if (type == POWER)
@@ -298,13 +298,13 @@ int perfmon_startCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
                     continue;
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_POWER");
             }
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = eventSet->events[i].threadCounter[thread_id].startData;
         }
@@ -358,14 +358,14 @@ int perfmon_stopCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
                 flags &= ~(1ULL<<AMD_K17_ENABLE_BIT);  /* clear enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, STOP_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "STOP_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "READ_CTR");
                 if (field64(counter_result, 0, box_map[type].regWidth) < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, OVERFLOW);
+                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "OVERFLOW");
                 }
             }
             else if (type == POWER)
@@ -379,10 +379,10 @@ int perfmon_stopCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                 }
 
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_POWER");
             }
             else if (type == FIXED)
             {
@@ -391,9 +391,9 @@ int perfmon_stopCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                 }
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = counter_result;
         }
@@ -446,7 +446,7 @@ int perfmon_readCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
                 ((type == CBOX0) && (haveL3Lock)))
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_CTR");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -460,10 +460,10 @@ int perfmon_readCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
                 if (counter == MSR_AMD17_RAPL_CORE_STATUS && (!haveCLock))
                     continue;
                 CHECK_POWER_READ_ERROR(power_read(cpu_id, counter, (uint32_t*)&counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_POWER)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_POWER");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -471,10 +471,10 @@ int perfmon_readCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet)
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -520,12 +520,12 @@ int perfmon_finalizeCountersThread_zen3(int thread_id, PerfmonEventSet* eventSet
         {
             if (counter_map[index].configRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, CLEAR_CTRL);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, "CLEAR_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, 0x0ULL));
             }
             if (counter_map[index].counterRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
             }
             eventSet->events[i].threadCounter[thread_id].init = FALSE;

--- a/src/includes/perfmon_zen4.h
+++ b/src/includes/perfmon_zen4.h
@@ -57,7 +57,7 @@ int zen4_fixed_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     {
         case 0x1:
             flags |= (1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT);
-            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, SETUP_FIXC0);
+            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, "SETUP_FIXC0");
             break;
         case 0x2:
         case 0x3:
@@ -105,7 +105,7 @@ int zen4_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -158,7 +158,7 @@ int zen4_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -187,7 +187,7 @@ int zen4_datafabric_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_DF);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_DF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -234,9 +234,9 @@ int perfmon_setupCounterThread_zen4(int thread_id, PerfmonEventSet* eventSet)
     {
         uint64_t tmp = 0x0ULL;
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, &tmp));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, READ_HW_CONFIG);
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "READ_HW_CONFIG");
         tmp |= fixed_flags;
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, WRITE_HW_CONFIG)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "WRITE_HW_CONFIG");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, tmp));
     }
     return 0;
@@ -287,12 +287,12 @@ int perfmon_startCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
                 ((type == MBOX0) && (haveSLock)) ||
                 ((type == CBOX0) && (haveL3Lock)))
             {
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, RESET_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, "RESET_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter, 0x0ULL));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, READ_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "READ_CTRL");
                 flags |= (1ULL << AMD_K17_ENABLE_BIT);  /* enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, START_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "START_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
             }
             else if (type == POWER)
@@ -305,13 +305,13 @@ int perfmon_startCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
                     continue;
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = flags;
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST flags, START_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST flags, "START_POWER");
             }
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = eventSet->events[i].threadCounter[thread_id].startData;
         }
@@ -365,14 +365,14 @@ int perfmon_stopCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
                 flags &= ~(1ULL<<AMD_K17_ENABLE_BIT);  /* clear enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, STOP_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "STOP_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "READ_CTR");
                 if (field64(counter_result, 0, box_map[type].regWidth) < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, OVERFLOW);
+                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "OVERFLOW");
                 }
             }
             else if (type == POWER)
@@ -387,10 +387,10 @@ int perfmon_stopCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                 }
 
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_POWER");
             }
             else if (type == FIXED)
             {
@@ -399,9 +399,9 @@ int perfmon_stopCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                 }
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = counter_result;
         }
@@ -454,7 +454,7 @@ int perfmon_readCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
                 ((type == CBOX0) && (haveL3Lock)))
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_CTR");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
@@ -470,10 +470,10 @@ int perfmon_readCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
                 if (counter == MSR_AMD19_RAPL_L3_STATUS && (!haveL3Lock))
                     continue;
                 CHECK_POWER_READ_ERROR(power_read(cpu_id, counter, (uint32_t*)&counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_POWER)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_POWER");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -481,10 +481,10 @@ int perfmon_readCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet)
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -530,12 +530,12 @@ int perfmon_finalizeCountersThread_zen4(int thread_id, PerfmonEventSet* eventSet
         {
             if (counter_map[index].configRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, CLEAR_CTRL);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, "CLEAR_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, 0x0ULL));
             }
             if (counter_map[index].counterRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
             }
             eventSet->events[i].threadCounter[thread_id].init = FALSE;

--- a/src/includes/perfmon_zen4c.h
+++ b/src/includes/perfmon_zen4c.h
@@ -57,7 +57,7 @@ int zen4c_fixed_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     {
         case 0x1:
             flags |= (1ULL << AMD_K17_INST_RETIRE_ENABLE_BIT);
-            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, SETUP_FIXC0);
+            VERBOSEPRINTREG(cpu_id, 0x00, LLU_CAST flags, "SETUP_FIXC0");
             break;
         case 0x2:
         case 0x3:
@@ -105,7 +105,7 @@ int zen4c_pmc_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
     }
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_PMC);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -158,7 +158,7 @@ int zen4c_cache_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_CBOX);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_CBOX");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -187,7 +187,7 @@ int zen4c_datafabric_setup(int cpu_id, RegisterIndex index, PerfmonEvent* event)
 
     if (flags != currentConfig[cpu_id][index])
     {
-        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, SETUP_DF);
+        VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, LLU_CAST flags, "SETUP_DF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, flags));
         currentConfig[cpu_id][index] = flags;
     }
@@ -202,7 +202,7 @@ int perfmon_setupCounterThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC_AND_FIXED)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC_AND_FIXED");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_CTRL, 0x0ULL));
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_GLOBAL_OVF_CTRL, 0x3F));
     }
@@ -241,9 +241,9 @@ int perfmon_setupCounterThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
     {
         uint64_t tmp = 0x0ULL;
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, &tmp));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, READ_HW_CONFIG);
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "READ_HW_CONFIG");
         tmp |= fixed_flags;
-        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, WRITE_HW_CONFIG)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD17_HW_CONFIG, LLU_CAST tmp, "WRITE_HW_CONFIG");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD17_HW_CONFIG, tmp));
     }
     return 0;
@@ -295,16 +295,16 @@ int perfmon_startCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
                 ((type == MBOX0) && (haveSLock)) ||
                 ((type == CBOX0) && (haveL3Lock)))
             {
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, RESET_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST 0x0ULL, "RESET_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter, 0x0ULL));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, READ_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "READ_CTRL");
                 flags |= (1ULL << AMD_K17_ENABLE_BIT);  /* enable flag */
                 if (type == PMC)
                 {
                     pmc_flags |= (1ULL << getCounterTypeOffset(index));
                 }
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, START_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "START_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
             }
             else if (type == POWER)
@@ -317,13 +317,13 @@ int perfmon_startCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
                     continue;
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = flags;
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST flags, START_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST flags, "START_POWER");
             }
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &flags));
                 eventSet->events[i].threadCounter[thread_id].startData = field64(flags, 0, box_map[type].regWidth);
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), START_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST field64(flags, 0, box_map[type].regWidth), "START_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = eventSet->events[i].threadCounter[thread_id].startData;
         }
@@ -331,9 +331,9 @@ int perfmon_startCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
 
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_GLOBAL_OVF_CTRL, LLU_CAST pmc_flags, CLEAR_PMC_OVERFLOW)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_GLOBAL_OVF_CTRL, LLU_CAST pmc_flags, "CLEAR_PMC_OVERFLOW");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_GLOBAL_OVF_CTRL, pmc_flags));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST pmc_flags, UNFREEZE_PMC)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST pmc_flags, "UNFREEZE_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_CTRL, pmc_flags));
     }
 
@@ -380,7 +380,7 @@ int perfmon_stopCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -403,10 +403,10 @@ int perfmon_stopCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, reg, &flags));
                 flags &= ~(1ULL<<AMD_K17_ENABLE_BIT);  /* clear enable flag */
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, STOP_CTRL);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST flags, "STOP_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, reg, flags));
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "READ_CTR");
                 if (type == PMC)
                 {
                     ZEN4C_CHECK_CORE_OVERFLOW(getCounterTypeOffset(index));
@@ -414,7 +414,7 @@ int perfmon_stopCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
                 else if (field64(counter_result, 0, box_map[type].regWidth) < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, OVERFLOW);
+                    VERBOSEPRINTREG(cpu_id, reg, LLU_CAST counter_result, "OVERFLOW");
                 }
             }
             else if (type == POWER)
@@ -429,10 +429,10 @@ int perfmon_stopCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                 }
 
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_POWER);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_POWER");
             }
             else if (type == FIXED)
             {
@@ -441,9 +441,9 @@ int perfmon_stopCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
                     eventSet->events[i].threadCounter[thread_id].overflows++;
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                 }
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, STOP_FIXED);
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "STOP_FIXED");
             }
             eventSet->events[i].threadCounter[thread_id].counterData = counter_result;
         }
@@ -481,8 +481,8 @@ int perfmon_readCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
     if (MEASURE_CORE(eventSet))
     {
         CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_CTRL, &flags));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST flags, SAFE_PMC_FLAGS)
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, 0x0ULL, FREEZE_PMC)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST flags, "SAFE_PMC_FLAGS");
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, 0x0ULL, "FREEZE_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_CTRL, 0x0ULL));
     }
 
@@ -504,7 +504,7 @@ int perfmon_readCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
                 ((type == CBOX0) && (haveL3Lock)))
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, counter_result, READ_CTR);
+                VERBOSEPRINTREG(cpu_id, counter, counter_result, "READ_CTR");
                 if (type == PMC)
                 {
                     ZEN4C_CHECK_CORE_OVERFLOW(getCounterTypeOffset(index));
@@ -524,10 +524,10 @@ int perfmon_readCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
                 if (counter == MSR_AMD19_RAPL_L3_STATUS && (!haveL3Lock))
                     continue;
                 CHECK_POWER_READ_ERROR(power_read(cpu_id, counter, (uint32_t*)&counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_POWER)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_POWER");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_POWER)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_POWER");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -535,10 +535,10 @@ int perfmon_readCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
             else if (type == FIXED)
             {
                 CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, counter, &counter_result));
-                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, READ_FIXED)
+                VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "READ_FIXED");
                 if (counter_result < eventSet->events[i].threadCounter[thread_id].counterData)
                 {
-                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, OVERFLOW_FIXED)
+                    VERBOSEPRINTREG(cpu_id, counter, LLU_CAST counter_result, "OVERFLOW_FIXED");
                     eventSet->events[i].threadCounter[thread_id].overflows++;
                 }
                 *current = field64(counter_result, 0, box_map[type].regWidth);
@@ -547,7 +547,7 @@ int perfmon_readCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSet)
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST flags, UNFREEZE_PMC)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST flags, "UNFREEZE_PMC");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_CTRL, flags));
     }
     return 0;
@@ -590,12 +590,12 @@ int perfmon_finalizeCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSe
         {
             if (counter_map[index].configRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, CLEAR_CTRL);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].configRegister, 0x0ULL, "CLEAR_CTRL");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].configRegister, 0x0ULL));
             }
             if (counter_map[index].counterRegister != 0x0)
             {
-                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, CLEAR_CTR);
+                VERBOSEPRINTREG(cpu_id, counter_map[index].counterRegister, 0x0ULL, "CLEAR_CTR");
                 CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, counter_map[index].counterRegister, 0x0ULL));
             }
             if (type == PMC)
@@ -617,9 +617,9 @@ int perfmon_finalizeCountersThread_zen4c(int thread_id, PerfmonEventSet* eventSe
     }
     if (MEASURE_CORE(eventSet))
     {
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, CLEAR_GLOBAL_OVF)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_GLOBAL_OVF_CTRL, LLU_CAST ovf_values_core, "CLEAR_GLOBAL_OVF");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_GLOBAL_OVF_CTRL, ovf_values_core));
-        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST 0x0ULL, CLEAR_GLOBAL_CTRL)
+        VERBOSEPRINTREG(cpu_id, MSR_AMD19_GLOBAL_CTRL, LLU_CAST 0x0ULL, "CLEAR_GLOBAL_CTRL");
         CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, MSR_AMD19_GLOBAL_CTRL, 0x0ULL));
     }
     return 0;

--- a/src/includes/power.h
+++ b/src/includes/power.h
@@ -107,7 +107,7 @@ power_start(PowerData* data, int cpuId, PowerType type)
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }
@@ -134,7 +134,7 @@ power_stop(PowerData* data, int cpuId, PowerType type)
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }
@@ -171,7 +171,7 @@ power_read(int cpuId, uint64_t reg, uint32_t *data)
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }
@@ -207,7 +207,7 @@ power_tread(int socket_fd, int cpuId, uint64_t reg, uint32_t *data)
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }

--- a/src/includes/power.h
+++ b/src/includes/power.h
@@ -94,20 +94,20 @@ power_start(PowerData* data, int cpuId, PowerType type)
         {
             uint64_t result = 0;
             data->before = 0;
-            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, power_regs[type], &result))
+            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, power_regs[type], &result));
             data->before = field64(result, 0, power_info.statusRegWidth);
             data->domain = type;
             return 0;
         }
         else
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, RAPL domain %s not supported, power_names[type]);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "RAPL domain %s not supported", power_names[type]);
             return -EFAULT;
         }
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, No RAPL support);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }
@@ -121,20 +121,20 @@ power_stop(PowerData* data, int cpuId, PowerType type)
         {
             uint64_t result = 0;
             data->after = 0;
-            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, power_regs[type], &result))
+            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, power_regs[type], &result));
             data->after = field64(result, 0, power_info.statusRegWidth);
             data->domain = type;
             return 0;
         }
         else
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, RAPL domain %s not supported, power_names[type]);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "RAPL domain %s not supported", power_names[type]);
             return -EFAULT;
         }
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, No RAPL support);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }
@@ -159,19 +159,19 @@ power_read(int cpuId, uint64_t reg, uint32_t *data)
         {
             uint64_t result = 0;
             *data = 0;
-            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, reg, &result))
+            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, reg, &result));
             *data = field64(result, 0, power_info.statusRegWidth);
             return 0;
         }
         else
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, RAPL domain %s not supported, power_names[type]);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "RAPL domain %s not supported", power_names[type]);
             return -EFAULT;
         }
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, No RAPL support);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }
@@ -195,19 +195,19 @@ power_tread(int socket_fd, int cpuId, uint64_t reg, uint32_t *data)
         {
             uint64_t result = 0;
             *data = 0;
-            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, reg, &result))
+            CHECK_MSR_READ_ERROR(HPMread(cpuId, MSR_DEV, reg, &result));
             *data = field64(result, 0, power_info.statusRegWidth);
             return 0;
         }
         else
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, RAPL domain %s not supported, power_names[type]);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "RAPL domain %s not supported", power_names[type]);
             return -EFAULT;
         }
     }
     else
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, No RAPL support);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_DEVELOP, "No RAPL support");
         return -EIO;
     }
 }

--- a/src/includes/registers_types.h
+++ b/src/includes/registers_types.h
@@ -1140,7 +1140,7 @@ static char* RegisterTypeNames[MAX_UNITS] = {
         } \
         else \
         { \
-            ERROR_PRINT(Cannot set out-of-bounds type %d, (type)); \
+            ERROR_PRINT("Cannot set out-of-bounds type %d", (type)); \
         }
 #define MEASURE_CORE(eventset) \
         (eventset->regTypeMask1 & (REG_TYPE_MASK(PMC)|REG_TYPE_MASK(FIXED)|REG_TYPE_MASK(METRICS)))

--- a/src/intel_perfmon_uncore_discovery.c
+++ b/src/intel_perfmon_uncore_discovery.c
@@ -156,7 +156,7 @@ static int pci_test_bus(int domain, int bus)
     }
     else
     {
-        ERROR_PRINT(Cannot format path to PCI bus directory for domain %d and bus %d, domain, bus);
+        ERROR_PRINT("Cannot format path to PCI bus directory for domain %d and bus %d", domain, bus);
     }
     return !access(fname, R_OK);
 }
@@ -212,7 +212,7 @@ static int max_socket_id(int* max_socket)
             }
         }
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Found max socket ID %d, cur_max);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Found max socket ID %d", cur_max);
     *max_socket = cur_max;
     return 0;
 }
@@ -401,7 +401,7 @@ static void print_unit(PciDeviceIndex idx, PerfmonDiscoveryUnit* unit)
     }
     if (name != NULL)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, PCIIDX %d Access %s NumRegs %d ID %d Type %s(%d) box_ctl 0x%X ctrl_offset 0x%X ctr_offset 0x%X mmap_addr 0x%X mmap_offset 0x%X,
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "PCIIDX %d Access %s NumRegs %d ID %d Type %s(%d) box_ctl 0x%X ctrl_offset 0x%X ctr_offset 0x%X mmap_addr 0x%X mmap_offset 0x%X",
                 idx, AccessTypeNames[unit->access_type], unit->num_regs, unit->box_id, name, unit->box_type,
                 unit->box_ctl, unit->ctrl_offset, unit->ctr_offset, unit->mmap_addr, unit->mmap_offset);
     }
@@ -469,13 +469,13 @@ int perfmon_uncore_discovery(int model, PerfmonDiscovery** perfmon)
             uncore_discovery_map = sierraforrest_uncore_discovery_map;
             break;
         default:
-            ERROR_PRINT(Uncore discovery not supported for model 0x%X, model);
+            ERROR_PRINT("Uncore discovery not supported for model 0x%X", model);
             return -1;
     }
 
     if (max_socket_id(&max_sockets) < 0)
     {
-        ERROR_PRINT(Failed to determine number of sockets);
+        ERROR_PRINT("Failed to determine number of sockets");
         return -1;
     }
 
@@ -483,14 +483,14 @@ int perfmon_uncore_discovery(int model, PerfmonDiscovery** perfmon)
     int pcihandle = open("/dev/mem", O_RDWR);
     if (pcihandle < 0)
     {
-        ERROR_PRINT(Cannot open /dev/mem);
+        ERROR_PRINT("Cannot open /dev/mem");
         return -errno;
     }
     PerfmonDiscovery* perf = malloc(sizeof(PerfmonDiscovery));
     if (!perf)
     {
         close(pcihandle);
-        ERROR_PRINT(Cannot allocate space for device tables);
+        ERROR_PRINT("Cannot allocate space for device tables");
         return -ENOMEM;
     }
     perf->sockets = NULL;
@@ -503,7 +503,7 @@ int perfmon_uncore_discovery(int model, PerfmonDiscovery** perfmon)
             ret = pci_read_config_dword(dev, dvsec + UNCORE_DISCOVERY_DVSEC_OFFSET, &val);
             if (ret < 0)
             {
-                ERROR_PRINT(Failed to read DVSEC offset from device %.04x:%.02x:%.02x.%.01x, dev->domain, dev->bus, dev->device, dev->func);
+                ERROR_PRINT("Failed to read DVSEC offset from device %.04x:%.02x:%.02x.%.01x", dev->domain, dev->bus, dev->device, dev->func);
                 continue;
             }
             entry_id = val & UNCORE_DISCOVERY_DVSEC_ID_MASK;
@@ -514,7 +514,7 @@ int perfmon_uncore_discovery(int model, PerfmonDiscovery** perfmon)
                 ret = pci_read_config_dword(dev, dvsec + UNCORE_DISCOVERY_DVSEC2_OFFSET, &bir);
                 if (ret < 0)
                 {
-                    ERROR_PRINT(Failed to read DIR from device %.04x:%.02x:%.02x.%.01x, dev->domain, dev->bus, dev->device, dev->func);
+                    ERROR_PRINT("Failed to read DIR from device %.04x:%.02x:%.02x.%.01x", dev->domain, dev->bus, dev->device, dev->func);
                     continue;
                 }
                /* read BIR value (2:0) */
@@ -525,14 +525,14 @@ int perfmon_uncore_discovery(int model, PerfmonDiscovery** perfmon)
                 ret = pci_read_config_dword(dev, bar_offset, &pci_dword);
                 if (ret < 0)
                 {
-                    ERROR_PRINT(Failed to read BAR offset from device %.04x:%.02x:%.02x.%.01x, dev->domain, dev->bus, dev->device, dev->func);
+                    ERROR_PRINT("Failed to read BAR offset from device %.04x:%.02x:%.02x.%.01x", dev->domain, dev->bus, dev->device, dev->func);
                     continue;
                 }
                 /* get page boundary address of pci_dword */
                 addr = pci_dword & ~(PAGE_SIZE - 1);
                 if ((pci_dword & PCI_BASE_ADDRESS_MEM_TYPE_MASK) == PCI_BASE_ADDRESS_MEM_TYPE_64)
                 {
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Mem type 64);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Mem type 64");
                     uint32_t pci_dword2;
                     ret = pci_read_config_dword(dev, bar_offset + sizeof(uint32_t), &pci_dword2);
                     if (ret > 0) addr |= ((uint64_t)pci_dword2) << 32;
@@ -543,7 +543,7 @@ int perfmon_uncore_discovery(int model, PerfmonDiscovery** perfmon)
                 io_addr = mmap(NULL, UNCORE_DISCOVERY_MAP_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED, pcihandle, addr);
                 if (io_addr == MAP_FAILED)
                 {
-                    ERROR_PRINT(Failed to mmap device %.04x:%.02x:%.02x.%.01x, dev->domain, dev->bus, dev->device, dev->func);
+                    ERROR_PRINT("Failed to mmap device %.04x:%.02x:%.02x.%.01x", dev->domain, dev->bus, dev->device, dev->func);
                     continue;
                 }
                 memset(&global, 0, sizeof(struct uncore_global_discovery));
@@ -554,12 +554,12 @@ int perfmon_uncore_discovery(int model, PerfmonDiscovery** perfmon)
                     continue;
                 }
                 //printf("Global 1=0x%lX 2=0x%lX 3=0x%lX\n", global.table1, global.table2, global.table3);
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Device %.04x:%.02x:%.02x.%.01x usable with %d units, dev->domain, dev->bus, dev->device, dev->func, global.max_units);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Device %.04x:%.02x:%.02x.%.01x usable with %d units", dev->domain, dev->bus, dev->device, dev->func, global.max_units);
 
                 PerfmonDiscoverySocket* tmp = realloc(perf->sockets, (socket_id + 1) * sizeof(PerfmonDiscoverySocket));
                 if (!tmp)
                 {
-                    ERROR_PRINT(Cannot enlarge socket device table to %d, socket_id);
+                    ERROR_PRINT("Cannot enlarge socket device table to %d", socket_id);
                     if (perf->sockets) free(perf->sockets);
                     free(perf);
                     close(pcihandle);

--- a/src/libnvctr.c
+++ b/src/libnvctr.c
@@ -220,13 +220,13 @@ void nvmon_markerClose(void) {
   file = fopen(markerfile, "w");
   if (file != NULL) {
     DEBUG_PRINT(DEBUGLEV_DEVELOP,
-                Creating GPU Marker file % s with % d regions % d groups and
-                    % d GPUs,
+                "Creating GPU Marker file % s with % d regions % d groups and "
+                    "%d GPUs",
                 markerfile, numberOfRegions, numberOfCudaGroups, numberOfGPUs);
     bstring thread_regs_grps =
         bformat("%d %d %d", numberOfGPUs, numberOfRegions, numberOfCudaGroups);
     fprintf(file, "%s\n", bdata(thread_regs_grps));
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, % s, bdata(thread_regs_grps));
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(thread_regs_grps));
     bdestroy(thread_regs_grps);
 
     for (int j = 0; j < numberOfRegions; j++) {
@@ -235,7 +235,7 @@ void nvmon_markerClose(void) {
       if (ret == 0) {
         bstring tmp = bformat("%d:%s", j, bdata(results->label));
         fprintf(file, "%s\n", bdata(tmp));
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, % s, bdata(tmp));
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(tmp));
         bdestroy(tmp);
       }
     }
@@ -256,7 +256,7 @@ void nvmon_markerClose(void) {
             bdestroy(tmp);
           }
           fprintf(file, "%s\n", bdata(l));
-          DEBUG_PRINT(DEBUGLEV_DEVELOP, % s, bdata(l));
+          DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(l));
           bdestroy(l);
         }
         free(results);
@@ -292,13 +292,13 @@ int nvmon_markerWriteFile(const char* markerfile)
   file = fopen(markerfile, "w");
   if (file != NULL) {
     DEBUG_PRINT(DEBUGLEV_DEVELOP,
-                Creating GPU Marker file % s with % d regions % d groups and
-                    % d GPUs,
+                "Creating GPU Marker file %s with %d regions %d groups and "
+                    "%d GPUs",
                 markerfile, numberOfRegions, numberOfCudaGroups, numberOfGPUs);
     bstring thread_regs_grps =
         bformat("%d %d %d", numberOfGPUs, numberOfRegions, numberOfCudaGroups);
     fprintf(file, "%s\n", bdata(thread_regs_grps));
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, % s, bdata(thread_regs_grps));
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(thread_regs_grps));
     bdestroy(thread_regs_grps);
 
     for (int j = 0; j < numberOfRegions; j++) {
@@ -307,7 +307,7 @@ int nvmon_markerWriteFile(const char* markerfile)
       if (ret == 0) {
         bstring tmp = bformat("%d:%s", j, bdata(results->label));
         fprintf(file, "%s\n", bdata(tmp));
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, % s, bdata(tmp));
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(tmp));
         bdestroy(tmp);
       }
     }
@@ -328,7 +328,7 @@ int nvmon_markerWriteFile(const char* markerfile)
             bdestroy(tmp);
           }
           fprintf(file, "%s\n", bdata(l));
-          DEBUG_PRINT(DEBUGLEV_DEVELOP, % s, bdata(l));
+          DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(l));
           bdestroy(l);
         }
         free(results);
@@ -421,8 +421,8 @@ int nvmon_markerStartRegion(const char *regionTag) {
             nvmon_getLastResult(results->groupID, j, i);
       else if (device->backend == LIKWID_NVMON_PERFWORKS_BACKEND)
         results->StartPMcounters[j] = nvmon_getResult(results->groupID, j, i);
-      GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, START Device % d Event % d
-                     : % f, i, j, results->StartPMcounters[j]);
+      GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "START Device %d Event %d"
+                     ": %f", i, j, results->StartPMcounters[j]);
     }
     results->state = GPUMARKER_STATE_START;
     timer_start(&(results->startTime));
@@ -471,8 +471,8 @@ int nvmon_markerStopRegion(const char *regionTag) {
       /*                */
       /*            }*/
       results->PMcounters[j] += end - results->StartPMcounters[j];
-      GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, STOP Device % d Event % d
-                     : % f - % f, i, j, end, results->StartPMcounters[j]);
+      GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "STOP Device %d Event %d"
+                     ": %f - %f", i, j, end, results->StartPMcounters[j]);
     }
     results->state = GPUMARKER_STATE_STOP;
   }
@@ -563,7 +563,7 @@ void nvmon_markerNextGroup(void) {
   }
   int next_group = (activeCudaGroup + 1) % numberOfCudaGroups;
   if (next_group != activeCudaGroup) {
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Switch from GPU group % d to group % d,
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Switch from GPU group %d to group %d",
                 activeCudaGroup, next_group);
     nvmon_switchActiveGroup(next_group);
   }

--- a/src/libperfctr.c
+++ b/src/libperfctr.c
@@ -362,7 +362,7 @@ likwid_markerThreadInit(void)
         if ((CPU_COUNT(&cpuset) > 1) || (likwid_getProcessorId() != threads2Cpu[myID % num_cpus]))
         {
             likwid_pinThread(threads2Cpu[myID % num_cpus]);
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Pin thread %lu to CPU %d currently %d, gettid(), threads2Cpu[myID % num_cpus], sched_getcpu());
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Pin thread %lu to CPU %d currently %d", gettid(), threads2Cpu[myID % num_cpus], sched_getcpu());
         }
     }
 }
@@ -381,7 +381,7 @@ likwid_markerNextGroup(void)
     next_group = (groupSet->activeGroup + 1) % numberOfGroups;
     if (next_group != groupSet->activeGroup)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Switch from group %d to group %d, groupSet->activeGroup, next_group);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Switch from group %d to group %d", groupSet->activeGroup, next_group);
         i = perfmon_switchActiveGroup(next_group);
     }
     return;
@@ -455,11 +455,11 @@ likwid_markerClose(void)
             fprintf(stderr, "      - The region was never started but stopped\n");
         }
         DEBUG_PRINT(DEBUGLEV_DEVELOP,
-                Creating Marker file %s with %d regions %d groups and %d threads,
+                "Creating Marker file %s with %d regions %d groups and %d threads",
                 markerfile, newNumberOfRegions, numberOfGroups, numberOfThreads);
         bstring thread_regs_grps = bformat("%d %d %d", numberOfThreads, newNumberOfRegions, numberOfGroups);
         fprintf(file,"%s\n", bdata(thread_regs_grps));
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, %s, bdata(thread_regs_grps));
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(thread_regs_grps));
         bdestroy(thread_regs_grps);
 
         for (int i=0; i<numberOfRegions; i++)
@@ -468,7 +468,7 @@ likwid_markerClose(void)
                 continue;
             bstring tmp = bformat("%d:%s", newRegionID, bdata(results[i].tag));
             fprintf(file,"%s\n", bdata(tmp));
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, %s, bdata(tmp));
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(tmp));
             bdestroy(tmp);
             newRegionID++;
         }
@@ -494,7 +494,7 @@ likwid_markerClose(void)
                     bdestroy(tmp);
                 }
                 fprintf(file,"%s\n", bdata(l));
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, %s, bdata(l));
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(l));
                 bdestroy(l);
             }
             newRegionID++;
@@ -593,11 +593,11 @@ likwid_markerWriteFile(const char* markerfile)
             fprintf(stderr, "      - The region was never started but stopped\n");
         }
         DEBUG_PRINT(DEBUGLEV_DEVELOP,
-                Creating Marker file %s with %d regions %d groups and %d threads,
+                "Creating Marker file %s with %d regions %d groups and %d threads",
                 markerfile, newNumberOfRegions, numberOfGroups, numberOfThreads);
         bstring thread_regs_grps = bformat("%d %d %d", numberOfThreads, newNumberOfRegions, numberOfGroups);
         fprintf(file,"%s\n", bdata(thread_regs_grps));
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, %s, bdata(thread_regs_grps));
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(thread_regs_grps));
         bdestroy(thread_regs_grps);
 
         for (int i=0; i<numberOfRegions; i++)
@@ -606,7 +606,7 @@ likwid_markerWriteFile(const char* markerfile)
                 continue;
             bstring tmp = bformat("%d:%s", newRegionID, perfmon_getTagOfRegion(i));
             fprintf(file,"%s\n", bdata(tmp));
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, %s, bdata(tmp));
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(tmp));
             bdestroy(tmp);
             newRegionID++;
         }
@@ -644,7 +644,7 @@ likwid_markerWriteFile(const char* markerfile)
                     bdestroy(tmp);
                 }
                 fprintf(file,"%s\n", bdata(l));
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, %s, bdata(l));
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s", bdata(l));
                 bdestroy(l);
             }
             newRegionID++;
@@ -722,7 +722,7 @@ likwid_markerStartRegion(const char* regionTag)
     {
         if (groupSet->groups[groupSet->activeGroup].events[i].type != NOTYPE)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, START [%s] READ EVENT [%d=%d] EVENT %d VALUE %llu,
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "START [%s] READ EVENT [%d=%d] EVENT %d VALUE %llu",
                     regionTag, thread_id, cpu_id, i,
                     LLU_CAST groupSet->groups[groupSet->activeGroup].events[i].threadCounter[thread_id].counterData);
             //groupSet->groups[groupSet->activeGroup].events[i].threadCounter[thread_id].startData =
@@ -805,7 +805,7 @@ likwid_markerStopRegion(const char* regionTag)
                                             groupSet->groups[groupSet->activeGroup].events[i].threadCounter[thread_id].counterData,
                                             groupSet->groups[groupSet->activeGroup].events[i].threadCounter[thread_id].overflows -
                                             results->StartOverflows[i]);
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, STOP [%s] READ EVENT [%d=%d] EVENT %d VALUE %llu DIFF %f, regionTag, thread_id, cpu_id, i,
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "STOP [%s] READ EVENT [%d=%d] EVENT %d VALUE %llu DIFF %f", regionTag, thread_id, cpu_id, i,
                             LLU_CAST groupSet->groups[groupSet->activeGroup].events[i].threadCounter[thread_id].counterData, result);
             if ((counter_map[groupSet->groups[groupSet->activeGroup].events[i].index].type != THERMAL) &&
                 (counter_map[groupSet->groups[groupSet->activeGroup].events[i].index].type != VOLTAGE) &&

--- a/src/likwid_device.c
+++ b/src/likwid_device.c
@@ -347,7 +347,7 @@ int likwid_device_create(LikwidDeviceType type, int id, LikwidDevice_t* device)
             return device_create_amdgpu_by_index(id, device);
 #endif
         default:
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Unimplemented device type: %d, type);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Unimplemented device type: %d", type);
             break;
     }
     return -ENODEV;
@@ -385,7 +385,7 @@ int likwid_device_create_from_string(LikwidDeviceType type, const char *id, Likw
 
         if (type == DEVICE_TYPE_INVALID)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Cannot create device from string type: %s, type_token);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Cannot create device from string type: %s", type_token);
             err = -EINVAL;
             goto cleanup;
         }
@@ -424,7 +424,7 @@ int likwid_device_create_from_string(LikwidDeviceType type, const char *id, Likw
 #endif
             default:
                 err = -EINVAL;
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Unable to use PCI address to create device type: %d, type);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Unable to use PCI address to create device type: %d", type);
                 break;
         }
     }
@@ -463,7 +463,7 @@ int likwid_device_create_from_string(LikwidDeviceType type, const char *id, Likw
 #endif
             default:
                 err = -EPERM;
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Unimplemented device type: %d, type);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Unimplemented device type: %d", type);
                 break;
         }
     }
@@ -474,7 +474,7 @@ int likwid_device_create_from_string(LikwidDeviceType type, const char *id, Likw
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Unable to parse '%s' as valid PCI address or integer, id_token);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Unable to parse '%s' as valid PCI address or integer", id_token);
         err = -EINVAL;
     }
 
@@ -553,7 +553,7 @@ static bool device_in_cpuset(LikwidDeviceType type, size_t id)
             case DEVICE_TYPE_NODE:
                 return true;
             default:
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Unimplemented device type: %d, type);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Unimplemented device type: %d", type);
                 return false;
         }
     }
@@ -614,7 +614,7 @@ static int likwid_device_get_list(LikwidDeviceType type, char ***id_list, size_t
             break;
 #endif
         default:
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Unimplemented device type: %d, type);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Unimplemented device type: %d", type);
             return -EINVAL;
     }
 

--- a/src/memsweep.c
+++ b/src/memsweep.c
@@ -105,7 +105,7 @@ cleanupCache(char* ptr)
         printf("Cleaning LLC with %g MB\n", (double)cachesize/(1024.0 * 1024.0));
     _loadData(cachesize,ptr);
 #else
-    ERROR_PLAIN_PRINT(Cleanup cache is currently only available on X86 systems.);
+    ERROR_PLAIN_PRINT("Cleanup cache is currently only available on X86 systems.");
 #endif
 }
 

--- a/src/memsweep.c
+++ b/src/memsweep.c
@@ -105,7 +105,7 @@ cleanupCache(char* ptr)
         printf("Cleaning LLC with %g MB\n", (double)cachesize/(1024.0 * 1024.0));
     _loadData(cachesize,ptr);
 #else
-    ERROR_PLAIN_PRINT("Cleanup cache is currently only available on X86 systems.");
+    ERROR_PRINT("Cleanup cache is currently only available on X86 systems.");
 #endif
 }
 

--- a/src/numa_proc.c
+++ b/src/numa_proc.c
@@ -248,7 +248,7 @@ nodeProcessorList(int node, uint32_t** list)
 
             if (endptr == (char*) tokens->entry[i]->data)
             {
-                ERROR_PLAIN_PRINT(No digits were found);
+                ERROR_PLAIN_PRINT("No digits were found");
                 return -EFAULT;
             }
 
@@ -264,7 +264,7 @@ nodeProcessorList(int node, uint32_t** list)
                         }
                         else
                         {
-                            ERROR_PRINT(Number Of threads %d too large for NUMA node %d, count, node);
+                            ERROR_PRINT("Number Of threads %d too large for NUMA node %d", count, node);
                             return -EFAULT;
                         }
                         count++;
@@ -319,7 +319,7 @@ nodeDistanceList(int node, int numberOfNodes, uint32_t** list)
             }
             else
             {
-                ERROR_PRINT(Number Of nodes %d too large,count);
+                ERROR_PRINT("Number Of nodes %d too large", count);
                 return -EFAULT;
             }
             count++;

--- a/src/numa_proc.c
+++ b/src/numa_proc.c
@@ -248,7 +248,7 @@ nodeProcessorList(int node, uint32_t** list)
 
             if (endptr == (char*) tokens->entry[i]->data)
             {
-                ERROR_PLAIN_PRINT("No digits were found");
+                ERROR_PRINT("No digits were found");
                 return -EFAULT;
             }
 

--- a/src/nvmon.c
+++ b/src/nvmon.c
@@ -93,13 +93,13 @@ nvmon_init(int nrGpus, const int* gpuIds)
 
     if (nrGpus <= 0)
     {
-        ERROR_PRINT(Number of gpus must be greater than 0 but only %d given, nrGpus);
+        ERROR_PRINT("Number of gpus must be greater than 0 but only %d given", nrGpus);
         return -EINVAL;
     }
 
     // if (!lock_check())
     // {
-    //     ERROR_PLAIN_PRINT(Access to performance monitoring locked);
+    //     ERROR_PLAIN_PRINT("Access to performance monitoring locked");
     //     return -EINVAL;
     // }
 
@@ -120,13 +120,13 @@ nvmon_init(int nrGpus, const int* gpuIds)
     nvGroupSet = calloc(1, sizeof(NvmonGroupSet));
     if (nvGroupSet == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate group descriptor);
+        ERROR_PLAIN_PRINT("Cannot allocate group descriptor");
         return -ENOMEM;
     }
     nvGroupSet->gpus = (NvmonDevice*) malloc(nrGpus * sizeof(NvmonDevice));
     if (nvGroupSet->gpus == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate set of GPUs);
+        ERROR_PLAIN_PRINT("Cannot allocate set of GPUs");
         free(nvGroupSet);
         nvGroupSet = NULL;
         return -ENOMEM;
@@ -165,7 +165,7 @@ nvmon_init(int nrGpus, const int* gpuIds)
         }
         if (!available)
         {
-            ERROR_PRINT(No device with ID %d, gpuIds[i]);
+            ERROR_PRINT("No device with ID %d", gpuIds[i]);
             free(nvGroupSet->gpus);
             free(nvGroupSet);
             nvGroupSet = NULL;
@@ -174,13 +174,13 @@ nvmon_init(int nrGpus, const int* gpuIds)
         NvmonDevice_t device = &nvGroupSet->gpus[i];
         if (gtopo->devices[gpuIds[i]].ccapMajor < 7)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Device %d runs with CUPTI Event API backend, gpuIds[i]);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Device %d runs with CUPTI Event API backend", gpuIds[i]);
             device->backend = LIKWID_NVMON_CUPTI_BACKEND;
             cputicount++;
         }
         else
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Device %d runs with CUPTI Profiling API backend, gpuIds[i]);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Device %d runs with CUPTI Profiling API backend", gpuIds[i]);
             device->backend = LIKWID_NVMON_PERFWORKS_BACKEND;
             perfworkscount++;
         }
@@ -190,7 +190,7 @@ nvmon_init(int nrGpus, const int* gpuIds)
         device->timeRead = 0;
         if (cputicount > 0 && perfworkscount > 0)
         {
-            ERROR_PRINT(Cannot use GPUs with different backends in a session, gpuIds[i]);
+            ERROR_PRINT("Cannot use GPUs with different backends in a session", gpuIds[i]);
             free(nvGroupSet->gpus);
             free(nvGroupSet);
             nvGroupSet = NULL;
@@ -203,7 +203,7 @@ nvmon_init(int nrGpus, const int* gpuIds)
             ret = funcs->createDevice(device->deviceId, device);
             if (ret < 0)
             {
-                ERROR_PRINT(Cannot create device %d (error: %d), device->deviceId, ret);
+                ERROR_PRINT("Cannot create device %d (error: %d)", device->deviceId, ret);
                 free(nvGroupSet->gpus);
                 free(nvGroupSet);
                 nvGroupSet = NULL;
@@ -352,7 +352,7 @@ nvmon_getEventsOfGpu(int gpuId, NvmonEventList_t* list)
     err = concatNvmonEventLists(*list, nvmlList);
     if (err < 0)
     {
-        ERROR_PLAIN_PRINT(Failed to concatenate event lists);
+        ERROR_PLAIN_PRINT("Failed to concatenate event lists");
         nvmon_returnEventsOfGpu(*list);
         nvml_returnEventsOfGpu(nvmlList);
         *list = NULL;
@@ -405,7 +405,7 @@ nvmon_splitEventSet(GroupInfo* backendEvents, GroupInfo* nvmlEvents, int gid)
             ret = perfgroup_addEvent(nvmlEvents, info->counters[i], info->events[i]);
             if (ret < 0)
             {
-                ERROR_PRINT(Failed to add event while splitting);
+                ERROR_PRINT("Failed to add event while splitting");
                 return ret;
             }
         }
@@ -414,7 +414,7 @@ nvmon_splitEventSet(GroupInfo* backendEvents, GroupInfo* nvmlEvents, int gid)
             ret = perfgroup_addEvent(backendEvents, info->counters[i], info->events[i]);
             if (ret < 0)
             {
-                ERROR_PRINT(Failed to add event while splitting);
+                ERROR_PRINT("Failed to add event while splitting");
                 return ret;
             }
         }
@@ -450,20 +450,20 @@ nvmon_initEventSourceLookupMaps(int gid, int gpuId)
         int* tmpSourceTypes = (int*) malloc(group->nevents * sizeof(int));
         if (tmpSourceTypes == NULL)
         {
-            ERROR_PLAIN_PRINT(Failed to allocate source type map);
+            ERROR_PLAIN_PRINT("Failed to allocate source type map");
             return -ENOMEM;
         }
         int* tmpSourceIds = (int*) malloc(group->nevents * sizeof(int));
         if (tmpSourceIds == NULL)
         {
-            ERROR_PLAIN_PRINT(Failed to allocate source id map);
+            ERROR_PLAIN_PRINT("Failed to allocate source id map");
             free(tmpSourceTypes);
             return -ENOMEM;
         }
         NvmonGroupSourceInfo* tmpInfo = (NvmonGroupSourceInfo*) realloc(nvGroupSet->groupSources, (gid+1) * sizeof(NvmonGroupSourceInfo));
         if (tmpInfo == NULL)
         {
-            ERROR_PLAIN_PRINT(Failed to allocate source infos);
+            ERROR_PLAIN_PRINT("Failed to allocate source infos");
             free(tmpSourceTypes);
             free(tmpSourceIds);
             return -ENOMEM;
@@ -542,25 +542,25 @@ nvmon_addEventSet(const char* eventCString)
         GroupInfo* tmpInfo = (GroupInfo*)realloc(nvGroupSet->groups, (nvGroupSet->numberOfGroups+1)*sizeof(GroupInfo));
         if (tmpInfo == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate additional group);
+            ERROR_PLAIN_PRINT("Cannot allocate additional group");
             return -ENOMEM;
         }
         nvGroupSet->groups = tmpInfo;
         nvGroupSet->numberOfGroups++;
-        GPUDEBUG_PRINT(DEBUGLEV_INFO, Allocating new group structure for group.);
+        GPUDEBUG_PRINT(DEBUGLEV_INFO, "Allocating new group structure for group.");
     }
-    GPUDEBUG_PRINT(DEBUGLEV_INFO, NVMON: Currently %d groups of %d active,
+    GPUDEBUG_PRINT(DEBUGLEV_INFO, "NVMON: Currently %d groups of %d active",
                                         nvGroupSet->numberOfActiveGroups+1,
                                         nvGroupSet->numberOfGroups+1);
 
     bstring eventBString = bfromcstr(eventCString);
     if (bstrchrp(eventBString, ':', 0) != BSTR_ERR)
     {
-        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Custom eventset);
+        GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Custom eventset");
         err = perfgroup_customGroup(eventCString, &nvGroupSet->groups[nvGroupSet->numberOfGroups-1]);
         if (err)
         {
-            ERROR_PRINT(Cannot transform %s to performance group, eventCString);
+            ERROR_PRINT("Cannot transform %s to performance group", eventCString);
             return err;
         }
     }
@@ -582,34 +582,34 @@ nvmon_addEventSet(const char* eventCString)
         }
         if (cputicount > 0 && perfworkscount > 0)
         {
-            ERROR_PRINT(GPUs with compute capability <7 and >= 7 are not allowed);
+            ERROR_PRINT("GPUs with compute capability <7 and >= 7 are not allowed");
             return -ENODEV;
         }
         if (cputicount > 0)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Performance group for CUPTI backend);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Performance group for CUPTI backend");
             err = perfgroup_readGroup(config->groupPath, "nvidia_gpu_cc_lt_7", eventCString,
                                       &nvGroupSet->groups[nvGroupSet->numberOfGroups-1]);
         }
         else if (perfworkscount > 0)
         {
-            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Performance group for PerfWorks backend);
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Performance group for PerfWorks backend");
             err = perfgroup_readGroup(config->groupPath, "nvidia_gpu_cc_ge_7", eventCString,
                                       &nvGroupSet->groups[nvGroupSet->numberOfGroups-1]);
         }
         if (err == -EACCES)
         {
-            ERROR_PRINT(Access to performance group %s not allowed, eventCString);
+            ERROR_PRINT("Access to performance group %s not allowed", eventCString);
             return err;
         }
         else if (err == -ENODEV)
         {
-            ERROR_PRINT(Performance group %s only available with deactivated HyperThreading, eventCString);
+            ERROR_PRINT("Performance group %s only available with deactivated HyperThreading", eventCString);
             return err;
         }
         else if (err < 0)
         {
-            ERROR_PRINT(Cannot read performance group %s, eventCString);
+            ERROR_PRINT("Cannot read performance group %s", eventCString);
             return err;
         }
     }
@@ -618,7 +618,7 @@ nvmon_addEventSet(const char* eventCString)
     err = nvmon_initEventSourceLookupMaps(nvGroupSet->numberOfGroups - 1, nvGroupSet->gpus[0].deviceId); // it is assumed that all gpus split the same
     if (err < 0)
     {
-        ERROR_PRINT(Failed to init source lookup for group %d, nvGroupSet->numberOfGroups - 1);
+        ERROR_PRINT("Failed to init source lookup for group %d", nvGroupSet->numberOfGroups - 1);
         return err;
     }
 
@@ -628,7 +628,7 @@ nvmon_addEventSet(const char* eventCString)
     err = nvmon_splitEventSet(&backendEvents, &nvmlEvents, nvGroupSet->numberOfGroups-1);
     if (err < 0)
     {
-        ERROR_PRINT(Failed to split events);
+        ERROR_PRINT("Failed to split events");
         return -1;
     }
 
@@ -636,14 +636,14 @@ nvmon_addEventSet(const char* eventCString)
     err = nvml_addEventSet(nvmlEvents.events, nvmlEvents.nevents);
     if (err < 0)
     {
-        ERROR_PRINT(Failed to add nvml events);
+        ERROR_PRINT("Failed to add nvml events");
         return -1;
     }
 
     bdestroy(eventBString);
     char * evstr = perfgroup_getEventStr(&backendEvents);
 /*    eventBString = bfromcstr(evstr);*/
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, EventStr %s, evstr);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "EventStr %s", evstr);
 /*    eventtokens = bsplit(eventBString, ',');*/
 /*    bdestroy(eventBString);*/
 
@@ -657,16 +657,16 @@ nvmon_addEventSet(const char* eventCString)
             NvmonFunctions* funcs = nvGroupSet->backends[device->backend];
             if (!funcs)
             {
-                ERROR_PRINT(Backend functions undefined?);
+                ERROR_PRINT("Backend functions undefined?");
             }
             if (funcs->addEvents)
             {
-                GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Calling addevents);
+                GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Calling addevents");
                 err = funcs->addEvents(device, evstr);
                 if (err < 0)
                 {
                     errno = -err;
-                    ERROR_PRINT(Failed to add event set for GPU %d, devId);
+                    ERROR_PRINT("Failed to add event set for GPU %d", devId);
                     return err;
                 }
             }
@@ -677,7 +677,7 @@ nvmon_addEventSet(const char* eventCString)
             NvmonEventSet* tmpEventSet = realloc(device->nvEventSets, (device->numNvEventSets+1)*sizeof(NvmonEventSet));
             if (!tmpEventSet)
             {
-                ERROR_PRINT(Cannot enlarge GPU %d eventSet list, device->deviceId);
+                ERROR_PRINT("Cannot enlarge GPU %d eventSet list", device->deviceId);
                 return -ENOMEM;
             }
             device->nvEventSets = tmpEventSet;
@@ -1164,7 +1164,7 @@ double nvmon_getMetric(int groupId, int metricId, int gpuId)
     }
     if (nvmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return NAN;
     }
     if (nvGroupSet->numberOfActiveGroups == 0)
@@ -1227,7 +1227,7 @@ double nvmon_getLastMetric(int groupId, int metricId, int gpuId)
     }
     if (nvmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return NAN;
     }
     if (nvGroupSet->numberOfActiveGroups == 0)
@@ -1481,7 +1481,7 @@ nvmon_getCountOfRegion(int region, int gpu)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1504,7 +1504,7 @@ nvmon_getTimeOfRegion(int region, int gpu)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1528,7 +1528,7 @@ nvmon_getGpulistOfRegion(int region, int count, int* gpulist)
     int i;
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1551,7 +1551,7 @@ nvmon_getGpusOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1566,7 +1566,7 @@ nvmon_getMetricsOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1581,7 +1581,7 @@ nvmon_getNumberOfRegions()
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     return gMarkerRegions;
@@ -1592,7 +1592,7 @@ nvmon_getGroupOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1607,7 +1607,7 @@ nvmon_getTagOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return NULL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1622,7 +1622,7 @@ nvmon_getEventsOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1636,7 +1636,7 @@ double nvmon_getResultOfRegionGpu(int region, int eventId, int gpuId)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1665,7 +1665,7 @@ double nvmon_getMetricOfRegionGpu(int region, int metricId, int gpuId)
     CounterList clist;
     if (nvmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Nvmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
         return NAN;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1702,7 +1702,7 @@ double nvmon_getMetricOfRegionGpu(int region, int metricId, int gpuId)
     err = calc_metric(f, &clist, &result);
     if (err < 0)
     {
-        ERROR_PRINT(Cannot calculate formula %s, f);
+        ERROR_PRINT("Cannot calculate formula %s", f);
         return NAN;
     }
     destroy_clist(&clist);

--- a/src/nvmon.c
+++ b/src/nvmon.c
@@ -99,7 +99,7 @@ nvmon_init(int nrGpus, const int* gpuIds)
 
     // if (!lock_check())
     // {
-    //     ERROR_PLAIN_PRINT("Access to performance monitoring locked");
+    //     ERROR_PRINT("Access to performance monitoring locked");
     //     return -EINVAL;
     // }
 
@@ -120,13 +120,13 @@ nvmon_init(int nrGpus, const int* gpuIds)
     nvGroupSet = calloc(1, sizeof(NvmonGroupSet));
     if (nvGroupSet == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate group descriptor");
+        ERROR_PRINT("Cannot allocate group descriptor");
         return -ENOMEM;
     }
     nvGroupSet->gpus = (NvmonDevice*) malloc(nrGpus * sizeof(NvmonDevice));
     if (nvGroupSet->gpus == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate set of GPUs");
+        ERROR_PRINT("Cannot allocate set of GPUs");
         free(nvGroupSet);
         nvGroupSet = NULL;
         return -ENOMEM;
@@ -352,7 +352,7 @@ nvmon_getEventsOfGpu(int gpuId, NvmonEventList_t* list)
     err = concatNvmonEventLists(*list, nvmlList);
     if (err < 0)
     {
-        ERROR_PLAIN_PRINT("Failed to concatenate event lists");
+        ERROR_PRINT("Failed to concatenate event lists");
         nvmon_returnEventsOfGpu(*list);
         nvml_returnEventsOfGpu(nvmlList);
         *list = NULL;
@@ -450,20 +450,20 @@ nvmon_initEventSourceLookupMaps(int gid, int gpuId)
         int* tmpSourceTypes = (int*) malloc(group->nevents * sizeof(int));
         if (tmpSourceTypes == NULL)
         {
-            ERROR_PLAIN_PRINT("Failed to allocate source type map");
+            ERROR_PRINT("Failed to allocate source type map");
             return -ENOMEM;
         }
         int* tmpSourceIds = (int*) malloc(group->nevents * sizeof(int));
         if (tmpSourceIds == NULL)
         {
-            ERROR_PLAIN_PRINT("Failed to allocate source id map");
+            ERROR_PRINT("Failed to allocate source id map");
             free(tmpSourceTypes);
             return -ENOMEM;
         }
         NvmonGroupSourceInfo* tmpInfo = (NvmonGroupSourceInfo*) realloc(nvGroupSet->groupSources, (gid+1) * sizeof(NvmonGroupSourceInfo));
         if (tmpInfo == NULL)
         {
-            ERROR_PLAIN_PRINT("Failed to allocate source infos");
+            ERROR_PRINT("Failed to allocate source infos");
             free(tmpSourceTypes);
             free(tmpSourceIds);
             return -ENOMEM;
@@ -542,7 +542,7 @@ nvmon_addEventSet(const char* eventCString)
         GroupInfo* tmpInfo = (GroupInfo*)realloc(nvGroupSet->groups, (nvGroupSet->numberOfGroups+1)*sizeof(GroupInfo));
         if (tmpInfo == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate additional group");
+            ERROR_PRINT("Cannot allocate additional group");
             return -ENOMEM;
         }
         nvGroupSet->groups = tmpInfo;
@@ -1164,7 +1164,7 @@ double nvmon_getMetric(int groupId, int metricId, int gpuId)
     }
     if (nvmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return NAN;
     }
     if (nvGroupSet->numberOfActiveGroups == 0)
@@ -1227,7 +1227,7 @@ double nvmon_getLastMetric(int groupId, int metricId, int gpuId)
     }
     if (nvmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return NAN;
     }
     if (nvGroupSet->numberOfActiveGroups == 0)
@@ -1481,7 +1481,7 @@ nvmon_getCountOfRegion(int region, int gpu)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1504,7 +1504,7 @@ nvmon_getTimeOfRegion(int region, int gpu)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1528,7 +1528,7 @@ nvmon_getGpulistOfRegion(int region, int count, int* gpulist)
     int i;
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1551,7 +1551,7 @@ nvmon_getGpusOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1566,7 +1566,7 @@ nvmon_getMetricsOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1581,7 +1581,7 @@ nvmon_getNumberOfRegions()
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     return gMarkerRegions;
@@ -1592,7 +1592,7 @@ nvmon_getGroupOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1607,7 +1607,7 @@ nvmon_getTagOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return NULL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1622,7 +1622,7 @@ nvmon_getEventsOfRegion(int region)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1636,7 +1636,7 @@ double nvmon_getResultOfRegionGpu(int region, int eventId, int gpuId)
 {
     if (gMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= gMarkerRegions)
@@ -1665,7 +1665,7 @@ double nvmon_getMetricOfRegionGpu(int region, int metricId, int gpuId)
     CounterList clist;
     if (nvmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Nvmon module not properly initialized");
+        ERROR_PRINT("Nvmon module not properly initialized");
         return NAN;
     }
     if (region < 0 || region >= gMarkerRegions)

--- a/src/nvmon_nvml.c
+++ b/src/nvmon_nvml.c
@@ -935,7 +935,7 @@ nvml_init()
     ret = _nvml_linkLibraries();
     if (ret < 0)
     {
-        ERROR_PLAIN_PRINT("Failed to link libraries");
+        ERROR_PRINT("Failed to link libraries");
         return -1;
     }
 
@@ -944,7 +944,7 @@ nvml_init()
     nvmlContext.devices = (NvmlDevice*) malloc(nvmlContext.numDevices * sizeof(NvmlDevice));
     if (nvmlContext.devices == NULL)
     {   
-        ERROR_PLAIN_PRINT("Cannot allocate NVML device structures");
+        ERROR_PRINT("Cannot allocate NVML device structures");
         return -ENOMEM;
     }
 
@@ -1005,20 +1005,20 @@ nvml_addEventSet(char** events, int numEvents)
         NvmlEvent* tmpEvents = (NvmlEvent*) malloc(numEvents * sizeof(NvmlEvent));
         if (tmpEvents == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate events for new event set");
+            ERROR_PRINT("Cannot allocate events for new event set");
             return -ENOMEM;
         }
         NvmlEventResult* tmpResults = (NvmlEventResult*) malloc(numEvents * sizeof(NvmlEventResult));
         if (tmpResults == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate event results");
+            ERROR_PRINT("Cannot allocate event results");
             free(tmpEvents);
             return -ENOMEM;
         }
         NvmlEventSet* tmpEventSets = (NvmlEventSet*) realloc(device->eventSets, (device->numEventSets+1) * sizeof(NvmlEventSet));
         if (tmpEventSets == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate new event set");
+            ERROR_PRINT("Cannot allocate new event set");
             free(tmpEvents);
             free(tmpResults);
             return -ENOMEM;
@@ -1100,13 +1100,13 @@ nvml_getEventsOfGpu(int gpuId, NvmonEventList_t* output)
     NvmonEventListEntry* entries = (NvmonEventListEntry*) malloc(device->numAllEvents * sizeof(NvmonEventListEntry));
     if (entries == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate event list entries");
+        ERROR_PRINT("Cannot allocate event list entries");
         return -ENOMEM;
     }
     NvmonEventList* list = (NvmonEventList*) malloc(sizeof(NvmonEventList));
     if (list == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate event list");
+        ERROR_PRINT("Cannot allocate event list");
         free(entries);
         return -ENOMEM;
     }

--- a/src/nvmon_nvml.c
+++ b/src/nvmon_nvml.c
@@ -395,7 +395,7 @@ static int
 _nvml_linkLibraries()
 {
     // Load NVML libary and link functions
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Init NVML Libaries);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Init NVML Libaries");
     dl_nvml = dlopen("libnvidia-ml.so", RTLD_NOW | RTLD_GLOBAL);
     if (!dl_nvml)
         dl_nvml = dlopen("libnvidia-ml.so.1", RTLD_NOW | RTLD_GLOBAL);
@@ -425,7 +425,7 @@ _nvml_linkLibraries()
     DLSYM_AND_CHECK(dl_nvml, nvmlDeviceGetUtilizationRates);
 
     // Load CUPTI library and link functions
-    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, Init NVML Libaries);
+    GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Init NVML Libaries");
     dl_cupti = dlopen("libcupti.so", RTLD_NOW | RTLD_GLOBAL);
     if (!dl_cupti || dlerror() != NULL)
     {
@@ -821,7 +821,7 @@ _nvml_createDevice(int idx, NvmlDevice* device)
 
     // Get NVML device handle
     NVML_CALL(nvmlDeviceGetHandleByIndex_v2, (device->nvDevice->deviceId, &device->nvmlDevice), {
-        ERROR_PRINT(Failed to get device handle for GPU %d, device->nvDevice->deviceId);
+        ERROR_PRINT("Failed to get device handle for GPU %d", device->nvDevice->deviceId);
         return -1;
     });
 
@@ -832,7 +832,7 @@ _nvml_createDevice(int idx, NvmlDevice* device)
     device->allEvents = (NvmlEvent*) malloc(device->numAllEvents * sizeof(NvmlEvent));
     if (device->allEvents == NULL)
     {
-        ERROR_PRINT(Failed to allocate memory for event list of GPU %d, device->nvDevice->deviceId);
+        ERROR_PRINT("Failed to allocate memory for event list of GPU %d", device->nvDevice->deviceId);
         return -ENOMEM;
     }
 
@@ -935,7 +935,7 @@ nvml_init()
     ret = _nvml_linkLibraries();
     if (ret < 0)
     {
-        ERROR_PLAIN_PRINT(Failed to link libraries);
+        ERROR_PLAIN_PRINT("Failed to link libraries");
         return -1;
     }
 
@@ -944,7 +944,7 @@ nvml_init()
     nvmlContext.devices = (NvmlDevice*) malloc(nvmlContext.numDevices * sizeof(NvmlDevice));
     if (nvmlContext.devices == NULL)
     {   
-        ERROR_PLAIN_PRINT(Cannot allocate NVML device structures);
+        ERROR_PLAIN_PRINT("Cannot allocate NVML device structures");
         return -ENOMEM;
     }
 
@@ -958,7 +958,7 @@ nvml_init()
         ret = _nvml_createDevice(i, device);
         if (ret < 0)
         {
-            ERROR_PRINT(Failed to create device #%d, i);
+            ERROR_PRINT("Failed to create device #%d", i);
             return ret;
         }
     }
@@ -1005,20 +1005,20 @@ nvml_addEventSet(char** events, int numEvents)
         NvmlEvent* tmpEvents = (NvmlEvent*) malloc(numEvents * sizeof(NvmlEvent));
         if (tmpEvents == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate events for new event set);
+            ERROR_PLAIN_PRINT("Cannot allocate events for new event set");
             return -ENOMEM;
         }
         NvmlEventResult* tmpResults = (NvmlEventResult*) malloc(numEvents * sizeof(NvmlEventResult));
         if (tmpResults == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate event results);
+            ERROR_PLAIN_PRINT("Cannot allocate event results");
             free(tmpEvents);
             return -ENOMEM;
         }
         NvmlEventSet* tmpEventSets = (NvmlEventSet*) realloc(device->eventSets, (device->numEventSets+1) * sizeof(NvmlEventSet));
         if (tmpEventSets == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate new event set);
+            ERROR_PLAIN_PRINT("Cannot allocate new event set");
             free(tmpEvents);
             free(tmpResults);
             return -ENOMEM;
@@ -1041,7 +1041,7 @@ nvml_addEventSet(char** events, int numEvents)
             // Check if event was found
             if (idx < 0)
             {
-                ERROR_PRINT(Could not find event %s, events[j]);
+                ERROR_PRINT("Could not find event %s", events[j]);
                 return -EINVAL;
             }
 
@@ -1100,13 +1100,13 @@ nvml_getEventsOfGpu(int gpuId, NvmonEventList_t* output)
     NvmonEventListEntry* entries = (NvmonEventListEntry*) malloc(device->numAllEvents * sizeof(NvmonEventListEntry));
     if (entries == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate event list entries);
+        ERROR_PLAIN_PRINT("Cannot allocate event list entries");
         return -ENOMEM;
     }
     NvmonEventList* list = (NvmonEventList*) malloc(sizeof(NvmonEventList));
     if (list == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate event list);
+        ERROR_PLAIN_PRINT("Cannot allocate event list");
         free(entries);
         return -ENOMEM;
     }

--- a/src/pci_proc.c
+++ b/src/pci_proc.c
@@ -124,7 +124,7 @@ static int getBusFromSocketByDevid(const uint32_t socket, uint16_t testDevice)
     }
     else
     {
-        ERROR_PLAIN_PRINT(Failed read file /proc/bus/pci/devices);
+        ERROR_PLAIN_PRINT("Failed read file /proc/bus/pci/devices");
     }
 
     while (cur_socket >= 0)

--- a/src/pci_proc.c
+++ b/src/pci_proc.c
@@ -124,7 +124,7 @@ static int getBusFromSocketByDevid(const uint32_t socket, uint16_t testDevice)
     }
     else
     {
-        ERROR_PLAIN_PRINT("Failed read file /proc/bus/pci/devices");
+        ERROR_PRINT("Failed read file /proc/bus/pci/devices");
     }
 
     while (cur_socket >= 0)

--- a/src/perfgroup.c
+++ b/src/perfgroup.c
@@ -628,7 +628,7 @@ int perfgroup_customGroup(const char* eventStr, GroupInfo* ginfo)
 #ifdef LIKWID_WITH_NVMON
     bstring gpu = bformat("GPU");
 #endif
-    DEBUG_PRINT(DEBUGLEV_INFO, Creating custom group for event string %s, eventStr);
+    DEBUG_PRINT(DEBUGLEV_INFO, "Creating custom group for event string %s", eventStr);
     ginfo->shortinfo = malloc(7 * sizeof(char));
     if (ginfo->shortinfo == NULL)
     {
@@ -854,10 +854,10 @@ perfgroup_readGroup(
 
     if (access(bdata(fullpath), R_OK))
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Cannot read group file %s. Trying %s, bdata(fullpath), bdata(homepath));
+        DEBUG_PRINT(DEBUGLEV_INFO, "Cannot read group file %s. Trying %s", bdata(fullpath), bdata(homepath));
         if (access(bdata(homepath), R_OK))
         {
-            ERROR_PRINT(Cannot read group file %s.txt. Searched in %s and %s, groupname, bdata(fullpath), bdata(homepath));
+            ERROR_PRINT("Cannot read group file %s.txt. Searched in %s and %s", groupname, bdata(fullpath), bdata(homepath));
             bdestroy(REQUIRE);
             bdestroy(fullpath);
             bdestroy(homepath);
@@ -870,7 +870,7 @@ perfgroup_readGroup(
         }
     }
 
-    DEBUG_PRINT(DEBUGLEV_INFO, Reading group %s from %s, groupname, bdata(fullpath));
+    DEBUG_PRINT(DEBUGLEV_INFO, "Reading group %s from %s", groupname, bdata(fullpath));
 
     ginfo->shortinfo = NULL;
     ginfo->nevents = 0;
@@ -1279,7 +1279,7 @@ perfgroup_addEvent(GroupInfo* ginfo, char* counter, char* event)
         return -ENOMEM;
     sprintf(ginfo->events[ginfo->nevents], "%s", event);
     sprintf(ginfo->counters[ginfo->nevents], "%s", counter);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Event %s:%s at pos %d, ginfo->events[ginfo->nevents], ginfo->counters[ginfo->nevents], ginfo->nevents);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Event %s:%s at pos %d", ginfo->events[ginfo->nevents], ginfo->counters[ginfo->nevents], ginfo->nevents);
     ginfo->nevents++;
     return 0;
 }
@@ -1292,7 +1292,7 @@ int perfgroup_removeEvent(GroupInfo* ginfo, char* counter)
     {
         if (strncmp(counter, ginfo->counters[i], strlen(ginfo->counters[i])) == 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Removing event %s:%s at pos %d, ginfo->events[i], ginfo->counters[i], i);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Removing event %s:%s at pos %d", ginfo->events[i], ginfo->counters[i], i);
             free(ginfo->events[i]);
             free(ginfo->counters[i]);
             for (int j = i+1; j < ginfo->nevents; j++)
@@ -1315,28 +1315,28 @@ perfgroup_addMetric(GroupInfo* ginfo, char* mname, char* mcalc)
     ginfo->metricnames = realloc(ginfo->metricnames, (ginfo->nmetrics + 1) * sizeof(char*));
     if (!ginfo->metricnames)
     {
-        ERROR_PRINT(Cannot increase space for metricnames to %d bytes, (ginfo->nmetrics + 1) * sizeof(char*));
+        ERROR_PRINT("Cannot increase space for metricnames to %d bytes", (ginfo->nmetrics + 1) * sizeof(char*));
         return -ENOMEM;
     }
     ginfo->metricformulas = realloc(ginfo->metricformulas, (ginfo->nmetrics + 1) * sizeof(char*));
     if (!ginfo->metricformulas)
     {
-        ERROR_PRINT(Cannot increase space for metricformulas to %d bytes, (ginfo->nmetrics + 1) * sizeof(char*));
+        ERROR_PRINT("Cannot increase space for metricformulas to %d bytes", (ginfo->nmetrics + 1) * sizeof(char*));
         return -ENOMEM;
     }
     ginfo->metricnames[ginfo->nmetrics] = malloc((strlen(mname) + 1) * sizeof(char));
     if (!ginfo->metricnames[ginfo->nmetrics])
     {
-        ERROR_PRINT(Cannot increase space for metricname to %d bytes, (strlen(mname) + 1) * sizeof(char));
+        ERROR_PRINT("Cannot increase space for metricname to %d bytes", (strlen(mname) + 1) * sizeof(char));
         return -ENOMEM;
     }
     ginfo->metricformulas[ginfo->nmetrics] = malloc((strlen(mcalc) + 1) * sizeof(char));
     if (!ginfo->metricformulas[ginfo->nmetrics])
     {
-        ERROR_PRINT(Cannot increase space for metricformula to %d bytes, (strlen(mcalc) + 1) * sizeof(char));
+        ERROR_PRINT("Cannot increase space for metricformula to %d bytes", (strlen(mcalc) + 1) * sizeof(char));
         return -ENOMEM;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Adding metric %s = %s, mname, mcalc);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding metric %s = %s", mname, mcalc);
     int ret = sprintf(ginfo->metricnames[ginfo->nmetrics], "%s", mname);
     if (ret > 0)
     {
@@ -1359,7 +1359,7 @@ int perfgroup_removeMetric(GroupInfo* ginfo, char* mname)
     {
         if (strncmp(mname, ginfo->metricnames[i], strlen(ginfo->metricnames[i])) == 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Removing metric %s at pos %d, ginfo->metricnames[i], i);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Removing metric %s at pos %d", ginfo->metricnames[i], i);
             free(ginfo->metricnames[i]);
             free(ginfo->metricformulas[i]);
             for (int j = i+1; j < ginfo->nmetrics; j++)
@@ -1407,10 +1407,10 @@ perfgroup_setGroupName(GroupInfo* ginfo, char* groupName)
     ginfo->groupname = realloc(ginfo->groupname, size * sizeof(char));
     if (ginfo->groupname == NULL)
     {
-        ERROR_PRINT(Cannot increase space for groupname to %d bytes, size * sizeof(char));
+        ERROR_PRINT("Cannot increase space for groupname to %d bytes", size * sizeof(char));
         return -ENOMEM;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Setting group name to %s, groupName);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Setting group name to %s", groupName);
     int ret = sprintf(ginfo->groupname, "%s", groupName);
     if (ret > 0)
     {
@@ -1548,12 +1548,12 @@ int perfgroup_mergeGroups(GroupInfo* grp1, GroupInfo* grp2)
             {
                 if (strncmp(grp1->events[i], grp2->events[j], strlen(grp1->events[i])) != 0)
                 {
-                    DEBUG_PRINT(DEBUGLEV_INFO, Cannot merge groups because counter %s is used for different events: %s and %s, grp1->counters[i], grp1->events[i], grp2->events[j]);
+                    DEBUG_PRINT(DEBUGLEV_INFO, "Cannot merge groups because counter %s is used for different events: %s and %s", grp1->counters[i], grp1->events[i], grp2->events[j]);
                     return -EFAULT;
                 }
                 else
                 {
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Counter %s used in both groups but measure the same event %s, grp1->counters[i], grp1->events[i]);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Counter %s used in both groups but measure the same event %s", grp1->counters[i], grp1->events[i]);
                 }
             }
         }
@@ -1575,7 +1575,7 @@ int perfgroup_mergeGroups(GroupInfo* grp1, GroupInfo* grp2)
             if (ret < 0)
             {
                 errno = -ret;
-                ERROR_PRINT(Cannot add event %s:%s, grp2->events[i], grp2->counters[i]);
+                ERROR_PRINT("Cannot add event %s:%s", grp2->events[i], grp2->counters[i]);
                 return ret;
             }
         }
@@ -1586,7 +1586,7 @@ int perfgroup_mergeGroups(GroupInfo* grp1, GroupInfo* grp2)
         if (ret < 0)
         {
             errno = -ret;
-            ERROR_PRINT(Cannot add metric %s, grp2->metricnames[i]);
+            ERROR_PRINT("Cannot add metric %s", grp2->metricnames[i]);
             return ret;
         }
     }

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -232,13 +232,13 @@ checkAccess(bstring reg, RegisterIndex index, RegisterType oldtype, int force)
     }
     if (type == NOTYPE)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, WARNING: Counter %s not available on the current system. Counter results defaults to 0.,bdata(reg));
+        DEBUG_PRINT(DEBUGLEV_INFO, "WARNING: Counter %s not available on the current system. Counter results defaults to 0.", bdata(reg));
         return NOTYPE;
     }
     checkName = bfromcstr(counter_map[index].key);
     if (bstrcmp(reg, checkName) != BSTR_OK)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, WARNING: Counter %s does not exist ,bdata(reg));
+        DEBUG_PRINT(DEBUGLEV_INFO, "WARNING: Counter %s does not exist", bdata(reg));
         bdestroy(checkName);
         return NOTYPE;
     }
@@ -246,7 +246,7 @@ checkAccess(bstring reg, RegisterIndex index, RegisterType oldtype, int force)
     err = HPMcheck(counter_map[index].device, 0);
     if (!err)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, WARNING: The device %s for counter %s does not exist, pci_device_names[counter_map[index].device], bdata(reg));
+        DEBUG_PRINT(DEBUGLEV_INFO, "WARNING: The device %s for counter %s does not exist", pci_device_names[counter_map[index].device], bdata(reg));
         return NOTYPE;
     }
     if ((type != THERMAL) && (type != VOLTAGE) && (type != POWER) && (type != WBOX0FIX))
@@ -263,12 +263,12 @@ checkAccess(bstring reg, RegisterIndex index, RegisterType oldtype, int force)
         {
             if (err == -ENODEV)
             {
-                DEBUG_PRINT(DEBUGLEV_DETAIL, Device %s not accessible on this machine,
+                DEBUG_PRINT(DEBUGLEV_DETAIL, "Device %s not accessible on this machine",
                                          pci_devices[box_map[type].device].name);
             }
             else
             {
-                DEBUG_PRINT(DEBUGLEV_DETAIL, Counter %s not readable on this machine,
+                DEBUG_PRINT(DEBUGLEV_DETAIL, "Counter %s not readable on this machine",
                                              counter_map[index].key);
             }
             type = NOTYPE;
@@ -280,12 +280,12 @@ checkAccess(bstring reg, RegisterIndex index, RegisterType oldtype, int force)
             {
                 if (err == -ENODEV)
                 {
-                    DEBUG_PRINT(DEBUGLEV_DETAIL, Device %s not accessible on this machine,
+                    DEBUG_PRINT(DEBUGLEV_DETAIL, "Device %s not accessible on this machine",
                                              pci_devices[box_map[type].device].name);
                 }
                 else
                 {
-                    DEBUG_PRINT(DEBUGLEV_DETAIL, Counter %s not writeable on this machine,
+                    DEBUG_PRINT(DEBUGLEV_DETAIL, "Counter %s not writeable on this machine",
                                              counter_map[index].key);
                 }
                 type = NOTYPE;
@@ -296,7 +296,7 @@ checkAccess(bstring reg, RegisterIndex index, RegisterType oldtype, int force)
         {
             if (force == 1 || groupSet->numberOfGroups > 1)
             {
-                DEBUG_PRINT(DEBUGLEV_DETAIL, Counter %s has bits set (0x%llx) but we are forced to overwrite them,
+                DEBUG_PRINT(DEBUGLEV_DETAIL, "Counter %s has bits set (0x%llx) but we are forced to overwrite them",
                                              counter_map[index].key, LLU_CAST tmp);
 /*                err = HPMwrite(testcpu, counter_map[index].device, reg, 0x0ULL);*/
 /*                for (int i = 0; i < groupSet->numberOfThreads; i++)*/
@@ -318,7 +318,7 @@ checkAccess(bstring reg, RegisterIndex index, RegisterType oldtype, int force)
         err = HPMread(testcpu, MSR_DEV, counter_map[index].counterRegister, &tmp);
         if (err != 0)
         {
-            DEBUG_PRINT(DEBUGLEV_DETAIL, Counter %s not readable on this machine,
+            DEBUG_PRINT(DEBUGLEV_DETAIL, "Counter %s not readable on this machine",
                                          counter_map[index].key);
             type = NOTYPE;
         }
@@ -606,7 +606,7 @@ parseOptions(struct bstrList* tokens, PerfmonEvent* event, RegisterIndex index)
         if (!(OPTIONS_TYPE_MASK(event->options[i].type) & (counter_map[index].optionMask|event->optionMask)))
 #endif
         {
-            DEBUG_PRINT(DEBUGLEV_INFO,Removing Option %s not valid for register %s,
+            DEBUG_PRINT(DEBUGLEV_INFO, "Removing Option %s not valid for register %s",
                         eventOptionTypeName[event->options[i].type],
                         counter_map[index].key);
             event->options[i].type = EVENT_OPTION_NONE;
@@ -635,7 +635,7 @@ parseOptions(struct bstrList* tokens, PerfmonEvent* event, RegisterIndex index)
             }
             else
             {
-                ERROR_PLAIN_PRINT(Cannot set threshold option to default. no more space in options list);
+                ERROR_PLAIN_PRINT("Cannot set threshold option to default. no more space in options list");
             }
         }
         else if (event->options[i].type == EVENT_OPTION_OCCUPANCY)
@@ -670,7 +670,7 @@ parseOptions(struct bstrList* tokens, PerfmonEvent* event, RegisterIndex index)
             }
             else
             {
-                ERROR_PLAIN_PRINT(Cannot set threshold option to default. no more space in options list);
+                ERROR_PLAIN_PRINT("Cannot set threshold option to default. no more space in options list");
             }
         }
     }
@@ -756,7 +756,7 @@ perfmon_check_counter_map(int cpu_id)
     int own_hpm = 0;
     if (perfmon_numCounters == 0 || perfmon_numArchEvents == 0)
     {
-        ERROR_PLAIN_PRINT(Counter and event maps not initialized.);
+        ERROR_PLAIN_PRINT("Counter and event maps not initialized.");
         return;
     }
 
@@ -765,7 +765,7 @@ perfmon_check_counter_map(int cpu_id)
 
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT(Access to performance monitoring registers locked);
+        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
         return;
     }
 #ifndef LIKWID_USE_PERFEVENT
@@ -774,13 +774,13 @@ perfmon_check_counter_map(int cpu_id)
         HPMinit();
         if (HPMaddThread(cpu_id) != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot check counters without access to performance counters)
+            ERROR_PLAIN_PRINT("Cannot check counters without access to performance counters");
             return;
         }
         own_hpm = 1;
     }
 #endif
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Checking %d counters, perfmon_numCounters);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Checking %d counters", perfmon_numCounters);
     int startpmcindex = -1;
     for (int i=0;i<perfmon_numCounters;i++)
     {
@@ -800,7 +800,7 @@ perfmon_check_counter_map(int cpu_id)
             counter_map[i].optionMask = 0x0ULL;
         }
 #ifndef LIKWID_USE_PERFEVENT
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Counter %s at pos %d with dev %s (%d), counter_map[i].key, i, pci_device_names[counter_map[i].device], counter_map[i].device, cpu_id);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Counter %s at pos %d with dev %s (%d)", counter_map[i].key, i, pci_device_names[counter_map[i].device], counter_map[i].device, cpu_id);
         if (HPMcheck(counter_map[i].device, cpu_id))
         {
             uint32_t reg = counter_map[i].configRegister;
@@ -826,7 +826,7 @@ perfmon_check_counter_map(int cpu_id)
         if (cpuid_info.vendor == APPLE_M1 && cpuid_info.model == APPLE_M1_STUDIO) {
             type = FPMC;
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Counter %s at pos %d with dev %s (%d): %s, counter_map[i].key, i, pci_device_names[counter_map[i].device], counter_map[i].device, translate_types[type]);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Counter %s at pos %d with dev %s (%d): %s", counter_map[i].key, i, pci_device_names[counter_map[i].device], counter_map[i].device, translate_types[type]);
         if (!translate_types[type])
         {
             counter_map[i].type = NOTYPE;
@@ -895,7 +895,7 @@ perfmon_check_counter_map(int cpu_id)
         bdestroy(estr);
         if (!found)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Cannot respect limit %s. Removing event %s, eventHash[i].limit, eventHash[i].name);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Cannot respect limit %s. Removing event %s", eventHash[i].limit, eventHash[i].name);
             eventHash[i].limit = "";
         }
     }
@@ -914,10 +914,10 @@ perfmon_init_maps(void)
         return 0;
     }
 #if defined(__x86_64__) || defined(__i386__) || defined(_ARCH_PPC)
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Initialize maps for family 0x%X model 0x%X stepping 0x%X, cpuid_info.family, cpuid_info.model, cpuid_info.stepping);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initialize maps for family 0x%X model 0x%X stepping 0x%X", cpuid_info.family, cpuid_info.model, cpuid_info.stepping);
 #endif
 #if defined(__ARM_ARCH_8A) || defined(__ARM_ARCH_7A__)
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Initialize maps for family 0x%X vendor 0x%X part 0x%X, cpuid_info.family, cpuid_info.family, cpuid_info.model);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initialize maps for family 0x%X vendor 0x%X part 0x%X", cpuid_info.family, cpuid_info.family, cpuid_info.model);
 #endif
     switch ( cpuid_info.family )
     {
@@ -976,7 +976,7 @@ perfmon_init_maps(void)
                     break;
 
                 case CORE_DUO:
-                    ERROR_PLAIN_PRINT(Unsupported Processor);
+                    ERROR_PLAIN_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
 
@@ -1248,7 +1248,7 @@ perfmon_init_maps(void)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported Intel Processor);
+                    ERROR_PLAIN_PRINT("Unsupported Intel Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1267,7 +1267,7 @@ perfmon_init_maps(void)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported Processor);
+                    ERROR_PLAIN_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1333,7 +1333,7 @@ perfmon_init_maps(void)
                     translate_types = zen2_translate_types;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported AMD Zen Processor);
+                    ERROR_PLAIN_PRINT("Unsupported AMD Zen Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1372,7 +1372,7 @@ perfmon_init_maps(void)
                     translate_types = zen4c_translate_types;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported AMD Zen Processor);
+                    ERROR_PLAIN_PRINT("Unsupported AMD Zen Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1398,7 +1398,7 @@ perfmon_init_maps(void)
                     perfmon_numCounters = NUM_COUNTERS_POWER9;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported PPC Processor);
+                    ERROR_PLAIN_PRINT("Unsupported PPC Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1441,7 +1441,7 @@ perfmon_init_maps(void)
                     }
                     break;
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported ARMv7 Processor);
+                    ERROR_PLAIN_PRINT("Unsupported ARMv7 Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1506,7 +1506,7 @@ perfmon_init_maps(void)
                             translate_types = nvidiagrace_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT(Unsupported ARMv8 Processor);
+                            ERROR_PLAIN_PRINT("Unsupported ARMv8 Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1523,7 +1523,7 @@ perfmon_init_maps(void)
                             translate_types = cav_tx2_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT(Unsupported Cavium/Marvell Processor);
+                            ERROR_PLAIN_PRINT("Unsupported Cavium/Marvell Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1540,7 +1540,7 @@ perfmon_init_maps(void)
                             translate_types = cav_tx2_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT(Unsupported Cavium/Marvell Processor);
+                            ERROR_PLAIN_PRINT("Unsupported Cavium/Marvell Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1557,7 +1557,7 @@ perfmon_init_maps(void)
                             translate_types = a64fx_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT(Unsupported Fujitsu Processor);
+                            ERROR_PLAIN_PRINT("Unsupported Fujitsu Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1574,7 +1574,7 @@ perfmon_init_maps(void)
                             translate_types = tsv110_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT(Unsupported Huawei Processor);
+                            ERROR_PLAIN_PRINT("Unsupported Huawei Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1592,20 +1592,20 @@ perfmon_init_maps(void)
                              translate_types = applem1_translate_types;
                              break;
                          default:
-                             ERROR_PLAIN_PRINT(Unsupported Apple Processor);
+                             ERROR_PLAIN_PRINT("Unsupported Apple Processor");
                              err = -EINVAL;
                              break;
                     }
                     break;
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported ARMv8 Processor);
+                    ERROR_PLAIN_PRINT("Unsupported ARMv8 Processor");
                     err = -EINVAL;
                     break;
             }
             break;
 
         default:
-            ERROR_PLAIN_PRINT(Unsupported Processor);
+            ERROR_PLAIN_PRINT("Unsupported Processor");
             err = -EINVAL;
             break;
     }
@@ -1614,11 +1614,11 @@ perfmon_init_maps(void)
     {
         int cpu_id = sched_getcpu();
         HPMaddThread(cpu_id);
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Adding GENERIC_EVENT);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding GENERIC_EVENT");
         PerfmonEvent* tmp = malloc((perfmon_numArchEvents+10)*sizeof(PerfmonEvent));
         if (tmp)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Copying %d events from input list, perfmon_numArchEvents);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Copying %d events from input list", perfmon_numArchEvents);
             memcpy(tmp, eventHash, perfmon_numArchEvents*sizeof(PerfmonEvent));
             memset(tmp + perfmon_numArchEvents, '\0', 10*sizeof(PerfmonEvent));
             eventHash = tmp;
@@ -1647,7 +1647,7 @@ perfmon_init_maps(void)
                             bstring bkey = bfromcstr(counter_map[k].key);
                             if (bstrncmp(xlist->entry[j], bkey, blength(xlist->entry[j])) == BSTR_OK)
                             {
-                                DEBUG_PRINT(DEBUGLEV_DEVELOP, Checking counter %s (device %d (%s), HWThread %d), bdata(bkey), pci_device_names[counter_map[k].device], counter_map[k].device, cpu_id);
+                                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Checking counter %s (device %d (%s), HWThread %d)", bdata(bkey), pci_device_names[counter_map[k].device], counter_map[k].device, cpu_id);
 #ifndef LIKWID_USE_PERFEVENT
                                 if (HPMcheck(counter_map[k].device, cpu_id))
 #else
@@ -1686,7 +1686,7 @@ perfmon_init_maps(void)
             perfmon_numArchEvents++;
             added_generic_event = 1;
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Adding GENERIC_EVENT done);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding GENERIC_EVENT done");
     }
 
     return 0;
@@ -1758,7 +1758,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     break;
 
                 case CORE_DUO:
-                    ERROR_PLAIN_PRINT(Unsupported Processor);
+                    ERROR_PLAIN_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
 
@@ -1956,7 +1956,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported Processor);
+                    ERROR_PLAIN_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1976,7 +1976,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported Processor);
+                    ERROR_PLAIN_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
             }
@@ -2044,7 +2044,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     perfmon_finalizeCountersThread = perfmon_finalizeCountersThread_zen2;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported AMD K17 Processor);
+                    ERROR_PLAIN_PRINT("Unsupported AMD K17 Processor");
                     err = -EINVAL;
                     break;
             }
@@ -2087,14 +2087,14 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     perfmon_finalizeCountersThread = perfmon_finalizeCountersThread_zen4c;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT(Unsupported AMD K19 Processor);
+                    ERROR_PLAIN_PRINT("Unsupported AMD K19 Processor");
                     err = -EINVAL;
                     break;
             }
             break;
 
         default:
-            ERROR_PLAIN_PRINT(Unsupported Processor);
+            ERROR_PLAIN_PRINT("Unsupported Processor");
             err = -EINVAL;
             break;
     }
@@ -2132,13 +2132,13 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
 
     if (nrThreads <= 0)
     {
-        ERROR_PRINT(Number of threads must be greater than 0 but only %d given,nrThreads);
+        ERROR_PRINT("Number of threads must be greater than 0 but only %d given", nrThreads);
         return -EINVAL;
     }
 
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT(Access to performance monitoring registers locked);
+        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
         return -EINVAL;
     }
 
@@ -2149,7 +2149,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
 
     if ((cpuid_info.family == 0) && (cpuid_info.model == 0))
     {
-        ERROR_PLAIN_PRINT(Topology module not inialized. Needed to determine current CPU type);
+        ERROR_PLAIN_PRINT("Topology module not inialized. Needed to determine current CPU type");
         return -ENODEV;
     }
 
@@ -2165,13 +2165,13 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     groupSet = (PerfmonGroupSet*) malloc(sizeof(PerfmonGroupSet));
     if (groupSet == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate group descriptor);
+        ERROR_PLAIN_PRINT("Cannot allocate group descriptor");
         return -ENOMEM;
     }
     groupSet->threads = (PerfmonThread*) malloc(nrThreads * sizeof(PerfmonThread));
     if (groupSet->threads == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate set of threads);
+        ERROR_PLAIN_PRINT("Cannot allocate set of threads");
         free(groupSet);
         groupSet = NULL;
         return -ENOMEM;
@@ -2179,7 +2179,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     currentConfig = malloc(cpuid_topology.numHWThreads*sizeof(uint64_t*));
     if (!currentConfig)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate config lists);
+        ERROR_PLAIN_PRINT("Cannot allocate config lists");
         free(groupSet);
         groupSet = NULL;
         return -ENOMEM;
@@ -2217,7 +2217,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     ret = HPMinit();
     if (ret)
     {
-        ERROR_PLAIN_PRINT(Cannot set access functions);
+        ERROR_PLAIN_PRINT("Cannot set access functions");
         free(groupSet->threads);
         free(groupSet);
         groupSet = NULL;
@@ -2235,7 +2235,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     ret = perfmon_init_maps();
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to initialize event and counter lists for %s, cpuid_info.name);
+        ERROR_PRINT("Failed to initialize event and counter lists for %s", cpuid_info.name);
         free(groupSet->threads);
         free(groupSet);
         groupSet = NULL;
@@ -2253,7 +2253,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     ret = perfmon_init_funcs(&initialize_power, &initialize_thermal);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to initialize event and counter lists for %s, cpuid_info.name);
+        ERROR_PRINT("Failed to initialize event and counter lists for %s", cpuid_info.name);
         free(groupSet->threads);
         free(groupSet);
         groupSet = NULL;
@@ -2275,7 +2275,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
         ret = HPMaddThread(threadsToCpu[i]);
         if (ret != 0)
         {
-            ERROR_PLAIN_PRINT(Cannot get access to performance counters);
+            ERROR_PLAIN_PRINT("Cannot get access to performance counters");
             free(groupSet->threads);
             free(groupSet);
             groupSet = NULL;
@@ -2410,30 +2410,30 @@ perfmon_addEventSet(const char* eventCString)
     Configuration_t config;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     config = get_configuration();
 
     if (eventCString == NULL)
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, Event string is empty. Trying environment variable LIKWID_EVENTS);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, "Event string is empty. Trying environment variable LIKWID_EVENTS");
         eventCString = getenv("LIKWID_EVENTS");
         if (eventCString == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot read event string. Also event string from environment variable is empty);
+            ERROR_PLAIN_PRINT("Cannot read event string. Also event string from environment variable is empty");
             return -EINVAL;
         }
     }
 
     if (strchr(eventCString, '-') != NULL)
     {
-        ERROR_PLAIN_PRINT(Event string contains invalid character -);
+        ERROR_PLAIN_PRINT("Event string contains invalid character -");
         return -EINVAL;
     }
     if (strchr(eventCString, '.') != NULL)
     {
-        ERROR_PLAIN_PRINT(Event string contains invalid character .);
+        ERROR_PLAIN_PRINT("Event string contains invalid character .");
         return -EINVAL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -2441,7 +2441,7 @@ perfmon_addEventSet(const char* eventCString)
         groupSet->groups = (PerfmonEventSet*) malloc(sizeof(PerfmonEventSet));
         if (groupSet->groups == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate initialize of event group list);
+            ERROR_PLAIN_PRINT("Cannot allocate initialize of event group list");
             return -ENOMEM;
         }
         groupSet->numberOfGroups = 1;
@@ -2460,15 +2460,15 @@ perfmon_addEventSet(const char* eventCString)
         groupSet->groups = (PerfmonEventSet*)realloc(groupSet->groups, groupSet->numberOfGroups*sizeof(PerfmonEventSet));
         if (groupSet->groups == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate additional group);
+            ERROR_PLAIN_PRINT("Cannot allocate additional group");
             return -ENOMEM;
         }
         groupSet->groups[groupSet->numberOfActiveGroups].rdtscTime = 0;
         groupSet->groups[groupSet->numberOfActiveGroups].runTime = 0;
         groupSet->groups[groupSet->numberOfActiveGroups].numberOfEvents = 0;
-        DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, Allocating new group structure for group.);
+        DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, "Allocating new group structure for group.");
     }
-    DEBUG_PRINT(DEBUGLEV_INFO, Currently %d groups of %d active,
+    DEBUG_PRINT(DEBUGLEV_INFO, "Currently %d groups of %d active",
                     groupSet->numberOfActiveGroups+1,
                     groupSet->numberOfGroups+1);
     cstringcopy = malloc((strlen(eventCString)+1)*sizeof(char));
@@ -2490,17 +2490,17 @@ perfmon_addEventSet(const char* eventCString)
                                   &groupSet->groups[groupSet->numberOfActiveGroups].group);
         if (err == -EACCES)
         {
-            ERROR_PRINT(Access to performance group %s not allowed, cstringcopy);
+            ERROR_PRINT("Access to performance group %s not allowed", cstringcopy);
             return err;
         }
         else if (err == -ENODEV)
         {
-            ERROR_PRINT(Performance group %s only available with deactivated HyperThreading, eventCString);
+            ERROR_PRINT("Performance group %s only available with deactivated HyperThreading", eventCString);
             return err;
         }
         else if (err < 0)
         {
-            ERROR_PRINT(Cannot read performance group %s, cstringcopy);
+            ERROR_PRINT("Cannot read performance group %s", cstringcopy);
             return err;
         }
         isPerfGroup = 1;
@@ -2510,7 +2510,7 @@ perfmon_addEventSet(const char* eventCString)
         err = perfgroup_customGroup(cstringcopy, &groupSet->groups[groupSet->numberOfActiveGroups].group);
         if (err)
         {
-            ERROR_PRINT(Cannot transform %s to performance group, cstringcopy);
+            ERROR_PRINT("Cannot transform %s to performance group", cstringcopy);
             return err;
         }
     }
@@ -2529,7 +2529,7 @@ perfmon_addEventSet(const char* eventCString)
             strcat(evstr, perf_pid);
         }
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Eventstring %s, evstr);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Eventstring %s", evstr);
     free(cstringcopy);
     eventBString = bfromcstr(evstr);
     eventtokens = bsplit(eventBString,',');
@@ -2540,7 +2540,7 @@ perfmon_addEventSet(const char* eventCString)
     eventSet->events = (PerfmonEventSetEntry*) malloc(eventtokens->qty * sizeof(PerfmonEventSetEntry));
     if (eventSet->events == NULL)
     {
-        ERROR_PRINT(Cannot allocate event list for group %d\n, groupSet->numberOfActiveGroups);
+        ERROR_PRINT("Cannot allocate event list for group %d\n", groupSet->numberOfActiveGroups);
         return -ENOMEM;
     }
     eventSet->numberOfEvents = 0;
@@ -2565,7 +2565,7 @@ perfmon_addEventSet(const char* eventCString)
         struct bstrList* subtokens = bsplit(eventtokens->entry[i],':');
         if (subtokens->qty < 2)
         {
-            ERROR_PRINT(Cannot parse event descriptor %s, bdata(eventtokens->entry[i]));
+            ERROR_PRINT("Cannot parse event descriptor %s", bdata(eventtokens->entry[i]));
             bstrListDestroy(subtokens);
             continue;
         }
@@ -2581,7 +2581,7 @@ perfmon_addEventSet(const char* eventCString)
             event->type = checkAccess(subtokens->entry[1], event->index, event->type, forceOverwrite);
             if (event->type == NOTYPE)
             {
-                DEBUG_PRINT(DEBUGLEV_INFO, Cannot access counter register %s, bdata(subtokens->entry[1]));
+                DEBUG_PRINT(DEBUGLEV_INFO, "Cannot access counter register %s", bdata(subtokens->entry[1]));
                 event->type = NOTYPE;
                 goto past_checks;
             }
@@ -2593,7 +2593,7 @@ perfmon_addEventSet(const char* eventCString)
             }
             if (!translate_types[type])
             {
-                DEBUG_PRINT(DEBUGLEV_INFO, Cannot access counter register %s, bdata(subtokens->entry[1]));
+                DEBUG_PRINT(DEBUGLEV_INFO, "Cannot access counter register %s", bdata(subtokens->entry[1]));
                 event->type = NOTYPE;
                 goto past_checks;
             }
@@ -2613,7 +2613,7 @@ perfmon_addEventSet(const char* eventCString)
             bstrListDestroy(folders);
             if (perf_folder == NULL)
             {
-                DEBUG_PRINT(DEBUGLEV_INFO, Cannot access counter register %s, bdata(subtokens->entry[1]));
+                DEBUG_PRINT(DEBUGLEV_INFO, "Cannot access counter register %s", bdata(subtokens->entry[1]));
                 event->type = NOTYPE;
                 goto past_checks;
             }
@@ -2659,7 +2659,7 @@ past_checks:
 
             if (event->threadCounter == NULL)
             {
-                ERROR_PRINT(Cannot allocate counter for all threads in group %d,groupSet->numberOfActiveGroups);
+                ERROR_PRINT("Cannot allocate counter for all threads in group %d", groupSet->numberOfActiveGroups);
                 //bstrListDestroy(subtokens);
                 continue;
             }
@@ -2678,7 +2678,7 @@ past_checks:
             {
                 valid_events++;
                 DEBUG_PRINT(DEBUGLEV_INFO,
-                        Added event %s for counter %s to group %d,
+                        "Added event %s for counter %s to group %d",
                         groupSet->groups[groupSet->numberOfActiveGroups].group.events[eventSet->numberOfEvents],
                         groupSet->groups[groupSet->numberOfActiveGroups].group.counters[eventSet->numberOfEvents],
                         groupSet->numberOfActiveGroups);
@@ -2742,7 +2742,7 @@ __perfmon_setupCountersThread(int thread_id, int groupId)
     int ret = 0;
     if (groupId >= groupSet->numberOfActiveGroups)
     {
-        ERROR_PRINT(Group %d does not exist in groupSet, groupId);
+        ERROR_PRINT("Group %d does not exist in groupSet", groupId);
         return -ENOENT;
     }
 
@@ -2765,12 +2765,12 @@ perfmon_setupCounters(int groupId)
     int force_setup = (getenv("LIKWID_FORCE_SETUP") != NULL);
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT(Access to performance monitoring registers locked);
+        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
         return -ENOLCK;
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2780,7 +2780,7 @@ perfmon_setupCounters(int groupId)
 
     if (groupId >= groupSet->numberOfActiveGroups)
     {
-        ERROR_PRINT(Group %d does not exist in groupSet, groupId);
+        ERROR_PRINT("Group %d does not exist in groupSet", groupId);
         return -ENOENT;
     }
 
@@ -2811,7 +2811,7 @@ __perfmon_startCounters(int groupId)
     }
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT(Access to performance monitoring registers locked);
+        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
         return -ENOLCK;
     }
     for(;i<groupSet->numberOfThreads;i++)
@@ -2833,17 +2833,17 @@ int perfmon_startCounters(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupSet->activeGroup < 0)
     {
-        ERROR_PLAIN_PRINT(Cannot find group to start);
+        ERROR_PLAIN_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     return __perfmon_startCounters(groupSet->activeGroup);
@@ -2853,7 +2853,7 @@ int perfmon_startGroupCounters(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2866,7 +2866,7 @@ int perfmon_startGroupCounters(int groupId)
     }
     else
     {
-        ERROR_PLAIN_PRINT(Cannot find group to start);
+        ERROR_PLAIN_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     return __perfmon_startCounters(groupId);
@@ -2882,7 +2882,7 @@ __perfmon_stopCounters(int groupId)
 
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT(Access to performance monitoring registers locked);
+        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
         return -ENOLCK;
     }
 
@@ -2918,7 +2918,7 @@ perfmon_stopCounters(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2927,7 +2927,7 @@ perfmon_stopCounters(void)
     }
     if (groupSet->activeGroup < 0)
     {
-        ERROR_PLAIN_PRINT(Cannot find group to start);
+        ERROR_PLAIN_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     if (groupSet->groups[groupSet->activeGroup].state != STATE_START)
@@ -2942,7 +2942,7 @@ perfmon_stopGroupCounters(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2955,7 +2955,7 @@ perfmon_stopGroupCounters(int groupId)
     }
     else
     {
-        ERROR_PLAIN_PRINT(Cannot find group to start);
+        ERROR_PLAIN_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     if (groupSet->groups[groupId].state != STATE_START)
@@ -2973,7 +2973,7 @@ __perfmon_readCounters(int groupId, int threadId)
     double result = 0.0;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (((groupId < 0) || (groupId >= groupSet->numberOfActiveGroups)) && (groupSet->activeGroup >= 0))
@@ -3042,7 +3042,7 @@ perfmon_readCountersCpu(int cpu_id)
     int thread_id = -1;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     for(i=0;i<groupSet->numberOfThreads;i++)
@@ -3055,7 +3055,7 @@ perfmon_readCountersCpu(int cpu_id)
     }
     if (thread_id < 0)
     {
-        ERROR_PRINT(Failed to read counters for CPU %d, cpu_id);
+        ERROR_PRINT("Failed to read counters for CPU %d", cpu_id);
         return -thread_id;
     }
     i = __perfmon_readCounters(groupSet->activeGroup, thread_id);
@@ -3115,7 +3115,7 @@ perfmon_getResult(int groupId, int eventId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3164,7 +3164,7 @@ perfmon_getLastResult(int groupId, int eventId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return 0;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3203,7 +3203,7 @@ perfmon_getMetric(int groupId, int metricId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3267,7 +3267,7 @@ perfmon_getMetric(int groupId, int metricId, int threadId)
                 err = update_clist(&clist,groupSet->groups[groupId].group.counters[e], perfmon_getResult(groupId, e, sock_cpu));
                 if (err < 0)
                 {
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Cannot add socket result of counter %s for thread %d, groupSet->groups[groupId].group.counters[e], threadId);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Cannot add socket result of counter %s for thread %d", groupSet->groups[groupId].group.counters[e], threadId);
                 }
             }
         }
@@ -3276,7 +3276,7 @@ perfmon_getMetric(int groupId, int metricId, int threadId)
     if (e < 0)
     {
         result = 0.0;
-        //ERROR_PRINT(Cannot calculate formula %s, groupSet->groups[groupId].group.metricformulas[metricId]);
+        //ERROR_PRINT("Cannot calculate formula %s", groupSet->groups[groupId].group.metricformulas[metricId]);
     }
     destroy_clist(&clist);
     return result;
@@ -3293,7 +3293,7 @@ perfmon_getLastMetric(int groupId, int metricId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3357,7 +3357,7 @@ perfmon_getLastMetric(int groupId, int metricId, int threadId)
                 err = update_clist(&clist,groupSet->groups[groupId].group.counters[e], perfmon_getLastResult(groupId, e, sock_cpu));
                 if (err < 0)
                 {
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Cannot add socket result of counter %s for thread %d, groupSet->groups[groupId].group.counters[e], threadId);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Cannot add socket result of counter %s for thread %d", groupSet->groups[groupId].group.counters[e], threadId);
                 }
             }
         }
@@ -3366,7 +3366,7 @@ perfmon_getLastMetric(int groupId, int metricId, int threadId)
     if (e < 0)
     {
         result = 0.0;
-        //ERROR_PRINT(Cannot calculate formula %s, groupSet->groups[groupId].group.metricformulas[metricId]);
+        //ERROR_PRINT("Cannot calculate formula %s", groupSet->groups[groupId].group.metricformulas[metricId]);
     }
     destroy_clist(&clist);
     return result;
@@ -3380,7 +3380,7 @@ __perfmon_switchActiveGroupThread(int thread_id, int new_group)
     GroupState state;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (thread_id < 0 || thread_id >= groupSet->numberOfThreads)
@@ -3447,7 +3447,7 @@ perfmon_getNumberOfGroups(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     return groupSet->numberOfActiveGroups;
@@ -3458,7 +3458,7 @@ perfmon_getIdOfActiveGroup(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     return groupSet->activeGroup;
@@ -3469,7 +3469,7 @@ perfmon_getNumberOfThreads(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     return groupSet->numberOfThreads;
@@ -3480,7 +3480,7 @@ perfmon_getNumberOfEvents(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3495,7 +3495,7 @@ perfmon_getTimeOfGroup(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3510,7 +3510,7 @@ perfmon_getLastTimeOfGroup(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3542,7 +3542,7 @@ perfmon_getEventName(int groupId, int eventId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3570,7 +3570,7 @@ perfmon_getCounterName(int groupId, int eventId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3598,7 +3598,7 @@ perfmon_getMetricName(int groupId, int metricId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3625,7 +3625,7 @@ perfmon_getGroupName(int groupId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3648,7 +3648,7 @@ perfmon_getGroupInfoShort(int groupId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3671,7 +3671,7 @@ perfmon_getGroupInfoLong(int groupId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3706,7 +3706,7 @@ perfmon_getNumberOfMetrics(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3742,7 +3742,7 @@ perfmon_getNumberOfRegions()
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (markerResults == NULL)
@@ -3757,7 +3757,7 @@ perfmon_getGroupOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3776,7 +3776,7 @@ perfmon_getTagOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3795,7 +3795,7 @@ perfmon_getEventsOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3828,7 +3828,7 @@ perfmon_getThreadsOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3848,7 +3848,7 @@ perfmon_getCpulistOfRegion(int region, int count, int* cpulist)
     int i;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3875,7 +3875,7 @@ perfmon_getTimeOfRegion(int region, int thread)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3898,7 +3898,7 @@ perfmon_getCountOfRegion(int region, int thread)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3921,7 +3921,7 @@ perfmon_getResultOfRegionThread(int region, int event, int thread)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3955,7 +3955,7 @@ perfmon_getMetricOfRegionThread(int region, int metricId, int threadId)
     CounterList clist;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (region < 0 || region >= markerRegions)
@@ -4027,7 +4027,7 @@ perfmon_getMetricOfRegionThread(int region, int metricId, int threadId)
                 err = update_clist(&clist,groupSet->groups[markerResults[region].groupID].group.counters[e], perfmon_getResultOfRegionThread(region, e, sock_cpu));
                 if (err < 0)
                 {
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, Cannot add socket result of counter %s for thread %d, groupSet->groups[markerResults[region].groupID].group.counters[e], threadId);
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Cannot add socket result of counter %s for thread %d", groupSet->groups[markerResults[region].groupID].group.counters[e], threadId);
                 }
             }
         }
@@ -4035,7 +4035,7 @@ perfmon_getMetricOfRegionThread(int region, int metricId, int threadId)
     err = calc_metric(groupSet->groups[markerResults[region].groupID].group.metricformulas[metricId], &clist, &result);
     if (err < 0)
     {
-        ERROR_PRINT(Cannot calculate formula %s, groupSet->groups[markerResults[region].groupID].group.metricformulas[metricId]);
+        ERROR_PRINT("Cannot calculate formula %s", groupSet->groups[markerResults[region].groupID].group.metricformulas[metricId]);
     }
     destroy_clist(&clist);
     return result;
@@ -4055,7 +4055,7 @@ perfmon_readMarkerFile(const char* filename)
 
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Perfmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (filename == NULL)

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -635,7 +635,7 @@ parseOptions(struct bstrList* tokens, PerfmonEvent* event, RegisterIndex index)
             }
             else
             {
-                ERROR_PLAIN_PRINT("Cannot set threshold option to default. no more space in options list");
+                ERROR_PRINT("Cannot set threshold option to default. no more space in options list");
             }
         }
         else if (event->options[i].type == EVENT_OPTION_OCCUPANCY)
@@ -670,7 +670,7 @@ parseOptions(struct bstrList* tokens, PerfmonEvent* event, RegisterIndex index)
             }
             else
             {
-                ERROR_PLAIN_PRINT("Cannot set threshold option to default. no more space in options list");
+                ERROR_PRINT("Cannot set threshold option to default. no more space in options list");
             }
         }
     }
@@ -756,7 +756,7 @@ perfmon_check_counter_map(int cpu_id)
     int own_hpm = 0;
     if (perfmon_numCounters == 0 || perfmon_numArchEvents == 0)
     {
-        ERROR_PLAIN_PRINT("Counter and event maps not initialized.");
+        ERROR_PRINT("Counter and event maps not initialized.");
         return;
     }
 
@@ -765,7 +765,7 @@ perfmon_check_counter_map(int cpu_id)
 
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
+        ERROR_PRINT("Access to performance monitoring registers locked");
         return;
     }
 #ifndef LIKWID_USE_PERFEVENT
@@ -774,7 +774,7 @@ perfmon_check_counter_map(int cpu_id)
         HPMinit();
         if (HPMaddThread(cpu_id) != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot check counters without access to performance counters");
+            ERROR_PRINT("Cannot check counters without access to performance counters");
             return;
         }
         own_hpm = 1;
@@ -976,7 +976,7 @@ perfmon_init_maps(void)
                     break;
 
                 case CORE_DUO:
-                    ERROR_PLAIN_PRINT("Unsupported Processor");
+                    ERROR_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
 
@@ -1248,7 +1248,7 @@ perfmon_init_maps(void)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported Intel Processor");
+                    ERROR_PRINT("Unsupported Intel Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1267,7 +1267,7 @@ perfmon_init_maps(void)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported Processor");
+                    ERROR_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1333,7 +1333,7 @@ perfmon_init_maps(void)
                     translate_types = zen2_translate_types;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported AMD Zen Processor");
+                    ERROR_PRINT("Unsupported AMD Zen Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1372,7 +1372,7 @@ perfmon_init_maps(void)
                     translate_types = zen4c_translate_types;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported AMD Zen Processor");
+                    ERROR_PRINT("Unsupported AMD Zen Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1398,7 +1398,7 @@ perfmon_init_maps(void)
                     perfmon_numCounters = NUM_COUNTERS_POWER9;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported PPC Processor");
+                    ERROR_PRINT("Unsupported PPC Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1441,7 +1441,7 @@ perfmon_init_maps(void)
                     }
                     break;
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported ARMv7 Processor");
+                    ERROR_PRINT("Unsupported ARMv7 Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1506,7 +1506,7 @@ perfmon_init_maps(void)
                             translate_types = nvidiagrace_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT("Unsupported ARMv8 Processor");
+                            ERROR_PRINT("Unsupported ARMv8 Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1523,7 +1523,7 @@ perfmon_init_maps(void)
                             translate_types = cav_tx2_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT("Unsupported Cavium/Marvell Processor");
+                            ERROR_PRINT("Unsupported Cavium/Marvell Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1540,7 +1540,7 @@ perfmon_init_maps(void)
                             translate_types = cav_tx2_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT("Unsupported Cavium/Marvell Processor");
+                            ERROR_PRINT("Unsupported Cavium/Marvell Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1557,7 +1557,7 @@ perfmon_init_maps(void)
                             translate_types = a64fx_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT("Unsupported Fujitsu Processor");
+                            ERROR_PRINT("Unsupported Fujitsu Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1574,7 +1574,7 @@ perfmon_init_maps(void)
                             translate_types = tsv110_translate_types;
                             break;
                         default:
-                            ERROR_PLAIN_PRINT("Unsupported Huawei Processor");
+                            ERROR_PRINT("Unsupported Huawei Processor");
                             err = -EINVAL;
                             break;
                     }
@@ -1592,20 +1592,20 @@ perfmon_init_maps(void)
                              translate_types = applem1_translate_types;
                              break;
                          default:
-                             ERROR_PLAIN_PRINT("Unsupported Apple Processor");
+                             ERROR_PRINT("Unsupported Apple Processor");
                              err = -EINVAL;
                              break;
                     }
                     break;
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported ARMv8 Processor");
+                    ERROR_PRINT("Unsupported ARMv8 Processor");
                     err = -EINVAL;
                     break;
             }
             break;
 
         default:
-            ERROR_PLAIN_PRINT("Unsupported Processor");
+            ERROR_PRINT("Unsupported Processor");
             err = -EINVAL;
             break;
     }
@@ -1758,7 +1758,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     break;
 
                 case CORE_DUO:
-                    ERROR_PLAIN_PRINT("Unsupported Processor");
+                    ERROR_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
 
@@ -1956,7 +1956,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported Processor");
+                    ERROR_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
             }
@@ -1976,7 +1976,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     break;
 
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported Processor");
+                    ERROR_PRINT("Unsupported Processor");
                     err = -EINVAL;
                     break;
             }
@@ -2044,7 +2044,7 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     perfmon_finalizeCountersThread = perfmon_finalizeCountersThread_zen2;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported AMD K17 Processor");
+                    ERROR_PRINT("Unsupported AMD K17 Processor");
                     err = -EINVAL;
                     break;
             }
@@ -2087,14 +2087,14 @@ perfmon_init_funcs(int* init_power, int* init_temp)
                     perfmon_finalizeCountersThread = perfmon_finalizeCountersThread_zen4c;
                     break;
                 default:
-                    ERROR_PLAIN_PRINT("Unsupported AMD K19 Processor");
+                    ERROR_PRINT("Unsupported AMD K19 Processor");
                     err = -EINVAL;
                     break;
             }
             break;
 
         default:
-            ERROR_PLAIN_PRINT("Unsupported Processor");
+            ERROR_PRINT("Unsupported Processor");
             err = -EINVAL;
             break;
     }
@@ -2138,7 +2138,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
 
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
+        ERROR_PRINT("Access to performance monitoring registers locked");
         return -EINVAL;
     }
 
@@ -2149,7 +2149,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
 
     if ((cpuid_info.family == 0) && (cpuid_info.model == 0))
     {
-        ERROR_PLAIN_PRINT("Topology module not inialized. Needed to determine current CPU type");
+        ERROR_PRINT("Topology module not inialized. Needed to determine current CPU type");
         return -ENODEV;
     }
 
@@ -2165,13 +2165,13 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     groupSet = (PerfmonGroupSet*) malloc(sizeof(PerfmonGroupSet));
     if (groupSet == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate group descriptor");
+        ERROR_PRINT("Cannot allocate group descriptor");
         return -ENOMEM;
     }
     groupSet->threads = (PerfmonThread*) malloc(nrThreads * sizeof(PerfmonThread));
     if (groupSet->threads == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate set of threads");
+        ERROR_PRINT("Cannot allocate set of threads");
         free(groupSet);
         groupSet = NULL;
         return -ENOMEM;
@@ -2179,7 +2179,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     currentConfig = malloc(cpuid_topology.numHWThreads*sizeof(uint64_t*));
     if (!currentConfig)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate config lists");
+        ERROR_PRINT("Cannot allocate config lists");
         free(groupSet);
         groupSet = NULL;
         return -ENOMEM;
@@ -2217,7 +2217,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     ret = HPMinit();
     if (ret)
     {
-        ERROR_PLAIN_PRINT("Cannot set access functions");
+        ERROR_PRINT("Cannot set access functions");
         free(groupSet->threads);
         free(groupSet);
         groupSet = NULL;
@@ -2275,7 +2275,7 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
         ret = HPMaddThread(threadsToCpu[i]);
         if (ret != 0)
         {
-            ERROR_PLAIN_PRINT("Cannot get access to performance counters");
+            ERROR_PRINT("Cannot get access to performance counters");
             free(groupSet->threads);
             free(groupSet);
             groupSet = NULL;
@@ -2410,30 +2410,30 @@ perfmon_addEventSet(const char* eventCString)
     Configuration_t config;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     config = get_configuration();
 
     if (eventCString == NULL)
     {
-        DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, "Event string is empty. Trying environment variable LIKWID_EVENTS");
+        DEBUG_PRINT(DEBUGLEV_INFO, "Event string is empty. Trying environment variable LIKWID_EVENTS");
         eventCString = getenv("LIKWID_EVENTS");
         if (eventCString == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot read event string. Also event string from environment variable is empty");
+            ERROR_PRINT("Cannot read event string. Also event string from environment variable is empty");
             return -EINVAL;
         }
     }
 
     if (strchr(eventCString, '-') != NULL)
     {
-        ERROR_PLAIN_PRINT("Event string contains invalid character -");
+        ERROR_PRINT("Event string contains invalid character -");
         return -EINVAL;
     }
     if (strchr(eventCString, '.') != NULL)
     {
-        ERROR_PLAIN_PRINT("Event string contains invalid character .");
+        ERROR_PRINT("Event string contains invalid character .");
         return -EINVAL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -2441,7 +2441,7 @@ perfmon_addEventSet(const char* eventCString)
         groupSet->groups = (PerfmonEventSet*) malloc(sizeof(PerfmonEventSet));
         if (groupSet->groups == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate initialize of event group list");
+            ERROR_PRINT("Cannot allocate initialize of event group list");
             return -ENOMEM;
         }
         groupSet->numberOfGroups = 1;
@@ -2460,13 +2460,13 @@ perfmon_addEventSet(const char* eventCString)
         groupSet->groups = (PerfmonEventSet*)realloc(groupSet->groups, groupSet->numberOfGroups*sizeof(PerfmonEventSet));
         if (groupSet->groups == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate additional group");
+            ERROR_PRINT("Cannot allocate additional group");
             return -ENOMEM;
         }
         groupSet->groups[groupSet->numberOfActiveGroups].rdtscTime = 0;
         groupSet->groups[groupSet->numberOfActiveGroups].runTime = 0;
         groupSet->groups[groupSet->numberOfActiveGroups].numberOfEvents = 0;
-        DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, "Allocating new group structure for group.");
+        DEBUG_PRINT(DEBUGLEV_INFO, "Allocating new group structure for group.");
     }
     DEBUG_PRINT(DEBUGLEV_INFO, "Currently %d groups of %d active",
                     groupSet->numberOfActiveGroups+1,
@@ -2765,12 +2765,12 @@ perfmon_setupCounters(int groupId)
     int force_setup = (getenv("LIKWID_FORCE_SETUP") != NULL);
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
+        ERROR_PRINT("Access to performance monitoring registers locked");
         return -ENOLCK;
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2811,7 +2811,7 @@ __perfmon_startCounters(int groupId)
     }
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
+        ERROR_PRINT("Access to performance monitoring registers locked");
         return -ENOLCK;
     }
     for(;i<groupSet->numberOfThreads;i++)
@@ -2833,17 +2833,17 @@ int perfmon_startCounters(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupSet->activeGroup < 0)
     {
-        ERROR_PLAIN_PRINT("Cannot find group to start");
+        ERROR_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     return __perfmon_startCounters(groupSet->activeGroup);
@@ -2853,7 +2853,7 @@ int perfmon_startGroupCounters(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2866,7 +2866,7 @@ int perfmon_startGroupCounters(int groupId)
     }
     else
     {
-        ERROR_PLAIN_PRINT("Cannot find group to start");
+        ERROR_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     return __perfmon_startCounters(groupId);
@@ -2882,7 +2882,7 @@ __perfmon_stopCounters(int groupId)
 
     if (!lock_check())
     {
-        ERROR_PLAIN_PRINT("Access to performance monitoring registers locked");
+        ERROR_PRINT("Access to performance monitoring registers locked");
         return -ENOLCK;
     }
 
@@ -2918,7 +2918,7 @@ perfmon_stopCounters(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2927,7 +2927,7 @@ perfmon_stopCounters(void)
     }
     if (groupSet->activeGroup < 0)
     {
-        ERROR_PLAIN_PRINT("Cannot find group to start");
+        ERROR_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     if (groupSet->groups[groupSet->activeGroup].state != STATE_START)
@@ -2942,7 +2942,7 @@ perfmon_stopGroupCounters(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (unlikely(groupSet == NULL))
@@ -2955,7 +2955,7 @@ perfmon_stopGroupCounters(int groupId)
     }
     else
     {
-        ERROR_PLAIN_PRINT("Cannot find group to start");
+        ERROR_PRINT("Cannot find group to start");
         return -EINVAL;
     }
     if (groupSet->groups[groupId].state != STATE_START)
@@ -2973,7 +2973,7 @@ __perfmon_readCounters(int groupId, int threadId)
     double result = 0.0;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (((groupId < 0) || (groupId >= groupSet->numberOfActiveGroups)) && (groupSet->activeGroup >= 0))
@@ -3042,7 +3042,7 @@ perfmon_readCountersCpu(int cpu_id)
     int thread_id = -1;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     for(i=0;i<groupSet->numberOfThreads;i++)
@@ -3115,7 +3115,7 @@ perfmon_getResult(int groupId, int eventId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3164,7 +3164,7 @@ perfmon_getLastResult(int groupId, int eventId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return 0;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3203,7 +3203,7 @@ perfmon_getMetric(int groupId, int metricId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3293,7 +3293,7 @@ perfmon_getLastMetric(int groupId, int metricId, int threadId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3380,7 +3380,7 @@ __perfmon_switchActiveGroupThread(int thread_id, int new_group)
     GroupState state;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (thread_id < 0 || thread_id >= groupSet->numberOfThreads)
@@ -3447,7 +3447,7 @@ perfmon_getNumberOfGroups(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     return groupSet->numberOfActiveGroups;
@@ -3458,7 +3458,7 @@ perfmon_getIdOfActiveGroup(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     return groupSet->activeGroup;
@@ -3469,7 +3469,7 @@ perfmon_getNumberOfThreads(void)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     return groupSet->numberOfThreads;
@@ -3480,7 +3480,7 @@ perfmon_getNumberOfEvents(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3495,7 +3495,7 @@ perfmon_getTimeOfGroup(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3510,7 +3510,7 @@ perfmon_getLastTimeOfGroup(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3542,7 +3542,7 @@ perfmon_getEventName(int groupId, int eventId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3570,7 +3570,7 @@ perfmon_getCounterName(int groupId, int eventId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3598,7 +3598,7 @@ perfmon_getMetricName(int groupId, int metricId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3625,7 +3625,7 @@ perfmon_getGroupName(int groupId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3648,7 +3648,7 @@ perfmon_getGroupInfoShort(int groupId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3671,7 +3671,7 @@ perfmon_getGroupInfoLong(int groupId)
     }
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (groupSet->numberOfActiveGroups == 0)
@@ -3706,7 +3706,7 @@ perfmon_getNumberOfMetrics(int groupId)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (groupId < 0)
@@ -3742,7 +3742,7 @@ perfmon_getNumberOfRegions()
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (markerResults == NULL)
@@ -3757,7 +3757,7 @@ perfmon_getGroupOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3776,7 +3776,7 @@ perfmon_getTagOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NULL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3795,7 +3795,7 @@ perfmon_getEventsOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3828,7 +3828,7 @@ perfmon_getThreadsOfRegion(int region)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3848,7 +3848,7 @@ perfmon_getCpulistOfRegion(int region, int count, int* cpulist)
     int i;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3875,7 +3875,7 @@ perfmon_getTimeOfRegion(int region, int thread)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3898,7 +3898,7 @@ perfmon_getCountOfRegion(int region, int thread)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3921,7 +3921,7 @@ perfmon_getResultOfRegionThread(int region, int event, int thread)
 {
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= markerRegions)
@@ -3955,7 +3955,7 @@ perfmon_getMetricOfRegionThread(int region, int metricId, int threadId)
     CounterList clist;
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return NAN;
     }
     if (region < 0 || region >= markerRegions)
@@ -4055,7 +4055,7 @@ perfmon_readMarkerFile(const char* filename)
 
     if (perfmon_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Perfmon module not properly initialized");
+        ERROR_PRINT("Perfmon module not properly initialized");
         return -EINVAL;
     }
     if (filename == NULL)

--- a/src/power.c
+++ b/src/power.c
@@ -156,7 +156,7 @@ power_init(int cpuId)
                     break;
 
                 default:
-                    DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, "NO RAPL SUPPORT");
+                    DEBUG_PRINT(DEBUGLEV_INFO, "NO RAPL SUPPORT");
                     return 0;
                     break;
             }

--- a/src/power.c
+++ b/src/power.c
@@ -67,10 +67,10 @@ power_init(int cpuId)
     {
         return 0;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Init power);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Init power");
     if (!lock_check())
     {
-        ERROR_PRINT(Access to performance monitoring registers locked);
+        ERROR_PRINT("Access to performance monitoring registers locked");
         return -ENOLCK;
     }
     init_configuration();
@@ -90,7 +90,7 @@ power_init(int cpuId)
     power_info.statusRegWidth = 32;
     if (config->daemonMode == ACCESSMODE_PERF)
     {
-        ERROR_PRINT(RAPL in access mode 'perf_event' only available with perfmon);
+        ERROR_PRINT("RAPL in access mode 'perf_event' only available with perfmon");
         return 0;
     }
 
@@ -156,7 +156,7 @@ power_init(int cpuId)
                     break;
 
                 default:
-                    DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, NO RAPL SUPPORT);
+                    DEBUG_PLAIN_PRINT(DEBUGLEV_INFO, "NO RAPL SUPPORT");
                     return 0;
                     break;
             }
@@ -252,7 +252,7 @@ power_init(int cpuId)
         err = HPMaddThread(cpuId);
         if (err != 0)
         {
-            ERROR_PRINT(Cannot get access to RAPL counters)
+            ERROR_PRINT("Cannot get access to RAPL counters");
             return err;
         }
     }
@@ -289,7 +289,7 @@ power_init(int cpuId)
             err = HPMread(cpuId, MSR_DEV, MSR_TURBO_RATIO_LIMIT, &flags);
             if (err)
             {
-                ERROR_PRINT(Cannot gather values from %s, "MSR_TURBO_RATIO_LIMIT");
+                ERROR_PRINT("Cannot gather values from %s", "MSR_TURBO_RATIO_LIMIT");
             }
             else
             {
@@ -304,7 +304,7 @@ power_init(int cpuId)
                         err = HPMread(cpuId, MSR_DEV, MSR_TURBO_RATIO_LIMIT1, &flag_vals[1]);
                         if (err)
                         {
-                            ERROR_PRINT(Cannot read core limits from %s, "MSR_TURBO_RATIO_LIMIT1");
+                            ERROR_PRINT("Cannot read core limits from %s", "MSR_TURBO_RATIO_LIMIT1");
                             flag_vals[1] = 0;
                         }
                     }
@@ -313,7 +313,7 @@ power_init(int cpuId)
                         err = HPMread(cpuId, MSR_DEV, MSR_TURBO_RATIO_LIMIT2, &flag_vals[2]);
                         if (err)
                         {
-                            ERROR_PRINT(Cannot read core limits from %s, "MSR_TURBO_RATIO_LIMIT2");
+                            ERROR_PRINT("Cannot read core limits from %s", "MSR_TURBO_RATIO_LIMIT2");
                             flag_vals[2] = 0;
                         }
                     }
@@ -322,7 +322,7 @@ power_init(int cpuId)
                         err = HPMread(cpuId, MSR_DEV, MSR_TURBO_RATIO_LIMIT3, &flag_vals[3]);
                         if (err)
                         {
-                            ERROR_PRINT(Cannot read core limits from %s, "MSR_TURBO_RATIO_LIMIT3");
+                            ERROR_PRINT("Cannot read core limits from %s", "MSR_TURBO_RATIO_LIMIT3");
                             flag_vals[3] = 0;
                         }
                     }
@@ -347,7 +347,7 @@ power_init(int cpuId)
                     err = HPMread(cpuId, MSR_DEV, MSR_TURBO_RATIO_LIMIT_CORES, &flags_cores);
                     if (err)
                     {
-                        ERROR_PRINT(Cannot read core limits from %s, "MSR_TURBO_RATIO_LIMIT_CORES");
+                        ERROR_PRINT("Cannot read core limits from %s", "MSR_TURBO_RATIO_LIMIT_CORES");
                         flags_cores = 0;
                     }
                     for (int i = 0; i < 8; i++)
@@ -368,7 +368,7 @@ power_init(int cpuId)
         }
         else
         {
-            ERROR_PRINT(Cannot gather values from %s, "MSR_PLATFORM_INFO");
+            ERROR_PRINT("Cannot gather values from %s", "MSR_PLATFORM_INFO");
         }
     }
 
@@ -428,7 +428,7 @@ power_init(int cpuId)
                 }
                 else
                 {
-                    DEBUG_PRINT(DEBUGLEV_DETAIL, RAPL domain %s not supported, power_names[i]);
+                    DEBUG_PRINT(DEBUGLEV_DETAIL, "RAPL domain %s not supported", power_names[i]);
                     continue;
                 }
                 if (limit_regs[i] != 0x0)
@@ -440,7 +440,7 @@ power_init(int cpuId)
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_DETAIL, Deactivating limit register for RAPL domain %s, power_names[i]);
+                        DEBUG_PRINT(DEBUGLEV_DETAIL, "Deactivating limit register for RAPL domain %s", power_names[i]);
                         limit_regs[i] = 0x0;
                     }
                 }
@@ -462,7 +462,7 @@ power_init(int cpuId)
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_DETAIL, Deactivating info register for RAPL domain %s, power_names[i]);
+                        DEBUG_PRINT(DEBUGLEV_DETAIL, "Deactivating info register for RAPL domain %s", power_names[i]);
                         info_regs[i] = 0x0;
                     }
                 }
@@ -475,7 +475,7 @@ power_init(int cpuId)
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_DETAIL, Deactivating policy register for RAPL domain %s, power_names[i]);
+                        DEBUG_PRINT(DEBUGLEV_DETAIL, "Deactivating policy register for RAPL domain %s", power_names[i]);
                         policy_regs[i] = 0x0;
                     }
                 }
@@ -488,7 +488,7 @@ power_init(int cpuId)
                     }
                     else
                     {
-                        DEBUG_PRINT(DEBUGLEV_DETAIL, Deactivating perf register for RAPL domain %s, power_names[i]);
+                        DEBUG_PRINT(DEBUGLEV_DETAIL, "Deactivating perf register for RAPL domain %s", power_names[i]);
                         perf_regs[i] = 0x0;
                     }
                 }
@@ -496,7 +496,7 @@ power_init(int cpuId)
         }
         else
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Cannot gather values from unit register 0x%X. deactivating RAPL support, unit_reg);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Cannot gather values from unit register 0x%X. deactivating RAPL support", unit_reg);
             power_info.hasRAPL =  0;
         }
 
@@ -520,7 +520,7 @@ power_init(int cpuId)
             err = HPMread(cpuId, MSR_DEV, MSR_AMD19_RAPL_L3_UNIT, &flags);
             if (err == 0)
             {
-                DEBUG_PRINT(DEBUGLEV_DETAIL, Reading energy unit for Zen4 L3 RAPL domain);
+                DEBUG_PRINT(DEBUGLEV_DETAIL, "Reading energy unit for Zen4 L3 RAPL domain");
                 power_info.domains[1].energyUnit = 1.0 / (1 << ((flags >> 8) & 0x1F));
             }
         }
@@ -550,7 +550,7 @@ power_perfGet(int cpuId, PowerType domain, uint32_t* status)
         err = HPMread(cpuId, MSR_DEV, perf_regs[domain], (uint64_t*)status);
         if (err)
         {
-            ERROR_PRINT(Failed to get power perf value for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to get power perf value for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
     }
@@ -580,7 +580,7 @@ power_limitSet(int cpuId, PowerType domain, double power, double time, int doCla
         err = HPMwrite(cpuId, MSR_DEV, limit_regs[domain], flags);
         if (err)
         {
-            ERROR_PRINT(Failed to set power limit for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to set power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
     }
@@ -604,7 +604,7 @@ power_limitGet(int cpuId, PowerType domain, double* power, double* time)
         err = HPMread(cpuId, MSR_DEV, limit_regs[domain], &flags);
         if (err)
         {
-            ERROR_PRINT(Failed to set power limit for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to set power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
         *power = ((double)extractBitField(flags, 15, 0)) * power_info.domains[domain].energyUnit;
@@ -630,7 +630,7 @@ power_limitState(int cpuId, PowerType domain)
         err = HPMread(cpuId, MSR_DEV, limit_regs[domain], &flags);
         if (err)
         {
-            ERROR_PRINT(Failed to activate power limit for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to activate power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
     }
@@ -656,14 +656,14 @@ power_limitActivate(int cpuId, PowerType domain)
         err = HPMread(cpuId, MSR_DEV, limit_regs[domain], &flags);
         if (err)
         {
-            ERROR_PRINT(Failed to activate power limit for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to activate power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
         flags |= (1ULL<<15);
         err = HPMwrite(cpuId, MSR_DEV, limit_regs[domain], flags);
         if (err)
         {
-            ERROR_PRINT(Failed to activate power limit for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to activate power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
     }
@@ -681,14 +681,14 @@ power_limitDectivate(int cpuId, PowerType domain)
         err = HPMread(cpuId, MSR_DEV, limit_regs[domain], &flags);
         if (err)
         {
-            ERROR_PRINT(Failed to deactivate power limit for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to deactivate power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
         flags &= ~(1ULL<<15);
         err = HPMwrite(cpuId, MSR_DEV, limit_regs[domain], flags);
         if (err)
         {
-            ERROR_PRINT(Failed to deactivate power limit for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to deactivate power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
     }
@@ -709,7 +709,7 @@ power_policySet(int cpuId, PowerType domain, uint32_t priority)
         err = HPMwrite(cpuId, MSR_DEV, policy_regs[domain], priority);
         if (err)
         {
-            ERROR_PRINT(Failed to set power policy for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to set power policy for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
     }
@@ -730,7 +730,7 @@ power_policyGet(int cpuId, PowerType domain, uint32_t* priority)
         err = HPMread(cpuId, MSR_DEV, policy_regs[domain], (uint64_t*)priority);
         if (err)
         {
-            ERROR_PRINT(Failed to get power policy for domain %s on CPU %d,power_names[domain], cpuId);
+            ERROR_PRINT("Failed to get power policy for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
     }

--- a/src/rocmon.c
+++ b/src/rocmon.c
@@ -552,14 +552,14 @@ _rocmon_iterate_agents_callback(hsa_agent_t agent, void* argv)
     device->rocMetrics = (rocprofiler_info_data_t*) malloc(device->numRocMetrics * sizeof(rocprofiler_info_data_t));
     if (device->rocMetrics == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate set of rocMetrics");
+        ERROR_PRINT("Cannot allocate set of rocMetrics");
         return HSA_STATUS_ERROR;
     }
 
     // Initialize SMI events map
     if (init_map(&device->smiMetrics, MAP_KEY_TYPE_STR, 0, &free) < 0)
     {
-        ERROR_PLAIN_PRINT("Cannot init smiMetrics map");
+        ERROR_PRINT("Cannot init smiMetrics map");
         return HSA_STATUS_ERROR;
     }
 
@@ -1168,7 +1168,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     int ret = _rocmon_link_libraries();
     if (ret < 0)
     {
-	ERROR_PLAIN_PRINT("Failed to initialize libraries");
+	ERROR_PRINT("Failed to initialize libraries");
         return ret;
     }
 
@@ -1176,7 +1176,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     rocmon_context = (RocmonContext*) malloc(sizeof(RocmonContext));
     if (rocmon_context == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate Rocmon context");
+        ERROR_PRINT("Cannot allocate Rocmon context");
         return -ENOMEM;
     }
     rocmon_context->groups = NULL;
@@ -1187,7 +1187,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     rocmon_context->numDevices = numGpus;
     if (rocmon_context->devices == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate set of GPUs");
+        ERROR_PRINT("Cannot allocate set of GPUs");
         free(rocmon_context);
         rocmon_context = NULL;
         return -ENOMEM;
@@ -1197,7 +1197,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initializing HSA");
     ROCM_CALL(hsa_init, (),
     {
-        ERROR_PLAIN_PRINT("Failed to init hsa library");
+        ERROR_PRINT("Failed to init hsa library");
         goto rocmon_init_hsa_failed;
     });
 
@@ -1205,7 +1205,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initializing RSMI");
     RSMI_CALL(rsmi_init, (0),
     {
-        ERROR_PLAIN_PRINT("Failed to init rocm_smi");
+        ERROR_PRINT("Failed to init rocm_smi");
         goto rocmon_init_rsmi_failed;
     });
 
@@ -1214,7 +1214,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Getting HSA timestamp factor");
     ROCM_CALL(hsa_system_get_info, (HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &frequency_hz),
     {
-        ERROR_PLAIN_PRINT("Failed to get HSA timestamp factor");
+        ERROR_PRINT("Failed to get HSA timestamp factor");
         goto rocmon_init_info_agents_failed;
     });
     rocmon_context->hsa_timestamp_factor = (long double)1000000000 / (long double)frequency_hz;
@@ -1343,7 +1343,7 @@ rocmon_addEventSet(const char* eventString, int* gid)
         GroupInfo* tmpInfo = (GroupInfo*) realloc(rocmon_context->groups, (rocmon_context->numGroups+1) * sizeof(GroupInfo));
         if (tmpInfo == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate additional group");
+            ERROR_PRINT("Cannot allocate additional group");
             return -ENOMEM;
         }
         rocmon_context->groups = tmpInfo;
@@ -1367,7 +1367,7 @@ rocmon_addEventSet(const char* eventString, int* gid)
         RocmonEventResult* tmpResults = (RocmonEventResult*) malloc(numEvents * sizeof(RocmonEventResult));
         if (tmpResults == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate event results");
+            ERROR_PRINT("Cannot allocate event results");
             return -ENOMEM;
         }
 
@@ -1375,7 +1375,7 @@ rocmon_addEventSet(const char* eventString, int* gid)
         RocmonEventResultList* tmpGroupResults = (RocmonEventResultList*) realloc(device->groupResults, (device->numGroupResults+1) * sizeof(RocmonEventResultList));
         if (tmpGroupResults == NULL)
         {
-            ERROR_PLAIN_PRINT("Cannot allocate new event group result list");
+            ERROR_PRINT("Cannot allocate new event group result list");
             return -ENOMEM;
         }
 
@@ -1411,7 +1411,7 @@ _rocmon_setupCounters_rocprofiler(RocmonDevice* device, const char** events, int
     rocprofiler_feature_t* features = (rocprofiler_feature_t*) malloc(numEvents * sizeof(rocprofiler_feature_t));
     if (features == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate feature list");
+        ERROR_PRINT("Cannot allocate feature list");
         return -ENOMEM;
     }
     for (int i = 0; i < numEvents; i++)
@@ -1462,7 +1462,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
     RocmonSmiEvent* activeEvents = (RocmonSmiEvent*) malloc(numEvents * sizeof(RocmonSmiEvent));
     if (activeEvents == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate active event list");
+        ERROR_PRINT("Cannot allocate active event list");
         return -ENOMEM;
     }
 
@@ -1597,13 +1597,13 @@ rocmon_setupCounters(int gid)
     smiEvents = (const char**) malloc(group->nevents * sizeof(const char*));
     if (smiEvents == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate smiEvent name array");
+        ERROR_PRINT("Cannot allocate smiEvent name array");
         return -ENOMEM;
     }
     rocEvents = (const char**) malloc(group->nevents * sizeof(const char*));
     if (rocEvents == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate rocEvent name array");
+        ERROR_PRINT("Cannot allocate rocEvent name array");
         free(smiEvents);
         return -ENOMEM;
     }
@@ -1919,7 +1919,7 @@ rocmon_getEventsOfGpu(int gpuIdx, EventList_rocm_t* list)
     EventList_rocm_t tmpList = (EventList_rocm_t) malloc(sizeof(EventList_rocm));
     if (tmpList == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate event list");
+        ERROR_PRINT("Cannot allocate event list");
         return -ENOMEM;
     }
     
@@ -1938,7 +1938,7 @@ rocmon_getEventsOfGpu(int gpuIdx, EventList_rocm_t* list)
     tmpList->events = (Event_rocm_t*) malloc(tmpList->numEvents * sizeof(Event_rocm_t));
     if (tmpList->events == NULL)
     {
-        ERROR_PLAIN_PRINT("Cannot allocate events for event list");
+        ERROR_PRINT("Cannot allocate events for event list");
         free(tmpList);
         return -ENOMEM;
     }

--- a/src/rocmon.c
+++ b/src/rocmon.c
@@ -143,7 +143,7 @@ static int
 _smi_wrapper_pci_throughput_get(int deviceId, RocmonSmiEvent* event, RocmonEventResult* result)
 {
     uint64_t value;
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, _smi_wrapper_pci_throughput_get(%d, %d), deviceId, event->extra);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "_smi_wrapper_pci_throughput_get(%d, %d)", deviceId, event->extra);
     // Internal variant: 0 for sent, 1 for received bytes and 2 for max packet size
     if (event->extra == 0)       RSMI_CALL(rsmi_dev_pci_throughput_get, (deviceId, &value, NULL, NULL), return -1);
     else if (event->extra == 1)  RSMI_CALL(rsmi_dev_pci_throughput_get, (deviceId, NULL, &value, NULL), return -1);
@@ -345,14 +345,14 @@ _smi_wrapper_compute_process_info_get(int deviceId, RocmonSmiEvent* event, Rocmo
 static int
 _rocmon_link_libraries()
 {
-    #define DLSYM_AND_CHECK( dllib, name ) name##_ptr = dlsym( dllib, #name ); if ( dlerror() != NULL ) { ERROR_PRINT(Failed to link  #name); return -1; }
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Linking AMD ROCMm libraries);
+    #define DLSYM_AND_CHECK( dllib, name ) name##_ptr = dlsym( dllib, #name ); if ( dlerror() != NULL ) { ERROR_PRINT("Failed to link " #name); return -1; }
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Linking AMD ROCMm libraries");
   
     // Need to link in the ROCm HSA libraries
     dl_hsa_lib = dlopen("libhsa-runtime64.so", RTLD_NOW | RTLD_GLOBAL);
     if (!dl_hsa_lib)
     {
-        ERROR_PRINT(ROCm HSA library libhsa-runtime64.so not found: %s, dlerror());
+        ERROR_PRINT("ROCm HSA library libhsa-runtime64.so not found: %s", dlerror());
         return -1;
     }
 
@@ -363,7 +363,7 @@ _rocmon_link_libraries()
         dl_profiler_lib = dlopen("librocprofiler64.so.1", RTLD_NOW | RTLD_GLOBAL);
         if (!dl_profiler_lib)
         {
-            ERROR_PRINT(Rocprofiler library librocprofiler64.so not found: %s, dlerror());
+            ERROR_PRINT("Rocprofiler library librocprofiler64.so not found: %s", dlerror());
             return -1;
         }
     }
@@ -372,7 +372,7 @@ _rocmon_link_libraries()
     dl_rsmi_lib = dlopen("librocm_smi64.so", RTLD_NOW | RTLD_GLOBAL);
     if (!dl_rsmi_lib)
     {
-        ERROR_PRINT(ROCm SMI library librocm_smi64.so not found: %s, dlerror());
+        ERROR_PRINT("ROCm SMI library librocm_smi64.so not found: %s", dlerror());
         return -1;
     }
 
@@ -417,7 +417,7 @@ _rocmon_link_libraries()
     DLSYM_AND_CHECK(dl_rsmi_lib, rsmi_dev_overdrive_level_get);
     DLSYM_AND_CHECK(dl_rsmi_lib, rsmi_dev_ecc_count_get);
     DLSYM_AND_CHECK(dl_rsmi_lib, rsmi_compute_process_info_get);
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Linking AMD ROCMm libraries done);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Linking AMD ROCMm libraries done");
     return 0;
 }
 
@@ -464,7 +464,7 @@ _rocmon_iterate_info_callback_add(const rocprofiler_info_data_t info, void* data
 {
     iterate_info_cb_arg* arg = (iterate_info_cb_arg*) data;
 
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, _rocmon_iterate_info_callback_add);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "_rocmon_iterate_info_callback_add");
     if (likwid_rocmon_verbosity == DEBUGLEV_DEVELOP)
     {
         _rocmon_print_rocprofiler_info_data(info);
@@ -472,14 +472,14 @@ _rocmon_iterate_info_callback_add(const rocprofiler_info_data_t info, void* data
     // Check info kind
     if (info.kind != ROCPROFILER_INFO_KIND_METRIC)
     {
-        ERROR_PRINT(Wrong info kind %u, info.kind);
+        ERROR_PRINT("Wrong info kind %u", info.kind);
         return HSA_STATUS_ERROR;
     }
 
     // Check index
     if (arg->currIndex >= arg->device->numRocMetrics)
     {
-        ERROR_PRINT(Metric index out of bounds: %d, arg->currIndex);
+        ERROR_PRINT("Metric index out of bounds: %d", arg->currIndex);
         return HSA_STATUS_ERROR;
     }
 
@@ -525,7 +525,7 @@ _rocmon_iterate_agents_callback(hsa_agent_t agent, void* argv)
     {
         return HSA_STATUS_SUCCESS;
     }
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Initializing agent %d, gpuIndex);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initializing agent %d", gpuIndex);
 
     // Add agent to context
     RocmonDevice *device = &arg->context->devices[gpuIndex];
@@ -540,7 +540,7 @@ _rocmon_iterate_agents_callback(hsa_agent_t agent, void* argv)
     // Get number of available metrics
     device->numRocMetrics = 0;
     ROCM_CALL(rocprofiler_iterate_info, (&agent, ROCPROFILER_INFO_KIND_METRIC, _rocmon_iterate_info_callback_count, device), return HSA_STATUS_ERROR);
-    ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, RocProfiler provides %d events, device->numRocMetrics);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, "RocProfiler provides %d events", device->numRocMetrics);
 
     // workaround for bug in ROCm 5.4.0
     if(device->numRocMetrics == 0) {
@@ -552,14 +552,14 @@ _rocmon_iterate_agents_callback(hsa_agent_t agent, void* argv)
     device->rocMetrics = (rocprofiler_info_data_t*) malloc(device->numRocMetrics * sizeof(rocprofiler_info_data_t));
     if (device->rocMetrics == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate set of rocMetrics);
+        ERROR_PLAIN_PRINT("Cannot allocate set of rocMetrics");
         return HSA_STATUS_ERROR;
     }
 
     // Initialize SMI events map
     if (init_map(&device->smiMetrics, MAP_KEY_TYPE_STR, 0, &free) < 0)
     {
-        ERROR_PLAIN_PRINT(Cannot init smiMetrics map);
+        ERROR_PLAIN_PRINT("Cannot init smiMetrics map");
         return HSA_STATUS_ERROR;
     }
 
@@ -568,7 +568,7 @@ _rocmon_iterate_agents_callback(hsa_agent_t agent, void* argv)
         .device = device,
         .currIndex = 0,
     };
-    ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, Read %d RocProfiler events for device %d, device->numRocMetrics, device->deviceId);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, "Read %d RocProfiler events for device %d", device->numRocMetrics, device->deviceId);
 
     // If the call fails with agent, call rocprofiler_iterate_info without agent
     if(noAgent)
@@ -595,7 +595,7 @@ _rocmon_parse_eventstring(const char* eventString, GroupInfo* group)
         err = perfgroup_customGroup(eventString, group);
         if (err < 0)
         {
-            ERROR_PRINT(Cannot transform %s to performance group, eventString);
+            ERROR_PRINT("Cannot transform %s to performance group", eventString);
             return err;
         }
     }
@@ -605,17 +605,17 @@ _rocmon_parse_eventstring(const char* eventString, GroupInfo* group)
         err = perfgroup_readGroup(config->groupPath, "amd_gpu", eventString, group);
         if (err == -EACCES)
         {
-            ERROR_PRINT(Access to performance group %s not allowed, eventString);
+            ERROR_PRINT("Access to performance group %s not allowed", eventString);
             return err;
         }
         else if (err == -ENODEV)
         {
-            ERROR_PRINT(Performance group %s only available with deactivated HyperThreading, eventString);
+            ERROR_PRINT("Performance group %s only available with deactivated HyperThreading", eventString);
             return err;
         }
         if (err < 0)
         {
-            ERROR_PRINT(Cannot read performance group %s, eventString);
+            ERROR_PRINT("Cannot read performance group %s", eventString);
             return err;
         }
     }
@@ -838,7 +838,7 @@ _rocmon_smi_add_event_to_device(RocmonDevice* device, const char* funcname, Rocm
             ret = get_smap_by_key(device->smiMetrics, event->name, (void**)&existingEvent);
             if (ret < 0)
             {
-                ERROR_PRINT(Failed to find previous instance for event %s, event->name);
+                ERROR_PRINT("Failed to find previous instance for event %s", event->name);
                 return -1;
             }
 
@@ -856,7 +856,7 @@ _rocmon_smi_add_event_to_device(RocmonDevice* device, const char* funcname, Rocm
         RocmonSmiEvent* tmpEvent = (RocmonSmiEvent*) malloc(sizeof(RocmonSmiEvent));
         if (tmpEvent == NULL)
         {
-            ERROR_PRINT(Failed to allocate memory for SMI event in device list %s, event->name);
+            ERROR_PRINT("Failed to allocate memory for SMI event in device list %s", event->name);
             return -ENOMEM;
         }
 
@@ -972,7 +972,7 @@ _rocmon_smi_get_functions(RocmonDevice* device)
         // Get function information
         //(*rsmi_func_iter_value_get_ptr)(iter_handle, &value);
         RSMI_CALL(rsmi_func_iter_value_get, (iter_handle, &value), {
-            ERROR_PRINT(Failed to get smi function value for device %d, device->deviceId);
+            ERROR_PRINT("Failed to get smi function value for device %d", device->deviceId);
             RSMI_CALL(rsmi_dev_supported_func_iterator_close, (&iter_handle), );
             return -1;
         });
@@ -981,7 +981,7 @@ _rocmon_smi_get_functions(RocmonDevice* device)
         ret = _rocmon_smi_get_function_variants(device, value.name, iter_handle);
         if (ret < 0)
         {
-            ERROR_PRINT(Failed to get smi function variants for device %d, device->deviceId);
+            ERROR_PRINT("Failed to get smi function variants for device %d", device->deviceId);
             RSMI_CALL(rsmi_dev_supported_func_iterator_close, (&iter_handle), );
             return -1;
         }
@@ -1022,7 +1022,7 @@ _rocmon_smi_add_event_to_map(char* name, RocmonSmiEventType type, char* smifunc,
         list = (RocmonSmiEventList*) malloc(sizeof(RocmonSmiEventList));
         if (list == NULL)
         {
-            ERROR_PRINT(Failed to allocate memory for SMI event list %s, name);
+            ERROR_PRINT("Failed to allocate memory for SMI event list %s", name);
             return -ENOMEM;
         }
         list->entries = NULL;
@@ -1037,7 +1037,7 @@ _rocmon_smi_add_event_to_map(char* name, RocmonSmiEventType type, char* smifunc,
     list->entries = (RocmonSmiEvent*) realloc(list->entries, list->numEntries * sizeof(RocmonSmiEvent));
     if (list->entries == NULL)
     {
-        ERROR_PRINT(Failed to allocate memory for SMI event %s, name);
+        ERROR_PRINT("Failed to allocate memory for SMI event %s", name);
         return -ENOMEM;
     }
 
@@ -1077,7 +1077,7 @@ _rocmon_smi_init_events()
     ret = init_map(&rocmon_context->smiEvents, MAP_KEY_TYPE_STR, 0, &_rcomon_smi_free_event_list);
     if (ret < 0)
     {
-        ERROR_PRINT(Failed to create map for ROCm SMI events);
+        ERROR_PRINT("Failed to create map for ROCm SMI events");
         return -1;
     }
 
@@ -1157,7 +1157,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     // Validate arguments
     if (numGpus <= 0)
     {
-        ERROR_PRINT(Number of gpus must be greater than 0 but only %d given, numGpus);
+        ERROR_PRINT("Number of gpus must be greater than 0 but only %d given", numGpus);
         return -EINVAL;
     }
     
@@ -1168,7 +1168,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     int ret = _rocmon_link_libraries();
     if (ret < 0)
     {
-	ERROR_PLAIN_PRINT(Failed to initialize libraries);
+	ERROR_PLAIN_PRINT("Failed to initialize libraries");
         return ret;
     }
 
@@ -1176,7 +1176,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     rocmon_context = (RocmonContext*) malloc(sizeof(RocmonContext));
     if (rocmon_context == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate Rocmon context);
+        ERROR_PLAIN_PRINT("Cannot allocate Rocmon context");
         return -ENOMEM;
     }
     rocmon_context->groups = NULL;
@@ -1187,34 +1187,34 @@ rocmon_init(int numGpus, const int* gpuIds)
     rocmon_context->numDevices = numGpus;
     if (rocmon_context->devices == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate set of GPUs);
+        ERROR_PLAIN_PRINT("Cannot allocate set of GPUs");
         free(rocmon_context);
         rocmon_context = NULL;
         return -ENOMEM;
     }
 
     // init hsa library
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Initializing HSA);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initializing HSA");
     ROCM_CALL(hsa_init, (),
     {
-        ERROR_PLAIN_PRINT(Failed to init hsa library);
+        ERROR_PLAIN_PRINT("Failed to init hsa library");
         goto rocmon_init_hsa_failed;
     });
 
     // init rocm smi library
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Initializing RSMI);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initializing RSMI");
     RSMI_CALL(rsmi_init, (0),
     {
-        ERROR_PLAIN_PRINT(Failed to init rocm_smi);
+        ERROR_PLAIN_PRINT("Failed to init rocm_smi");
         goto rocmon_init_rsmi_failed;
     });
 
     // Get hsa timestamp factor
     uint64_t frequency_hz;
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Getting HSA timestamp factor);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Getting HSA timestamp factor");
     ROCM_CALL(hsa_system_get_info, (HSA_SYSTEM_INFO_TIMESTAMP_FREQUENCY, &frequency_hz),
     {
-        ERROR_PLAIN_PRINT(Failed to get HSA timestamp factor);
+        ERROR_PLAIN_PRINT("Failed to get HSA timestamp factor");
         goto rocmon_init_info_agents_failed;
     });
     rocmon_context->hsa_timestamp_factor = (long double)1000000000 / (long double)frequency_hz;
@@ -1225,10 +1225,10 @@ rocmon_init(int numGpus, const int* gpuIds)
         .numGpus = numGpus,
         .gpuIds = gpuIds,
     };
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Iterating through %d available agents, numGpus);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Iterating through %d available agents", numGpus);
     ROCM_CALL(hsa_iterate_agents, (_rocmon_iterate_agents_callback, &arg),
     {
-        ERROR_PRINT(Error while iterating through available agents);
+        ERROR_PRINT("Error while iterating through available agents");
         goto rocmon_init_info_agents_failed;
     });
 
@@ -1238,7 +1238,7 @@ rocmon_init(int numGpus, const int* gpuIds)
     {
         if (_rocmon_smi_get_functions(&rocmon_context->devices[i]) < 0)
         {
-            ERROR_PRINT(Failed to get SMI functions for device %d, rocmon_context->devices[i].deviceId);
+            ERROR_PRINT("Failed to get SMI functions for device %d", rocmon_context->devices[i].deviceId);
             goto rocmon_init_info_agents_failed;
         }
     }
@@ -1270,7 +1270,7 @@ rocmon_finalize(void)
     {
         return;
     }
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Finalize LIKWID ROCMON);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Finalize LIKWID ROCMON");
 
     if (context)
     {
@@ -1312,11 +1312,11 @@ rocmon_finalize(void)
     }
 
     RSMI_CALL(rsmi_shut_down, (), {
-        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Shutdown SMI);
+        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Shutdown SMI");
         // fall through
     });
     ROCM_CALL(hsa_shut_down, (), {
-        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Shutdown HSA);
+        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Shutdown HSA");
         // fall through
     });
 }
@@ -1343,7 +1343,7 @@ rocmon_addEventSet(const char* eventString, int* gid)
         GroupInfo* tmpInfo = (GroupInfo*) realloc(rocmon_context->groups, (rocmon_context->numGroups+1) * sizeof(GroupInfo));
         if (tmpInfo == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate additional group);
+            ERROR_PLAIN_PRINT("Cannot allocate additional group");
             return -ENOMEM;
         }
         rocmon_context->groups = tmpInfo;
@@ -1367,7 +1367,7 @@ rocmon_addEventSet(const char* eventString, int* gid)
         RocmonEventResult* tmpResults = (RocmonEventResult*) malloc(numEvents * sizeof(RocmonEventResult));
         if (tmpResults == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate event results);
+            ERROR_PLAIN_PRINT("Cannot allocate event results");
             return -ENOMEM;
         }
 
@@ -1375,7 +1375,7 @@ rocmon_addEventSet(const char* eventString, int* gid)
         RocmonEventResultList* tmpGroupResults = (RocmonEventResultList*) realloc(device->groupResults, (device->numGroupResults+1) * sizeof(RocmonEventResultList));
         if (tmpGroupResults == NULL)
         {
-            ERROR_PLAIN_PRINT(Cannot allocate new event group result list);
+            ERROR_PLAIN_PRINT("Cannot allocate new event group result list");
             return -ENOMEM;
         }
 
@@ -1397,7 +1397,7 @@ _rocmon_setupCounters_rocprofiler(RocmonDevice* device, const char** events, int
     // Close previous rocprofiler context
     if (device->context)
     {
-        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, Closing previous rocprofiler context);
+        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Closing previous rocprofiler context");
         ROCM_CALL(rocprofiler_close, (device->context), return -1);
     }
 
@@ -1411,14 +1411,14 @@ _rocmon_setupCounters_rocprofiler(RocmonDevice* device, const char** events, int
     rocprofiler_feature_t* features = (rocprofiler_feature_t*) malloc(numEvents * sizeof(rocprofiler_feature_t));
     if (features == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate feature list);
+        ERROR_PLAIN_PRINT("Cannot allocate feature list");
         return -ENOMEM;
     }
     for (int i = 0; i < numEvents; i++)
     {
         features[i].kind = ROCPROFILER_FEATURE_KIND_METRIC;
         features[i].name = events[i];
-        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, SETUP EVENT %d %s, i, events[i]);
+        ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "SETUP EVENT %d %s", i, events[i]);
     }
 
     // Free previous feature array if present
@@ -1462,7 +1462,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
     RocmonSmiEvent* activeEvents = (RocmonSmiEvent*) malloc(numEvents * sizeof(RocmonSmiEvent));
     if (activeEvents == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate active event list);
+        ERROR_PLAIN_PRINT("Cannot allocate active event list");
         return -ENOMEM;
     }
 
@@ -1482,7 +1482,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
             // Check if number fit in 'withoutBrackets'
             if (partlen - 2 > instanceNumLen)
             {
-                ERROR_PRINT(Instance number in '%s' is too large, event);
+                ERROR_PRINT("Instance number in '%s' is too large", event);
                 free(activeEvents);
                 return -EINVAL;
             }
@@ -1499,7 +1499,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
             char* endOfString = &withoutBrackets[partlen-2];
             if (endParsed != endOfString)
             {
-                ERROR_PRINT(Failed to parse instance number in '%s', event);
+                ERROR_PRINT("Failed to parse instance number in '%s'", event);
                 free(activeEvents);
                 return -EINVAL;
             }
@@ -1520,7 +1520,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
         ret = get_smap_by_key(device->smiMetrics, eventName, (void**)&metric);
         if (ret < 0)
         {
-            ERROR_PRINT(RSMI event '%s' not found for device %d, eventName, device->deviceId);
+            ERROR_PRINT("RSMI event '%s' not found for device %d", eventName, device->deviceId);
             free(activeEvents);
             return -EINVAL;
         }
@@ -1532,7 +1532,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
         // Check if event supports instances
         if (instance >= 0 && tmpEvent->type != ROCMON_SMI_EVENT_TYPE_INSTANCES)
         {
-            ERROR_PRINT(Instance number given but event '%s' does not support one, eventName);
+            ERROR_PRINT("Instance number given but event '%s' does not support one", eventName);
             free(activeEvents);
             return -EINVAL;
         }
@@ -1540,7 +1540,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
         // Check if event requires instances
         if (instance < 0 && tmpEvent->type == ROCMON_SMI_EVENT_TYPE_INSTANCES)
         {
-            ERROR_PRINT(No instance number given but event '%s' requires one, eventName);
+            ERROR_PRINT("No instance number given but event '%s' requires one", eventName);
             free(activeEvents);
             return -EINVAL;
         }
@@ -1548,7 +1548,7 @@ _rocmon_setupCounters_smi(RocmonDevice* device, const char** events, int numEven
         // Check if event has enough instances
         if (instance >= 0 && instance >= metric->instances)
         {
-            ERROR_PRINT(Instance %d seleced but event '%s' has only %d, instance, eventName, metric->instances);
+            ERROR_PRINT("Instance %d seleced but event '%s' has only %d", instance, eventName, metric->instances);
             free(activeEvents);
             return -EINVAL;
         }
@@ -1597,13 +1597,13 @@ rocmon_setupCounters(int gid)
     smiEvents = (const char**) malloc(group->nevents * sizeof(const char*));
     if (smiEvents == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate smiEvent name array);
+        ERROR_PLAIN_PRINT("Cannot allocate smiEvent name array");
         return -ENOMEM;
     }
     rocEvents = (const char**) malloc(group->nevents * sizeof(const char*));
     if (rocEvents == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate rocEvent name array);
+        ERROR_PLAIN_PRINT("Cannot allocate rocEvent name array");
         free(smiEvents);
         return -ENOMEM;
     }
@@ -1627,7 +1627,7 @@ rocmon_setupCounters(int gid)
         else
         {
             // Unknown event
-            ERROR_PRINT(Event '%s' has no prefix ('ROCP_' or 'RSMI_'), name);
+            ERROR_PRINT(""Event '%s' has no prefix ('ROCP_' or 'RSMI_'")", name);
             return -EINVAL;
         }
     }
@@ -1638,7 +1638,7 @@ rocmon_setupCounters(int gid)
         RocmonDevice* device = &rocmon_context->devices[i];
 
         // Add rocprofiler events
-        ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, SETUP ROCPROFILER WITH %d events, numRocEvents);
+        ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, "SETUP ROCPROFILER WITH %d events", numRocEvents);
         ret = _rocmon_setupCounters_rocprofiler(device, rocEvents, numRocEvents);
         if (ret < 0)
         {
@@ -1648,7 +1648,7 @@ rocmon_setupCounters(int gid)
         }
 
         // Add SMI events
-        ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, SETUP ROCM SMI WITH %d events, numSmiEvents);
+        ROCMON_DEBUG_PRINT(DEBUGLEV_INFO, "SETUP ROCM SMI WITH %d events", numSmiEvents);
         ret = _rocmon_setupCounters_smi(device, smiEvents, numSmiEvents);
         if (ret < 0)
         {
@@ -1919,7 +1919,7 @@ rocmon_getEventsOfGpu(int gpuIdx, EventList_rocm_t* list)
     EventList_rocm_t tmpList = (EventList_rocm_t) malloc(sizeof(EventList_rocm));
     if (tmpList == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate event list);
+        ERROR_PLAIN_PRINT("Cannot allocate event list");
         return -ENOMEM;
     }
     
@@ -1938,7 +1938,7 @@ rocmon_getEventsOfGpu(int gpuIdx, EventList_rocm_t* list)
     tmpList->events = (Event_rocm_t*) malloc(tmpList->numEvents * sizeof(Event_rocm_t));
     if (tmpList->events == NULL)
     {
-        ERROR_PLAIN_PRINT(Cannot allocate events for event list);
+        ERROR_PLAIN_PRINT("Cannot allocate events for event list");
         free(tmpList);
         return -ENOMEM;
     }

--- a/src/rocmon_marker.c
+++ b/src/rocmon_marker.c
@@ -863,7 +863,7 @@ rocmon_getCountOfRegion(int region, int gpu)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -886,7 +886,7 @@ rocmon_getTimeOfRegion(int region, int gpu)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -910,7 +910,7 @@ rocmon_getGpulistOfRegion(int region, int count, int* gpulist)
     int i;
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -933,7 +933,7 @@ rocmon_getGpusOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -948,7 +948,7 @@ rocmon_getMetricsOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -963,7 +963,7 @@ rocmon_getNumberOfRegions()
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     return rocmMarkerRegions;
@@ -974,7 +974,7 @@ rocmon_getGroupOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -989,7 +989,7 @@ rocmon_getTagOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return NULL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -1004,7 +1004,7 @@ rocmon_getEventsOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -1019,7 +1019,7 @@ rocmon_getResultOfRegionGpu(int region, int eventId, int gpuId)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -1049,7 +1049,7 @@ rocmon_getMetricOfRegionGpu(int region, int metricId, int gpuId)
     CounterList clist;
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
+        ERROR_PRINT("Rocmon module not properly initialized");
         return NAN;
     }
     if (region < 0 || region >= rocmMarkerRegions)

--- a/src/rocmon_marker.c
+++ b/src/rocmon_marker.c
@@ -485,7 +485,7 @@ rocmon_markerStartRegion(const char* regionTag)
 
     // Read counters (for all devices)
     TimerData timestamp;
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DETAIL, START REGION '%s' (group %d), regionTag, active_group);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DETAIL, "START REGION '%s' (group %d)", regionTag, active_group);
     timer_start(&timestamp);
     rocmon_readCounters();
 
@@ -544,7 +544,7 @@ rocmon_markerStopRegion(const char* regionTag)
 
     // Read counters (for all devices)
     TimerData timestamp;
-    ROCMON_DEBUG_PRINT(DEBUGLEV_DETAIL, STOP REGION '%s' (group %d), regionTag, active_group);
+    ROCMON_DEBUG_PRINT(DEBUGLEV_DETAIL, "STOP REGION '%s' (group %d)", regionTag, active_group);
     timer_stop(&timestamp);
     rocmon_readCounters();
 
@@ -863,7 +863,7 @@ rocmon_getCountOfRegion(int region, int gpu)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -886,7 +886,7 @@ rocmon_getTimeOfRegion(int region, int gpu)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -910,7 +910,7 @@ rocmon_getGpulistOfRegion(int region, int count, int* gpulist)
     int i;
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -933,7 +933,7 @@ rocmon_getGpusOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -948,7 +948,7 @@ rocmon_getMetricsOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -963,7 +963,7 @@ rocmon_getNumberOfRegions()
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     return rocmMarkerRegions;
@@ -974,7 +974,7 @@ rocmon_getGroupOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -989,7 +989,7 @@ rocmon_getTagOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return NULL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -1004,7 +1004,7 @@ rocmon_getEventsOfRegion(int region)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -1019,7 +1019,7 @@ rocmon_getResultOfRegionGpu(int region, int eventId, int gpuId)
 {
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return -EINVAL;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -1049,7 +1049,7 @@ rocmon_getMetricOfRegionGpu(int region, int metricId, int gpuId)
     CounterList clist;
     if (rocmMarkerResults == NULL)
     {
-        ERROR_PLAIN_PRINT(Rocmon module not properly initialized);
+        ERROR_PLAIN_PRINT("Rocmon module not properly initialized");
         return NAN;
     }
     if (region < 0 || region >= rocmMarkerRegions)
@@ -1086,7 +1086,7 @@ rocmon_getMetricOfRegionGpu(int region, int metricId, int gpuId)
     err = calc_metric(f, &clist, &result);
     if (err < 0)
     {
-        ERROR_PRINT(Cannot calculate formula %s, f);
+        ERROR_PRINT("Cannot calculate formula %s", f);
         return NAN;
     }
     destroy_clist(&clist);

--- a/src/sysFeatures.c
+++ b/src/sysFeatures.c
@@ -120,7 +120,7 @@ static int get_device_access(LikwidDevice_t device)
             return 0;
 #endif
         default:
-            ERROR_PRINT(get_device_access: Unimplemented device type: %d\n, device->type);
+            ERROR_PRINT("get_device_access: Unimplemented device type: %d\n", device->type);
             return -EPERM;
     }
 #if defined(__x86_64) || defined(__i386__)
@@ -147,7 +147,7 @@ int likwid_sysft_init(void)
         err = HPMinit();
         if (err < 0)
         {
-            ERROR_PRINT(Failed to initialize access to hardware registers);
+            ERROR_PRINT("Failed to initialize access to hardware registers");
             return err;
         }
     }
@@ -156,7 +156,7 @@ int likwid_sysft_init(void)
         err = likwid_sysft_init_x86_intel(&_feature_list);
         if (err < 0)
         {
-            ERROR_PRINT(Failed to initialize SysFeatures for Intel architecture);
+            ERROR_PRINT("Failed to initialize SysFeatures for Intel architecture");
             return err;
         }
     }
@@ -165,7 +165,7 @@ int likwid_sysft_init(void)
         err = likwid_sysft_init_x86_amd(&_feature_list);
         if (err < 0)
         {
-            ERROR_PRINT(Failed to initialize SysFeatures for AMD architecture);
+            ERROR_PRINT("Failed to initialize SysFeatures for AMD architecture");
             return err;
         }
     }
@@ -173,23 +173,23 @@ int likwid_sysft_init(void)
     err = likwid_sysft_init_cpufreq(&_feature_list);
     if (err < 0)
     {
-        ERROR_PRINT(Failed to initialize SysFeatures cpufreq module);
+        ERROR_PRINT("Failed to initialize SysFeatures cpufreq module");
         return err;
     }
 
     err = likwid_sysft_init_linux_numa_balancing(&_feature_list);
     if (err < 0)
     {
-        ERROR_PRINT(Failed to initialize SysFeatures numa_balancing module);
+        ERROR_PRINT("Failed to initialize SysFeatures numa_balancing module");
         return err;
     }
 #ifdef LIKWID_WITH_NVMON
     err = likwid_sysft_init_nvml(&_feature_list);
     if (err < 0)
-        DEBUG_PRINT(DEBUGLEV_INFO, Failed to initialize SysFeatures nvml module);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Failed to initialize SysFeatures nvml module");
 #endif
     
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Initialized %d features, _feature_list.num_features);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Initialized %d features", _feature_list.num_features);
     return 0;
 }
 
@@ -202,7 +202,7 @@ static int get_feature_index(const char* name)
     if (!strchr(name, '.'))
     {
         int out = -1;
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Features name has no dot -> compare with name);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Features name has no dot -> compare with name");
         for (int i = 0; i < _feature_list.num_features; i++)
         {
             if (strncmp(name, _feature_list.features[i].name, strlen(_feature_list.features[i].name)) == 0)
@@ -213,7 +213,7 @@ static int get_feature_index(const char* name)
                 }
                 else
                 {
-                    ERROR_PRINT(Feature name '%s' matches multiple features, name);
+                    ERROR_PRINT("Feature name '%s' matches multiple features", name);
                     return -EINVAL;
                 }
             }
@@ -225,7 +225,7 @@ static int get_feature_index(const char* name)
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Features name contains dot -> compare with category.name);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Features name contains dot -> compare with category.name");
         for (int i = 0; i < _feature_list.num_features; i++)
         {
             int featlen = strlen(_feature_list.features[i].name) + strlen(_feature_list.features[i].category) + 2;
@@ -237,7 +237,7 @@ static int get_feature_index(const char* name)
             }
         }
     }
-    ERROR_PRINT(SysFeatures modules does not provide a feature called %s, name);
+    ERROR_PRINT("SysFeatures modules does not provide a feature called %s", name);
     return -ENOTSUP;
 }
 
@@ -249,35 +249,35 @@ int likwid_sysft_getByName(const char* name, const LikwidDevice_t device, char**
     _SysFeature *f = NULL;
     if ((!name) || (!device) || (!value))
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Invalid inputs to sysFeatures_getByName);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Invalid inputs to sysFeatures_getByName");
         return -EINVAL;
     }
     if (device->type == DEVICE_TYPE_INVALID)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Invalid device type);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Invalid device type");
         return -EINVAL;
     }
     int idx = get_feature_index(name);
     if (idx < 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Failed to get index for %s, name);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Failed to get index for %s", name);
         return -EINVAL;
     }
     f = &_feature_list.features[idx];
     if ((!f) || (!f->getter))
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, No feature %s or no support to read current state, name);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "No feature %s or no support to read current state", name);
         return -EINVAL;
     }
     if (f->type != device->type)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Feature %s has a different type than device, name);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Feature %s has a different type than device", name);
         return -EINVAL;
     }
     err = get_device_access(device);
     if (err < 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Failed to get access to device);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Failed to get access to device");
         return err;
     }
     err = f->getter(device, value);

--- a/src/sysFeatures_amd.c
+++ b/src/sysFeatures_amd.c
@@ -51,7 +51,7 @@ int likwid_sysft_init_x86_amd(_SysFeatureList* out)
     int err = likwid_sysft_init_generic(amd_arch_features, out);
     if (err < 0)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Failed to init general x86 HWFeatures);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Failed to init general x86 HWFeatures");
     }
     else
     {
@@ -60,7 +60,7 @@ int likwid_sysft_init_x86_amd(_SysFeatureList* out)
     err = likwid_sysft_init_amd_rapl(out);
     if (err < 0)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Failed to init AMD RAPL HWFeatures);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Failed to init AMD RAPL HWFeatures");
     }
     else
     {
@@ -69,7 +69,7 @@ int likwid_sysft_init_x86_amd(_SysFeatureList* out)
     err = likwid_sysft_init_amd_hsmp(out);
     if (err < 0)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Failed to init AMD HSMP HWFeatures);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Failed to init AMD HSMP HWFeatures");
     }
     else
     {
@@ -86,7 +86,7 @@ static int amd_cpu_register_access_test()
     if (err < 0)
     {
         errno = -err;
-        ERROR_PRINT(Failed to initialize configuration);
+        ERROR_PRINT("Failed to initialize configuration");
         return err;
     }
     config = get_configuration();

--- a/src/sysFeatures_amd_hsmp.c
+++ b/src/sysFeatures_amd_hsmp.c
@@ -428,7 +428,7 @@ static int amd_hsmp_dimm_temp_getter(LikwidDevice_t dev, uint32_t channel, bool 
     const double refresh_pre_scale = field32(range_raw, 3, 1) ? 2.0 : 1.0;
     if (field32(range_raw, 0, 3) != 0x1 && field32(range_raw, 0, 3) != 0x5)
     {
-        ERROR_PRINT(AMD HSMP: received invalid or unknown temperature range: %x, field32(range_raw, 0, 3));
+        ERROR_PRINT("AMD HSMP: received invalid or unknown temperature range: %x", field32(range_raw, 0, 3));
         return -EBADE;
     }
     const double temp_pre_scale = (field32(range_raw, 0, 3) == 0x1) ? 1.0 : 2.0;
@@ -613,7 +613,7 @@ static int amd_hsmp_sock_freq_limit_getter(LikwidDevice_t dev, bool show_reason,
     }
 
     if (reason)
-        ERROR_PRINT(Found unexpected bits in HSMP Freq Limit string: %04x, reason);
+        ERROR_PRINT("Found unexpected bits in HSMP Freq Limit string: %04x", reason);
 
     err = likwid_sysft_copystr(bdata(reasons), value);
     bdestroy(reasons);

--- a/src/sysFeatures_amd_rapl.c
+++ b/src/sysFeatures_amd_rapl.c
@@ -203,53 +203,53 @@ int likwid_sysft_init_amd_rapl(_SysFeatureList* out)
     if (err < 0)
     {
         errno = -err;
-        ERROR_PRINT(Failed to initialize configuration);
+        ERROR_PRINT("Failed to initialize configuration");
         return err;
     }
     config = get_configuration();
     if (config->daemonMode == ACCESSMODE_PERF)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, No AMD RAPL support with accessmode=perf_event);
+        DEBUG_PRINT(DEBUGLEV_INFO, "No AMD RAPL support with accessmode=perf_event");
         return 0;
     }
     if (amd_rapl_pkg_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register AMD RAPL PKG domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register AMD RAPL PKG domain");
         err = likwid_sysft_register_features(out, &amd_rapl_pkg_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, AMD RAPL domain PKG not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "AMD RAPL domain PKG not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, AMD RAPL domain PKG not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "AMD RAPL domain PKG not supported");
     }
     if (amd_rapl_core_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register AMD RAPL CORE domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register AMD RAPL CORE domain");
         err = likwid_sysft_register_features(out, &amd_rapl_core_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, AMD RAPL domain CORE not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "AMD RAPL domain CORE not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, AMD RAPL domain CORE not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "AMD RAPL domain CORE not supported");
     }
     if (amd_rapl_l3_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register AMD RAPL L3 domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register AMD RAPL L3 domain");
         err = likwid_sysft_register_features(out, &amd_rapl_l3_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, AMD RAPL domain L3 not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "AMD RAPL domain L3 not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, AMD RAPL domain L3 not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "AMD RAPL domain L3 not supported");
     }
     return 0;
 }

--- a/src/sysFeatures_amd_thermal.c
+++ b/src/sysFeatures_amd_thermal.c
@@ -117,7 +117,7 @@ static int create_paths(void)
     DIR *k10temp_dir = opendir(k10temp_base);
     if (!k10temp_dir)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, %s not found. Not initializing k10temp);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "%s not found. Not initializing k10temp", k10temp_base);
         return -errno;
     }
 
@@ -187,7 +187,7 @@ static int create_paths(void)
         if (!hwmon_base_dir)
         {
             const int errno_save = errno;
-            DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, k10temp: Unable to read dir %s, hwmon_base);
+            DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "k10temp: Unable to read dir %s", hwmon_base);
             free_paths();
             return -errno_save;
         }
@@ -230,7 +230,7 @@ static int create_paths(void)
         if (!hwmon_dir)
         {
             const int errno_save = errno;
-            DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, k10temp: Unable to read dir %s, bdata(s->hwmon_path));
+            DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "k10temp: Unable to read dir %s", bdata(s->hwmon_path));
             free_paths();
             return -errno_save;
         }
@@ -300,7 +300,7 @@ static int create_paths(void)
                 {
                     /* If s->label is alreay set, we have encountered more then one non-CCD temperature.
                      * We only support one sensors per socket, so issue a warning but continue regardless. */
-                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, Found more than one non-Tccd. current=%s new=%s, bdata(s->label), label_string);
+                    DEBUG_PRINT(DEBUGLEV_ONLY_ERROR, "Found more than one non-Tccd. current=%s new=%s", bdata(s->label), label_string);
                     bdestroy(s->label);
                     bdestroy(s->temp_path);
                 }

--- a/src/sysFeatures_common.c
+++ b/src/sysFeatures_common.c
@@ -56,21 +56,21 @@ int likwid_sysft_register_features(_SysFeatureList *features, const _SysFeatureL
     for (int i = 0; i < in->num_features; i++)
     {
         _SysFeature *f = &in->features[i];
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Registering feature %s.%s, f->category, f->name);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Registering feature %s.%s", f->category, f->name);
         if (f->tester)
         {
             if (f->tester())
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Running test for feature %s.%s, f->category, f->name);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Running test for feature %s.%s", f->category, f->name);
                 int err = _add_to_feature_list(features, f);
                 if (err < 0)
                 {
-                    ERROR_PRINT(Failed to add HW feature %s.%s to feature list, f->category, f->name);
+                    ERROR_PRINT("Failed to add HW feature %s.%s to feature list", f->category, f->name);
                 }
             }
             else
             {
-                DEBUG_PRINT(DEBUGLEV_DEVELOP, Test function for feature %s.%s failed, f->category, f->name);
+                DEBUG_PRINT(DEBUGLEV_DEVELOP, "Test function for feature %s.%s failed", f->category, f->name);
             }
         }
         else
@@ -78,7 +78,7 @@ int likwid_sysft_register_features(_SysFeatureList *features, const _SysFeatureL
             int err = _add_to_feature_list(features, f);
             if (err < 0)
             {
-                ERROR_PRINT(Failed to add HW feature %s.%s to feature list, f->category, f->name);
+                ERROR_PRINT("Failed to add HW feature %s.%s to feature list", f->category, f->name);
             }
         }
     }
@@ -90,7 +90,7 @@ int likwid_sysft_init_generic(const _HWArchFeatures* infeatures, _SysFeatureList
     int err = topology_init();
     if (err < 0)
     {
-        ERROR_PRINT(Failed to initialize topology module);
+        ERROR_PRINT("Failed to initialize topology module");
         return err;
     }
     CpuInfo_t cpuinfo = get_cpuInfo();
@@ -100,7 +100,7 @@ int likwid_sysft_init_generic(const _HWArchFeatures* infeatures, _SysFeatureList
     {
         if ((unsigned)infeatures[c].family == cpuinfo->family && (unsigned)infeatures[c].model == cpuinfo->model)
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Using feature list for CPU family 0x%X and model 0x%X, cpuinfo->family, cpuinfo->model);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Using feature list for CPU family 0x%X and model 0x%X", cpuinfo->family, cpuinfo->model);
             feature_list = infeatures[c].features;
             break;
         }
@@ -108,7 +108,7 @@ int likwid_sysft_init_generic(const _HWArchFeatures* infeatures, _SysFeatureList
     if (!feature_list)
     {
         errno = ENOTSUP;
-        DEBUG_PRINT(DEBUGLEV_INFO, No architectural sysFeatures for family 0x%X and model 0x%X, cpuinfo->family, cpuinfo->model);
+        DEBUG_PRINT(DEBUGLEV_INFO, "No architectural sysFeatures for family 0x%X and model 0x%X", cpuinfo->family, cpuinfo->model);
         return -ENOTSUP;
     }
 
@@ -125,7 +125,7 @@ int likwid_sysft_uint64_to_string(uint64_t value, char** str)
     const int len = snprintf(s, sizeof(s), "%llu", value);
     if (len < 0)
     {
-        ERROR_PRINT(Conversion of uint64_t %lld failed: %s, value, strerror(errno));
+        ERROR_PRINT("Conversion of uint64_t %lld failed: %s", value, strerror(errno));
         return -errno;
     }
     char *newstr = realloc(*str, len+1);
@@ -155,7 +155,7 @@ int likwid_sysft_string_to_uint64(const char* str, uint64_t* value)
     uint64_t v = strtoull(str, &ptr, 0);
     if (v == 0 && errno != 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Conversion of string '%s' to uint64_t failed %d: %s, str, v, strerror(errno));
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Conversion of string '%s' to uint64_t failed %d: %s", str, v, strerror(errno));
         return -errno;
     }
     *value = v;
@@ -168,7 +168,7 @@ int likwid_sysft_double_to_string(double value, char **str)
     const int len = snprintf(s, sizeof(s), "%f", value);
     if (len < 0)
     {
-        ERROR_PRINT(Conversion of double %f failed: %s, value, strerror(errno));
+        ERROR_PRINT("Conversion of double %f failed: %s", value, strerror(errno));
         return -errno;
     }
     char* newstr = realloc(*str, len+1);
@@ -188,12 +188,12 @@ int likwid_sysft_string_to_double(const char* str, double *value)
     const double result = strtod(str, &endptr);
     if (!endptr)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Conversion of string '%s' to double failed: %s, str, strerror(errno));
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Conversion of string '%s' to double failed: %s", str, strerror(errno));
         return -errno;
     }
     if (errno != 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Conversion of string '%s' to double failed: %s, str, result, strerror(errno));
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Conversion of string '%s' to double failed: %s", str, result, strerror(errno));
         return -errno;
     }
     *value = result;

--- a/src/sysFeatures_cpufreq.c
+++ b/src/sysFeatures_cpufreq.c
@@ -98,7 +98,7 @@ static int cpufreq_sysfs_setter(const LikwidDevice_t device, const char* value, 
         fp = fopen(bdata(filename), "w");
         if (fp == NULL) {
             err = -errno;
-            ERROR_PRINT("Failed to open file '%s' for writing: %s", bdata(filename), strerror(errno))
+            ERROR_PRINT("Failed to open file '%s' for writing: %s", bdata(filename), strerror(errno));
         }
         else
         {
@@ -106,7 +106,7 @@ static int cpufreq_sysfs_setter(const LikwidDevice_t device, const char* value, 
             const size_t ret = fwrite(value, sizeof(char), vallen, fp);
             if (ret != (sizeof(char) * vallen))
             {
-                ERROR_PRINT("Failed to open file '%s' for writing: %s", bdata(filename), strerror(errno))
+                ERROR_PRINT("Failed to open file '%s' for writing: %s", bdata(filename), strerror(errno));
             }
             fclose(fp);
         }
@@ -418,7 +418,7 @@ int likwid_sysft_init_cpufreq(_SysFeatureList* out)
     int err = 0;
     if (cpufreq_intel_pstate_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Registering Intel Pstate knobs for cpufreq)
+        DEBUG_PRINT(DEBUGLEV_INFO, "Registering Intel Pstate knobs for cpufreq");
         err = likwid_sysft_register_features(out, &cpufreq_pstate_feature_list);
         if (err < 0)
         {
@@ -427,7 +427,7 @@ int likwid_sysft_init_cpufreq(_SysFeatureList* out)
     }
     else if (cpufreq_intel_cpufreq_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Registering Intel Cpufreq knobs for cpufreq)
+        DEBUG_PRINT(DEBUGLEV_INFO, "Registering Intel Cpufreq knobs for cpufreq");
         err = likwid_sysft_register_features(out, &cpufreq_intel_cpufreq_feature_list);
         if (err < 0)
         {
@@ -436,7 +436,7 @@ int likwid_sysft_init_cpufreq(_SysFeatureList* out)
     }
     else if (cpufreq_acpi_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Registering ACPI cpufreq knobs for cpufreq)
+        DEBUG_PRINT(DEBUGLEV_INFO, "Registering ACPI cpufreq knobs for cpufreq");
         likwid_sysft_register_features(out, &cpufreq_acpi_feature_list);
         if (err < 0)
         {
@@ -445,7 +445,7 @@ int likwid_sysft_init_cpufreq(_SysFeatureList* out)
     }
     else if (cpufreq_cppc_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Registering CPPC cpufreq knobs for cpufreq)
+        DEBUG_PRINT(DEBUGLEV_INFO, "Registering CPPC cpufreq knobs for cpufreq");
         likwid_sysft_register_features(out, &cpufreq_cppc_feature_list);
         if (err < 0)
         {
@@ -454,7 +454,7 @@ int likwid_sysft_init_cpufreq(_SysFeatureList* out)
     }
     else if (cpufreq_apple_cpufreq_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Registering Apple cpufreq knobs for cpufreq)
+        DEBUG_PRINT(DEBUGLEV_INFO, "Registering Apple cpufreq knobs for cpufreq");
         likwid_sysft_register_features(out, &cpufreq_apple_cpufreq_feature_list);
         if (err < 0)
         {
@@ -464,7 +464,7 @@ int likwid_sysft_init_cpufreq(_SysFeatureList* out)
 
     if (cpufreq_epp_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Registering Energy Performance Preference knobs for cpufreq)
+        DEBUG_PRINT(DEBUGLEV_INFO, "Registering Energy Performance Preference knobs for cpufreq");
         err = likwid_sysft_register_features(out, &cpufreq_epp_feature_list);
         if (err < 0)
         {
@@ -473,7 +473,7 @@ int likwid_sysft_init_cpufreq(_SysFeatureList* out)
     }
     if (cpufreq_scaling_driver_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Registering Scaling Driver knobs for cpufreq)
+        DEBUG_PRINT(DEBUGLEV_INFO, "Registering Scaling Driver knobs for cpufreq");
         err = likwid_sysft_register_features(out, &cpufreq_scaling_driver_feature_list);
         if (err < 0)
         {

--- a/src/sysFeatures_intel.c
+++ b/src/sysFeatures_intel.c
@@ -58,7 +58,7 @@ int likwid_sysft_init_x86_intel(_SysFeatureList* out)
     int err = likwid_sysft_init_generic(intel_arch_features, out);
     if (err < 0)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Failed to init general Intel HWFetures);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Failed to init general Intel HWFetures");
     }
     else
     {
@@ -67,7 +67,7 @@ int likwid_sysft_init_x86_intel(_SysFeatureList* out)
     err = likwid_sysft_init_intel_rapl(out);
     if (err < 0)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Failed to init Intel RAPL HWFetures);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Failed to init Intel RAPL HWFetures");
     }
     else
     {

--- a/src/sysFeatures_intel_rapl.c
+++ b/src/sysFeatures_intel_rapl.c
@@ -1046,21 +1046,21 @@ int likwid_sysft_init_intel_rapl(_SysFeatureList* out)
     if (err < 0)
     {
         errno = -err;
-        ERROR_PRINT(Failed to initialize configuration);
+        ERROR_PRINT("Failed to initialize configuration");
         return err;
     }
     config = get_configuration();
     if (config->daemonMode == ACCESSMODE_PERF)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, No Intel RAPL support with accessmode=perf_event);
+        DEBUG_PRINT(DEBUGLEV_INFO, "No Intel RAPL support with accessmode=perf_event");
         return 0;
     }
     if (intel_rapl_pkg_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register Intel RAPL PKG domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register Intel RAPL PKG domain");
         if (intel_rapl_pkg_limit_test_lock() > 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL PKG domain locked);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL PKG domain locked");
             for (int i = 0; i < intel_rapl_pkg_feature_list.num_features; i++)
             {
                 intel_rapl_pkg_feature_list.features[i].setter = NULL;
@@ -1069,19 +1069,19 @@ int likwid_sysft_init_intel_rapl(_SysFeatureList* out)
         err = likwid_sysft_register_features(out, &intel_rapl_pkg_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PKG not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PKG not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PKG not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PKG not supported");
     }
     if (intel_rapl_dram_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register Intel RAPL DRAM domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register Intel RAPL DRAM domain");
         if (intel_rapl_dram_limit_test_lock() > 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL DRAM domain locked);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL DRAM domain locked");
             for (int i = 0; i < intel_rapl_dram_feature_list.num_features; i++)
             {
                 intel_rapl_dram_feature_list.features[i].setter = NULL;
@@ -1090,19 +1090,19 @@ int likwid_sysft_init_intel_rapl(_SysFeatureList* out)
         err = likwid_sysft_register_features(out, &intel_rapl_dram_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain DRAM not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain DRAM not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain DRAM not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain DRAM not supported");
     }
     if (intel_rapl_pp0_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register Intel RAPL PP0 domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register Intel RAPL PP0 domain");
         if (intel_rapl_pp0_limit_test_lock() > 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL PP0 domain locked);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL PP0 domain locked");
             for (int i = 0; i < intel_rapl_pp0_feature_list.num_features; i++)
             {
                 intel_rapl_pp0_feature_list.features[i].setter = NULL;
@@ -1111,19 +1111,19 @@ int likwid_sysft_init_intel_rapl(_SysFeatureList* out)
         err = likwid_sysft_register_features(out, &intel_rapl_pp0_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PP0 not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PP0 not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PP0 not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PP0 not supported");
     }
     if (intel_rapl_pp1_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register Intel RAPL PP1 domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register Intel RAPL PP1 domain");
         if (intel_rapl_pp1_limit_test_lock() > 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL PP1 domain locked);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL PP1 domain locked");
             for (int i = 0; i < intel_rapl_pp1_feature_list.num_features; i++)
             {
                 intel_rapl_pp1_feature_list.features[i].setter = NULL;
@@ -1132,19 +1132,19 @@ int likwid_sysft_init_intel_rapl(_SysFeatureList* out)
         err = likwid_sysft_register_features(out, &intel_rapl_pp1_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PP1 not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PP1 not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PP1 not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PP1 not supported");
     }
     if (intel_rapl_psys_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register Intel RAPL PSYS domain);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register Intel RAPL PSYS domain");
         if (intel_rapl_psys_limit_test_lock() > 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL PSYS domain locked);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL PSYS domain locked");
             for (int i = 0; i < intel_rapl_psys_feature_list.num_features; i++)
             {
                 intel_rapl_psys_feature_list.features[i].setter = NULL;
@@ -1153,12 +1153,12 @@ int likwid_sysft_init_intel_rapl(_SysFeatureList* out)
         err = likwid_sysft_register_features(out, &intel_rapl_psys_feature_list);
         if (err < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PSYS not supported);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PSYS not supported");
         }
     }
     else
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Intel RAPL domain PSYS not supported);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Intel RAPL domain PSYS not supported");
     }
     return 0;
 }

--- a/src/sysFeatures_intel_turbo.c
+++ b/src/sysFeatures_intel_turbo.c
@@ -45,7 +45,7 @@ static int intel_cpu_turbo_test(void)
     CPUID(eax, ebx, ecx, edx);
     if (field32(ecx, 7, 1) == 0)
     {
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Intel SpeedStep not supported by architecture);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Intel SpeedStep not supported by architecture");
         return 0;
     }
 

--- a/src/sysFeatures_linux_numa_balancing.c
+++ b/src/sysFeatures_linux_numa_balancing.c
@@ -52,7 +52,7 @@ static int numa_balancing_procfs_getter(const LikwidDevice_t device, char** valu
         return -EINVAL;
     }
     bstring filename = bformat("/proc/sys/kernel/%s", sysfsfile);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Reading file %s, bdata(filename));
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Reading file %s", bdata(filename));
 #pragma GCC diagnostic ignored "-Wnonnull"
     if (!access(bdata(filename), R_OK))
     {
@@ -105,7 +105,7 @@ static int numa_balancing_test(void)
     {
         return 1;
     }
-    DEBUG_PRINT(DEBUGLEV_INFO, NUMA balancing not available. System has only a single NUMA domain);
+    DEBUG_PRINT(DEBUGLEV_INFO, "NUMA balancing not available. System has only a single NUMA domain");
     return 0;
 }
 
@@ -183,7 +183,7 @@ int likwid_sysft_init_linux_numa_balancing(_SysFeatureList* out)
 {
     if (numa_balancing_test())
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, Register OS NUMA balancing);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Register OS NUMA balancing");
         return likwid_sysft_register_features(out, &numa_balancing_feature_list);
     }
     return 0;

--- a/src/sysFeatures_list.c
+++ b/src/sysFeatures_list.c
@@ -41,14 +41,14 @@ int likwid_sysft_add_to_feature_list(LikwidSysFeatureList *list, const LikwidSys
 {
     if ((!list) || (!feature))
     {
-        ERROR_PRINT(Invalid arguments for add_to_feature_list);
+        ERROR_PRINT("Invalid arguments for add_to_feature_list");
         return -EINVAL;
     }
 
     LikwidSysFeature* flist = realloc(list->features, (list->num_features + 1) * sizeof(LikwidSysFeature));
     if (!flist)
     {
-        ERROR_PRINT(Cannot allocate space for extended feature list);
+        ERROR_PRINT("Cannot allocate space for extended feature list");
         return -ENOMEM;
     }
     list->features = flist;
@@ -86,14 +86,14 @@ int likwid_sysft_merge_feature_lists(LikwidSysFeatureList *inout, const LikwidSy
 {
     if ((!inout) || (!in))
     {
-        ERROR_PRINT(Invalid arguments for merge_feature_lists);
+        ERROR_PRINT("Invalid arguments for merge_feature_lists");
         return -EINVAL;
     }
 
     LikwidSysFeature *flist = realloc(inout->features, (inout->num_features + in->num_features) * sizeof(LikwidSysFeature));
     if (!flist)
     {
-        ERROR_PRINT(Cannot allocate space for extended feature list);
+        ERROR_PRINT("Cannot allocate space for extended feature list");
         return -ENOMEM;
     }
     inout->features = flist;
@@ -129,14 +129,14 @@ int _add_to_feature_list(_SysFeatureList *list, const _SysFeature* feature)
 {
     if ((!list) || (!feature))
     {
-        ERROR_PRINT(Invalid arguments for _add_to_feature_list);
+        ERROR_PRINT("Invalid arguments for _add_to_feature_list");
         return -EINVAL;
     }
 
     _SysFeature* flist = realloc(list->features, (list->num_features + 1) * sizeof(_SysFeature));
     if (!flist)
     {
-        ERROR_PRINT(Cannot allocate space for extended feature list);
+        ERROR_PRINT("Cannot allocate space for extended feature list");
         return -ENOMEM;
     }
     list->features = flist;
@@ -160,14 +160,14 @@ int _merge_feature_lists(_SysFeatureList *inout, const _SysFeatureList *in)
 {
     if ((!inout) || (!in))
     {
-        ERROR_PRINT(Invalid arguments for _merge_feature_lists);
+        ERROR_PRINT("Invalid arguments for _merge_feature_lists");
         return -EINVAL;
     }
 
     _SysFeature* flist = realloc(inout->features, (inout->num_features + in->num_features) * sizeof(_SysFeature));
     if (!flist)
     {
-        ERROR_PRINT(Cannot allocate space for extended feature list);
+        ERROR_PRINT("Cannot allocate space for extended feature list");
         return -ENOMEM;
     }
     inout->features = flist;
@@ -205,7 +205,7 @@ int likwid_sysft_internal_to_external_feature_list(const _SysFeatureList *inlist
 {
     if ((!inlist) || (!outlist))
     {
-        ERROR_PRINT(Invalid arguments for internal_to_external_feature_list);
+        ERROR_PRINT("Invalid arguments for internal_to_external_feature_list");
         return -EINVAL;
     }
     outlist->num_features = 0;

--- a/src/sysFeatures_nvml.c
+++ b/src/sysFeatures_nvml.c
@@ -50,7 +50,7 @@
     do {                                                                \
         const char *err = dlerror();                                    \
         if (err) {                                                      \
-            ERROR_PRINT(Error: dlsym on symbol '%s' failed with error: %s, #name, err); \
+            ERROR_PRINT("Error: dlsym on symbol '%s' failed with error: %s", #name, err); \
             return -EINVAL;                                             \
         }                                                               \
     } while (0)
@@ -59,7 +59,7 @@
     do {                                                \
         nvmlReturn_t s = (*func##_ptr)(__VA_ARGS__);    \
         if (s != NVML_SUCCESS) {                        \
-            ERROR_PRINT(Error: function %s failed with error: '%s' (nvmlReturn=%d).\n, #func, nvmlErrorString_ptr(s), s);   \
+            ERROR_PRINT("Error: function %s failed with error: '%s' (nvmlReturn=%d).", #func, nvmlErrorString_ptr(s), s);   \
             return -EPERM;                              \
         }                                               \
     } while (0)
@@ -156,7 +156,7 @@ int likwid_sysft_init_nvml(_SysFeatureList *list)
 
     if (!dl_nvml)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, dlopen(libnvidia-ml.so) failed: %s, dlerror());
+        DEBUG_PRINT(DEBUGLEV_INFO, "dlopen(libnvidia-ml.so) failed: %s", dlerror());
         return -ELIBACC;
     }
 
@@ -217,7 +217,7 @@ int likwid_sysft_init_nvml(_SysFeatureList *list)
     if (nverr != NVML_SUCCESS)
     {
         dlclose(dl_nvml);
-        ERROR_PRINT(nvmlInit_v2() failed: %s, nvmlErrorString_ptr(nverr));
+        ERROR_PRINT("nvmlInit_v2() failed: %s", nvmlErrorString_ptr(nverr));
         return -EPERM;
     }
 

--- a/src/timer.c
+++ b/src/timer.c
@@ -470,7 +470,7 @@ timer_printCycles( const TimerData* time )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return _timer_printCycles(time);
@@ -483,7 +483,7 @@ timer_print( const TimerData* time )
     uint64_t cycles;
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return _timer_print(time);
@@ -494,7 +494,7 @@ timer_getCpuClock( void )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return cpuClock;
@@ -513,13 +513,13 @@ timer_getCpuClockCurrent( int cpu_id )
     sprintf(buff, "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", cpu_id);
     if (access(buff, R_OK))
     {
-        ERROR_PRINT(File %s not readable, buff);
+        ERROR_PRINT("File %s not readable", buff);
         return clock;
     }
     sprintf(cmd, "cat %s", buff);
     if ( !(fpipe = (FILE*)popen(cmd,"r")) )
     {  // If fpipe is NULL
-        ERROR_PRINT(Problems reading cpu frequency of CPU %d, cpu_id);
+        ERROR_PRINT("Problems reading cpu frequency of CPU %d", cpu_id);
         return clock;
     }
 
@@ -537,7 +537,7 @@ timer_getCycleClock( void )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return cyclesClock;
@@ -548,7 +548,7 @@ timer_getBaseline( void )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return baseline;
@@ -559,7 +559,7 @@ timer_start( TimerData* time )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return;
     }
     _timer_start(time);
@@ -570,7 +570,7 @@ timer_stop( TimerData* time )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return;
     }
     _timer_stop(time);
@@ -610,7 +610,7 @@ timer_finalize(void)
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT(Timer module not properly initialized);
+        ERROR_PLAIN_PRINT("Timer module not properly initialized");
         return;
     }
     baseline = 0ULL;

--- a/src/timer.c
+++ b/src/timer.c
@@ -470,7 +470,7 @@ timer_printCycles( const TimerData* time )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return _timer_printCycles(time);
@@ -483,7 +483,7 @@ timer_print( const TimerData* time )
     uint64_t cycles;
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return _timer_print(time);
@@ -494,7 +494,7 @@ timer_getCpuClock( void )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return cpuClock;
@@ -537,7 +537,7 @@ timer_getCycleClock( void )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return cyclesClock;
@@ -548,7 +548,7 @@ timer_getBaseline( void )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return 0ULL;
     }
     return baseline;
@@ -559,7 +559,7 @@ timer_start( TimerData* time )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return;
     }
     _timer_start(time);
@@ -570,7 +570,7 @@ timer_stop( TimerData* time )
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return;
     }
     _timer_stop(time);
@@ -610,7 +610,7 @@ timer_finalize(void)
 {
     if (timer_initialized != 1)
     {
-        ERROR_PLAIN_PRINT("Timer module not properly initialized");
+        ERROR_PRINT("Timer module not properly initialized");
         return;
     }
     baseline = 0ULL;

--- a/src/topology.c
+++ b/src/topology.c
@@ -1121,7 +1121,7 @@ topology_setName(void)
 
             if (cpuid_info.isIntel)
             {
-                ERROR_PLAIN_PRINT("Netburst architecture is not supported");
+                ERROR_PRINT("Netburst architecture is not supported");
                 err = -EFAULT;
                 break;
             }
@@ -1530,7 +1530,7 @@ topology_init(void)
 
     if (init_configuration())
     {
-        ERROR_PLAIN_PRINT("Cannot initialize configuration module to check for topology file name");
+        ERROR_PRINT("Cannot initialize configuration module to check for topology file name");
         return EXIT_FAILURE;
     }
 

--- a/src/topology.c
+++ b/src/topology.c
@@ -275,7 +275,7 @@ readTopologyFile(const char* filename, cpu_set_t cpuSet)
     fp = fopen(filename, "r");
     if (!fp)
     {
-        ERROR_PRINT(Failed to open topology file %s, filename);
+        ERROR_PRINT("Failed to open topology file %s", filename);
         return -errno;
     }
 
@@ -300,7 +300,7 @@ readTopologyFile(const char* filename, cpu_set_t cpuSet)
     }
     if (numHWThreads < 0 || numCacheLevels < 0 || numberOfNodes < 0)
     {
-        ERROR_PRINT(Cannot read topology information from file %s, filename);
+        ERROR_PRINT("Cannot read topology information from file %s", filename);
         fclose(fp);
         return -EINVAL;
     }
@@ -1121,7 +1121,7 @@ topology_setName(void)
 
             if (cpuid_info.isIntel)
             {
-                ERROR_PLAIN_PRINT(Netburst architecture is not supported);
+                ERROR_PLAIN_PRINT("Netburst architecture is not supported");
                 err = -EFAULT;
                 break;
             }
@@ -1472,7 +1472,7 @@ void topology_setupTree(void)
         if (!tree_nodeExists(cpuid_topology.topologyTree,
                     hwThreadPool[i].packageId))
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Adding socket %d, hwThreadPool[i].packageId);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding socket %d", hwThreadPool[i].packageId);
             tree_insertNode(cpuid_topology.topologyTree,
                     hwThreadPool[i].packageId);
         }
@@ -1486,7 +1486,7 @@ void topology_setupTree(void)
         currentNode = tree_getNode(currentNode, hwThreadPool[i].dieId);*/
         if (!tree_nodeExists(currentNode, hwThreadPool[i].coreId))
         {
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Adding core %d to socket %d, hwThreadPool[i].coreId, hwThreadPool[i].packageId);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding core %d to socket %d", hwThreadPool[i].coreId, hwThreadPool[i].packageId);
             tree_insertNode(currentNode, hwThreadPool[i].coreId);
         }
         currentNode = tree_getNode(currentNode, hwThreadPool[i].coreId);
@@ -1495,23 +1495,23 @@ void topology_setupTree(void)
             /*
                printf("WARNING: Thread already exists!\n");
                */
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, Adding hwthread %d at core %d on socket %d, hwThreadPool[i].apicId, hwThreadPool[i].coreId, hwThreadPool[i].packageId);
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "Adding hwthread %d at core %d on socket %d", hwThreadPool[i].apicId, hwThreadPool[i].coreId, hwThreadPool[i].packageId);
             tree_insertNode(currentNode, hwThreadPool[i].apicId);
         }
 
     }
     i = tree_countChildren(cpuid_topology.topologyTree);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Determine number of sockets. tree tells %d, i);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Determine number of sockets. tree tells %d", i);
     if (cpuid_topology.numSockets == 0)
         cpuid_topology.numSockets = i;
     currentNode = tree_getChildNode(cpuid_topology.topologyTree);
     i = tree_countChildren(currentNode);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Determine number of cores per socket. tree tells %d, i);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Determine number of cores per socket. tree tells %d", i);
     if (cpuid_topology.numCoresPerSocket == 0)
         cpuid_topology.numCoresPerSocket = i;
     currentNode = tree_getChildNode(currentNode);
     i = tree_countChildren(currentNode);
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, Determine number of hwthreads per cores. tree tells %d, i);
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "Determine number of hwthreads per cores. tree tells %d", i);
     if (cpuid_topology.numThreadsPerCore == 0)
         cpuid_topology.numThreadsPerCore = i;
     return;
@@ -1530,7 +1530,7 @@ topology_init(void)
 
     if (init_configuration())
     {
-        ERROR_PLAIN_PRINT(Cannot initialize configuration module to check for topology file name);
+        ERROR_PLAIN_PRINT("Cannot initialize configuration module to check for topology file name");
         return EXIT_FAILURE;
     }
 
@@ -1568,20 +1568,20 @@ standard_init:
         if (ret < 0)
         {
             errno = ret;
-            ERROR_PRINT(Failed to read cpuinfo);
+            ERROR_PRINT("Failed to read cpuinfo");
             cpuid_topology.activeHWThreads = 0;
             return ret;
         }
         ret = topology_setName();
         if (ret < 0)
         {
-            DEBUG_PRINT(DEBUGLEV_INFO, Cannot use machine-given CPU name);
+            DEBUG_PRINT(DEBUGLEV_INFO, "Cannot use machine-given CPU name");
         }
         ret = funcs.init_cpuFeatures();
         if (ret < 0)
         {
             errno = ret;
-            ERROR_PRINT(Failed to detect CPU features);
+            ERROR_PRINT("Failed to detect CPU features");
             free(cpuid_info.osname);
             memset(&cpuid_info, 0, sizeof(CpuInfo));
             memset(&cpuid_topology, 0, sizeof(CpuTopology));
@@ -1591,7 +1591,7 @@ standard_init:
         if (ret < 0)
         {
             errno = ret;
-            ERROR_PRINT(Failed to setup system topology);
+            ERROR_PRINT("Failed to setup system topology");
             free(cpuid_info.osname);
             free(cpuid_info.features);
             free(cpuid_topology.threadPool);
@@ -1611,7 +1611,7 @@ standard_init:
         if (ret < 0)
         {
             errno = ret;
-            ERROR_PRINT(Failed to setup cache topology);
+            ERROR_PRINT("Failed to setup cache topology");
             free(cpuid_info.osname);
             free(cpuid_topology.threadPool);
             memset(&cpuid_info, 0, sizeof(CpuInfo));
@@ -1716,7 +1716,7 @@ standard_init:
                     break;
             }
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, Setting up tree);
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "Setting up tree");
         topology_setupTree();
         sched_setaffinity(0, sizeof(cpu_set_t), &cpuSet);
     }
@@ -1737,7 +1737,7 @@ standard_init:
                 }
             }
         }
-        DEBUG_PRINT(DEBUGLEV_INFO, Reading topology information from %s, config.topologyCfgFileName);
+        DEBUG_PRINT(DEBUGLEV_INFO, "Reading topology information from %s", config.topologyCfgFileName);
         ret = readTopologyFile(config.topologyCfgFileName, cpuSet);
         if (ret < 0)
             goto standard_init;

--- a/src/topology_cpuid.c
+++ b/src/topology_cpuid.c
@@ -943,7 +943,7 @@ cpuid_init_cacheTopology(void)
             }
             break;
         default:
-            ERROR_PLAIN_PRINT("Processor is not supported");
+            ERROR_PRINT("Processor is not supported");
             break;
     }
 

--- a/src/topology_cpuid.c
+++ b/src/topology_cpuid.c
@@ -353,13 +353,13 @@ cpuid_init_cpuInfo(cpu_set_t cpuSet)
     {
         cpuid_topology.numHWThreads = cpus_in_set;
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, CPU-ID CpuInfo Family %d Model %d Stepping %d isIntel %d numHWThreads %d activeHWThreads %d,
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "CPU-ID CpuInfo Family %d Model %d Stepping %d isIntel %d numHWThreads %d activeHWThreads %d",
                             cpuid_info.family,
                             cpuid_info.model,
                             cpuid_info.stepping,
                             cpuid_info.isIntel,
                             cpuid_topology.numHWThreads,
-                            cpuid_topology.activeHWThreads)
+                            cpuid_topology.activeHWThreads);
     return 0;
 }
 
@@ -611,7 +611,7 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                 }
                 prevOffset = currOffset;
             }
-            DEBUG_PRINT(DEBUGLEV_DEVELOP, I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d], i, id,
+            DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
                                     hwThreadPool[id].coreId, hwThreadPool[id].packageId);
         }
@@ -668,7 +668,7 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                                 8-getBitFieldWidth(maxNumLogicalProcs),
                                 getBitFieldWidth(maxNumLogicalProcs));
 
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d], i, id,
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
                                     hwThreadPool[id].coreId, hwThreadPool[id].packageId);
                 }
@@ -719,7 +719,7 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                         extractBitField(hwThreadPool[i].apicId,
                                 8-getBitFieldWidth(maxNumCores),
                                 getBitFieldWidth(maxNumCores));
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d], i, id,
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
                                     hwThreadPool[id].coreId, hwThreadPool[id].packageId);
                 }
@@ -767,7 +767,7 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                     hwThreadPool[id].packageId =
                         extractBitField(hwThreadPool[i].apicId,
                                 (8-width), width);
-                    DEBUG_PRINT(DEBUGLEV_DEVELOP, I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d], i, id,
+                    DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
                                     hwThreadPool[id].coreId, hwThreadPool[id].packageId);
                 }
@@ -943,7 +943,7 @@ cpuid_init_cacheTopology(void)
             }
             break;
         default:
-            ERROR_PLAIN_PRINT(Processor is not supported);
+            ERROR_PLAIN_PRINT("Processor is not supported");
             break;
     }
 

--- a/src/topology_cuda.c
+++ b/src/topology_cuda.c
@@ -50,7 +50,7 @@
     do {                                                                \
         CUresult _status = (call);                                      \
         if (_status != CUDA_SUCCESS) {                                  \
-            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
+            ERROR_PRINT("Function %s failed with error %d", #call, _status); \
             handleerror;                                                \
         }                                                               \
     } while (0)
@@ -63,7 +63,7 @@
     do {                                                                \
         cudaError_t _status = (call);                                   \
         if (_status != cudaSuccess) {                                   \
-            ERROR_PRINT(Function %s failed with error %d, #call, _status); \
+            ERROR_PRINT("Function %s failed with error %d", #call, _status); \
             handleerror;                                                \
         }                                                               \
     } while (0)
@@ -111,13 +111,13 @@ cuda_topo_link_libraries(void)
     topo_dl_libcuda = dlopen("libcuda.so", RTLD_NOW | RTLD_GLOBAL);
     if (!topo_dl_libcuda)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcuda.so not found);
+        DEBUG_PRINT(DEBUGLEV_INFO, "CUDA library libcuda.so not found");
         return -1;
     }
     topo_dl_libcudart = dlopen("libcudart.so", RTLD_NOW | RTLD_GLOBAL | RTLD_NODELETE);
     if (!topo_dl_libcudart)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, CUDA library libcudart.so not found);
+        DEBUG_PRINT(DEBUGLEV_INFO, "CUDA library libcudart.so not found");
         return -1;
     }
     cuDeviceGetTopoPtr = DLSYM_AND_CHECK(topo_dl_libcuda, "cuDeviceGet");
@@ -145,7 +145,7 @@ cuda_topo_init(void)
     CUresult cuErr = (*cuInitTopoPtr)(0);
     if (cuErr != CUDA_SUCCESS)
     {
-        DEBUG_PRINT(DEBUGLEV_INFO, CUDA cannot be found and initialized (cuInit failed): %d, cuErr);
+        DEBUG_PRINT(DEBUGLEV_INFO, "CUDA cannot be found and initialized (cuInit failed): %d", cuErr);
         return -ENODEV;
     }
     return 0;
@@ -166,7 +166,7 @@ cuda_topo_get_numDevices(void)
     cuErr = (*cuDeviceGetCountTopoPtr)(&count);
     if (cuErr == CUDA_SUCCESS)
         return count;
-    DEBUG_PRINT(DEBUGLEV_INFO, uDeviceGetCount failed even though cuda_topo_init succeeded: %d, cuErr);
+    DEBUG_PRINT(DEBUGLEV_INFO, "uDeviceGetCount failed even though cuda_topo_init succeeded: %d", cuErr);
     return -ELIBACC;
 }
 
@@ -260,7 +260,7 @@ topology_cuda_init()
             cudaTopology.devices[i].name = calloc(NAME_LONG_MAX, sizeof(char));
             if (!cudaTopology.devices[i].name)
             {
-                ERROR_PRINT(Cannot allocate space for name of GPU %d, i);
+                ERROR_PRINT("Cannot allocate space for name of GPU %d", i);
                 ret = -ENOMEM;
                 goto topology_gpu_init_error;
             }
@@ -269,7 +269,7 @@ topology_cuda_init()
             cudaTopology.devices[i].short_name = calloc(NAME_SHORT_MAX, sizeof(char));
             if (!cudaTopology.devices[i].short_name)
             {
-                ERROR_PRINT(Cannot allocate space for short name of GPU %d, i);
+                ERROR_PRINT("Cannot allocate space for short name of GPU %d", i);
                 ret = -ENOMEM;
                 goto topology_gpu_init_error;
             }
@@ -348,7 +348,7 @@ get_cudaTopology(void)
     {
         return &cudaTopology;
     }
-    ERROR_PRINT(Cannot get CUDA topology before initialization);
+    ERROR_PRINT("Cannot get CUDA topology before initialization");
     return NULL;
 }
 

--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -358,7 +358,7 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
             cpuid_topology.numHWThreads = cpuid_topology.activeHWThreads;
         }
     }
-    DEBUG_PRINT(DEBUGLEV_DEVELOP, HWLOC CpuInfo Family %d Model %d Stepping %d Vendor 0x%X Part 0x%X isIntel %d numHWThreads %d activeHWThreads %d,
+    DEBUG_PRINT(DEBUGLEV_DEVELOP, "HWLOC CpuInfo Family %d Model %d Stepping %d Vendor 0x%X Part 0x%X isIntel %d numHWThreads %d activeHWThreads %d",
                             cpuid_info.family,
                             cpuid_info.model,
                             cpuid_info.stepping,
@@ -366,7 +366,7 @@ hwloc_init_cpuInfo(cpu_set_t cpuSet)
                             cpuid_info.part,
                             cpuid_info.isIntel,
                             cpuid_topology.numHWThreads,
-                            cpuid_topology.activeHWThreads)
+                            cpuid_topology.activeHWThreads);
     return 0;
 }
 
@@ -574,13 +574,13 @@ hwloc_init_nodeTopology(cpu_set_t cpuSet)
         {
             hwThreadPool[id].dieId = 0;
         }
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, HWLOC Thread Pool PU %d Thread %d Core %d Die %d Socket %d inCpuSet %d,
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "HWLOC Thread Pool PU %d Thread %d Core %d Die %d Socket %d inCpuSet %d",
                             hwThreadPool[id].apicId,
                             hwThreadPool[id].threadId,
                             hwThreadPool[id].coreId,
                             hwThreadPool[id].dieId,
                             hwThreadPool[id].packageId,
-                            hwThreadPool[id].inCpuSet)
+                            hwThreadPool[id].inCpuSet);
     }
 
     int socket_nums[MAX_NUM_NODES];
@@ -804,7 +804,7 @@ hwloc_init_cacheTopology(void)
 #if defined(_ARCH_PPC) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_8A)
         cachePool[id].inclusive = 0;
 #endif
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, HWLOC Cache Pool ID %d Level %d Size %d Threads %d,
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "HWLOC Cache Pool ID %d Level %d Size %d Threads %d",
                                       id, cachePool[id].level,
                                       cachePool[id].size,
                                       cachePool[id].threads);

--- a/src/topology_proc.c
+++ b/src/topology_proc.c
@@ -328,12 +328,12 @@ proc_init_cpuInfo(cpu_set_t cpuSet)
         }
 
 #endif
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, PROC CpuInfo Family %d Model %d Stepping %d isIntel %d numHWThreads %d,
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "PROC CpuInfo Family %d Model %d Stepping %d isIntel %d numHWThreads %d",
                             cpuid_info.family,
                             cpuid_info.model,
                             cpuid_info.stepping,
                             cpuid_info.isIntel,
-                            cpuid_topology.numHWThreads)
+                            cpuid_topology.numHWThreads);
     }
     return 0;
 }
@@ -716,13 +716,13 @@ proc_init_nodeTopology(cpu_set_t cpuSet)
         if (hwThreadPool[i].dieId == -1)
             hwThreadPool[i].dieId = 0;
 #endif
-        DEBUG_PRINT(DEBUGLEV_DEVELOP, PROC Thread Pool PU %d Thread %d Core %d Die %d Socket %d inCpuSet %d,
+        DEBUG_PRINT(DEBUGLEV_DEVELOP, "PROC Thread Pool PU %d Thread %d Core %d Die %d Socket %d inCpuSet %d",
                             hwThreadPool[i].apicId,
                             hwThreadPool[i].threadId,
                             hwThreadPool[i].coreId,
                             hwThreadPool[i].dieId,
                             hwThreadPool[i].packageId,
-                            hwThreadPool[i].inCpuSet)
+                            hwThreadPool[i].inCpuSet);
         bdestroy(cpudir);
     }
     int* helper = malloc(cpuid_topology.numHWThreads * sizeof(int));
@@ -1100,7 +1100,7 @@ proc_init_cacheTopology(void)
                 cachePool[i].inclusive = 0;
                 break;
             default:
-                ERROR_PLAIN_PRINT(Processor is not supported);
+                ERROR_PLAIN_PRINT("Processor is not supported");
                 break;
         }
     }

--- a/src/topology_proc.c
+++ b/src/topology_proc.c
@@ -1100,7 +1100,7 @@ proc_init_cacheTopology(void)
                 cachePool[i].inclusive = 0;
                 break;
             default:
-                ERROR_PLAIN_PRINT("Processor is not supported");
+                ERROR_PRINT("Processor is not supported");
                 break;
         }
     }

--- a/src/topology_rocm.c
+++ b/src/topology_rocm.c
@@ -148,12 +148,12 @@ topo_gpu_init(RocmDevice *device, int deviceId)
     err = (*hipGetDevicePropertiesTopoPtr)(&props, deviceId);
     if (err == hipErrorInvalidDevice)
     {
-        ERROR_PRINT(GPU %d is not a valid device, deviceId);
+        ERROR_PRINT("GPU %d is not a valid device", deviceId);
         return -ENODEV;
     }
     if (err != hipSuccess)
     {
-        ERROR_PRINT(Failed to retreive properties for GPU %d, deviceId);
+        ERROR_PRINT("Failed to retreive properties for GPU %d", deviceId);
         return EXIT_FAILURE;
     }
 
@@ -196,7 +196,7 @@ topo_gpu_init(RocmDevice *device, int deviceId)
     device->name = malloc(256 * sizeof(char));
     if (!device->name)
     {
-        ERROR_PRINT(Cannot allocate space for name of GPU %d, deviceId);
+        ERROR_PRINT("Cannot allocate space for name of GPU %d", deviceId);
         return -ENOMEM;
     }
     strncpy(device->name, props.name, 256);
@@ -220,7 +220,7 @@ topology_rocm_init()
     ret = topo_link_libraries();
     if (ret != 0)
     {
-        ERROR_PLAIN_PRINT(Cannot open ROCm HIP library to fill GPU topology);
+        ERROR_PLAIN_PRINT("Cannot open ROCm HIP library to fill GPU topology");
         return EXIT_FAILURE;
     }
 
@@ -228,7 +228,7 @@ topology_rocm_init()
     int num_devs = topo_get_numDevices();
     if (num_devs < 0)
     {
-        ERROR_PLAIN_PRINT(Cannot get number of devices from ROCm HIP library);
+        ERROR_PLAIN_PRINT("Cannot get number of devices from ROCm HIP library");
         return EXIT_FAILURE;
     }
 

--- a/src/topology_rocm.c
+++ b/src/topology_rocm.c
@@ -220,7 +220,7 @@ topology_rocm_init()
     ret = topo_link_libraries();
     if (ret != 0)
     {
-        ERROR_PLAIN_PRINT("Cannot open ROCm HIP library to fill GPU topology");
+        ERROR_PRINT("Cannot open ROCm HIP library to fill GPU topology");
         return EXIT_FAILURE;
     }
 
@@ -228,7 +228,7 @@ topology_rocm_init()
     int num_devs = topo_get_numDevices();
     if (num_devs < 0)
     {
-        ERROR_PLAIN_PRINT("Cannot get number of devices from ROCm HIP library");
+        ERROR_PRINT("Cannot get number of devices from ROCm HIP library");
         return EXIT_FAILURE;
     }
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -123,7 +123,7 @@ tree_insertNode(TreeNode* nodePtr, int id)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT("Node invalid");
+        ERROR_PRINT("Node invalid");
     }
 
     newNode = (TreeNode*) malloc(sizeof(TreeNode));
@@ -175,7 +175,7 @@ tree_nodeExists(TreeNode* nodePtr, int id)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT("Node invalid");
+        ERROR_PRINT("Node invalid");
         return 0;
     }
 
@@ -204,7 +204,7 @@ tree_countChildren(TreeNode* nodePtr)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT("Node invalid");
+        ERROR_PRINT("Node invalid");
         return 0;
     }
     if (nodePtr->llink == NULL)
@@ -230,7 +230,7 @@ tree_getNode(TreeNode* nodePtr, int id)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT("Node invalid");
+        ERROR_PRINT("Node invalid");
         return NULL;
     }
     if (nodePtr->llink == NULL)
@@ -260,7 +260,7 @@ tree_getChildNode(TreeNode* nodePtr)
 {
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT("Node invalid");
+        ERROR_PRINT("Node invalid");
         return NULL;
     }
     if (nodePtr->llink == NULL)
@@ -276,7 +276,7 @@ tree_getNextNode(TreeNode* nodePtr)
 {
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT("Node invalid");
+        ERROR_PRINT("Node invalid");
     }
 
     if (nodePtr->rlink == NULL)

--- a/src/tree.c
+++ b/src/tree.c
@@ -123,7 +123,7 @@ tree_insertNode(TreeNode* nodePtr, int id)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT(Node invalid);
+        ERROR_PLAIN_PRINT("Node invalid");
     }
 
     newNode = (TreeNode*) malloc(sizeof(TreeNode));
@@ -175,7 +175,7 @@ tree_nodeExists(TreeNode* nodePtr, int id)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT(Node invalid);
+        ERROR_PLAIN_PRINT("Node invalid");
         return 0;
     }
 
@@ -204,7 +204,7 @@ tree_countChildren(TreeNode* nodePtr)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT(Node invalid);
+        ERROR_PLAIN_PRINT("Node invalid");
         return 0;
     }
     if (nodePtr->llink == NULL)
@@ -230,7 +230,7 @@ tree_getNode(TreeNode* nodePtr, int id)
 
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT(Node invalid);
+        ERROR_PLAIN_PRINT("Node invalid");
         return NULL;
     }
     if (nodePtr->llink == NULL)
@@ -260,7 +260,7 @@ tree_getChildNode(TreeNode* nodePtr)
 {
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT(Node invalid);
+        ERROR_PLAIN_PRINT("Node invalid");
         return NULL;
     }
     if (nodePtr->llink == NULL)
@@ -276,7 +276,7 @@ tree_getNextNode(TreeNode* nodePtr)
 {
     if (nodePtr == NULL)
     {
-        ERROR_PLAIN_PRINT(Node invalid);
+        ERROR_PLAIN_PRINT("Node invalid");
     }
 
     if (nodePtr->rlink == NULL)


### PR DESCRIPTION
This PR requires the strings passed to the print helper macros to be properly passed with quotes. There are many reasons why not having quotes is a bad idea. For example syntax highlighting in your editor, or actually being able to print a `,` symbol.