### PR TITLE
Fixes HBM Metric

### DIFF
--- a/src/includes/perfmon_types.h
+++ b/src/includes/perfmon_types.h
@@ -244,6 +244,9 @@ typedef struct {
     uint64_t              regTypeMask4; /*!< \brief Bitmask4 for easy checks which types are included in the eventSet */
     uint64_t              regTypeMask5; /*!< \brief Bitmask5 for easy checks which types are included in the eventSet */
     uint64_t              regTypeMask6; /*!< \brief Bitmask6 for easy checks which types are included in the eventSet */
+    uint64_t              regTypeMask7; /*!< \brief Bitmask6 for easy checks which types are included in the eventSet */
+    uint64_t              regTypeMask8; /*!< \brief Bitmask6 for easy checks which types are included in the eventSet */
+    uint64_t              regTypeMask9; /*!< \brief Bitmask6 for easy checks which types are included in the eventSet */
     GroupState            state; /*!< \brief Current state of the event group (configured, started, none) */
     GroupInfo             group; /*!< \brief Structure holding the performance group information */
 } PerfmonEventSet;

--- a/src/includes/registers_types.h
+++ b/src/includes/registers_types.h
@@ -1111,7 +1111,10 @@ static char* RegisterTypeNames[MAX_UNITS] = {
         ((type) >= 128 && (type) <= 191 ? eventset->regTypeMask3 & (1ULL<<((type)-128)) : \
         ((type) >= 192 && (type) <= 255 ? eventset->regTypeMask4 & (1ULL<<((type)-192)) : \
         ((type) >= 256 && (type) <= 319 ? eventset->regTypeMask5 & (1ULL<<((type)-256)) : \
-        ((type) >= 320 && (type) <= 383 ? eventset->regTypeMask6 & (1ULL<<((type)-320)) : 0x0ULL)))))))
+        ((type) >= 320 && (type) <= 383 ? eventset->regTypeMask6 & (1ULL<<((type)-320)) : \
+        ((type) >= 384 && (type) <= 447 ? eventset->regTypeMask7 & (1ULL<<((type)-384)) : \
+        ((type) >= 448 && (type) <= 511 ? eventset->regTypeMask8 & (1ULL<<((type)-448)) : \
+        ((type) >= 512 && (type) <= 575 ? eventset->regTypeMask9 & (1ULL<<((type)-512)) : 0x0ULL))))))))))
 
 #define SETTYPE(eventset, type) \
         if ((type) >= 0 && (type) <= 63) \
@@ -1138,6 +1141,18 @@ static char* RegisterTypeNames[MAX_UNITS] = {
         { \
             eventset->regTypeMask6 |= (1ULL<<((type)-320)); \
         } \
+        else if ((type) >= 384 && (type) <= 447) \
+        { \
+            eventset->regTypeMask7 |= (1ULL<<((type)-384)); \
+        } \
+        else if ((type) >= 448 && (type) <= 511) \
+        { \
+            eventset->regTypeMask8 |= (1ULL<<((type)-448)); \
+        } \
+        else if ((type) >= 512 && (type) <= 575) \
+        { \
+            eventset->regTypeMask9 |= (1ULL<<((type)-512)); \
+        } \
         else \
         { \
             ERROR_PRINT(Cannot set out-of-bounds type %d, (type)); \
@@ -1148,7 +1163,7 @@ static char* RegisterTypeNames[MAX_UNITS] = {
 #define MEASURE_METRICS(eventset) ((eventset)->regTypeMask1 & (REG_TYPE_MASK(METRICS))
 
 #define MEASURE_UNCORE(eventset) \
-        (eventset->regTypeMask1 & ~(REG_TYPE_MASK(PMC)|REG_TYPE_MASK(FIXED)|REG_TYPE_MASK(THERMAL)|REG_TYPE_MASK(VOLTAGE)|REG_TYPE_MASK(PERF)|REG_TYPE_MASK(POWER)|REG_TYPE_MASK(METRICS)) || eventset->regTypeMask2 || eventset->regTypeMask3 || eventset->regTypeMask4 || eventset->regTypeMask5 || eventset->regTypeMask6 )
+        (eventset->regTypeMask1 & ~(REG_TYPE_MASK(PMC)|REG_TYPE_MASK(FIXED)|REG_TYPE_MASK(THERMAL)|REG_TYPE_MASK(VOLTAGE)|REG_TYPE_MASK(PERF)|REG_TYPE_MASK(POWER)|REG_TYPE_MASK(METRICS)) || eventset->regTypeMask2 || eventset->regTypeMask3 || eventset->regTypeMask4 || eventset->regTypeMask5 || eventset->regTypeMask6 || eventset->regTypeMask7 || eventset->regTypeMask8 || eventset->regTypeMask9)
 
 
 typedef struct {

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -2551,6 +2551,9 @@ perfmon_addEventSet(const char* eventCString)
     eventSet->regTypeMask4 = 0x0ULL;
     eventSet->regTypeMask5 = 0x0ULL;
     eventSet->regTypeMask6 = 0x0ULL;
+    eventSet->regTypeMask7 = 0x0ULL;
+    eventSet->regTypeMask8 = 0x0ULL;
+    eventSet->regTypeMask9 = 0x0ULL;
 
     int forceOverwrite = 0;
     int valid_events = 0;
@@ -2703,7 +2706,10 @@ past_checks:
         (eventSet->regTypeMask3 != 0x0ULL) ||
         (eventSet->regTypeMask4 != 0x0ULL) ||
         (eventSet->regTypeMask5 != 0x0ULL) ||
-        (eventSet->regTypeMask6 != 0x0ULL)))
+        (eventSet->regTypeMask6 != 0x0ULL) ||
+        (eventSet->regTypeMask7 != 0x0ULL) ||
+        (eventSet->regTypeMask8 != 0x0ULL) ||
+        (eventSet->regTypeMask9 != 0x0ULL)))
     {
         eventSet->state = STATE_NONE;
         groupSet->numberOfActiveGroups++;


### PR DESCRIPTION
In 638191a211e71d4d0db42eebe839a0ff187354e0 the enum `RegisterType` has been extended. This results in overflows for HBM events: `Cannot set out-of-bounds event->type 489` up to 510 in this case.

**Before:**
```
+-------------------------------------+------------+-----------+-----------+-----------+-----------+-----------+-----------+
|                Metric               |     Sum    |    Min    |    Max    |    Avg    |  %ile 25  |  %ile 50  |  %ile 75  |
+-------------------------------------+------------+-----------+-----------+-----------+-----------+-----------+-----------+
|       Runtime (RDTSC) [s] STAT      |   299.9565 |   12.4427 |   12.5986 |   12.4982 |   12.4612 |   12.4832 |   12.5143 |
|      Runtime unhalted [s] STAT      |   350.0533 |   13.6187 |   15.0294 |   14.5856 |   14.2725 |   14.5495 |   14.9585 |
|           Clock [MHz] STAT          | 62713.3750 | 2596.5493 | 2627.6580 | 2613.0573 | 2601.1137 | 2611.1599 | 2624.9736 |
|               CPI STAT              |    34.7111 |    0.3517 |    3.3122 |    1.4463 |    0.7706 |    1.1879 |    2.0302 |
|  DDR read bandwidth [MBytes/s] STAT |   381.6682 |         0 |  381.6682 |   15.9028 |         0 |         0 |         0 |
|  DDR read data volume [GBytes] STAT |     4.7691 |         0 |    4.7691 |    0.1987 |         0 |         0 |         0 |
| DDR write bandwidth [MBytes/s] STAT |   183.5279 |         0 |  183.5279 |    7.6470 |         0 |         0 |         0 |
| DDR write data volume [GBytes] STAT |     2.2933 |         0 |    2.2933 |    0.0956 |         0 |         0 |         0 |
|    DDR bandwidth [MBytes/s] STAT    |   565.1961 |         0 |  565.1961 |   23.5498 |         0 |         0 |         0 |
|    DDR data volume [GBytes] STAT    |     7.0624 |         0 |    7.0624 |    0.2943 |         0 |         0 |         0 |
|  HBM read bandwidth [MBytes/s] STAT |          0 |         0 |         0 |         0 |         0 |         0 |         0 |
|  HBM read data volume [GBytes] STAT |          0 |         0 |         0 |         0 |         0 |         0 |         0 |
| HBM write bandwidth [MBytes/s] STAT |          0 |         0 |         0 |         0 |         0 |         0 |         0 |
| HBM write data volume [GBytes] STAT |          0 |         0 |         0 |         0 |         0 |         0 |         0 |
|    HBM bandwidth [MBytes/s] STAT    |          0 |         0 |         0 |         0 |         0 |         0 |         0 |
|    HBM data volume [GBytes] STAT    |          0 |         0 |         0 |         0 |         0 |         0 |         0 |
+-------------------------------------+------------+-----------+-----------+-----------+-----------+-----------+-----------+
```

**After:**
```
+-------------------------------------+-------------+-----------+-------------+------------+-----------+-----------+-----------+
|                Metric               |     Sum     |    Min    |     Max     |     Avg    |  %ile 25  |  %ile 50  |  %ile 75  |
+-------------------------------------+-------------+-----------+-------------+------------+-----------+-----------+-----------+
|       Runtime (RDTSC) [s] STAT      |    300.8751 |   12.4758 |     12.6299 |    12.5365 |   12.5035 |   12.5193 |   12.5775 |
|      Runtime unhalted [s] STAT      |    304.4826 |   11.7456 |     12.9202 |    12.6868 |   12.7254 |   12.7672 |   12.7890 |
|           Clock [MHz] STAT          |  54172.3133 | 2226.3687 |   2262.2872 |  2257.1797 | 2258.7218 | 2259.1296 | 2259.7789 |
|               CPI STAT              |     15.3227 |    0.2494 |      0.9953 |     0.6384 |    0.5062 |    0.5806 |    0.7721 |
|  DDR read bandwidth [MBytes/s] STAT |    472.5902 |         0 |    472.5902 |    19.6913 |         0 |         0 |         0 |
|  DDR read data volume [GBytes] STAT |      5.9215 |         0 |      5.9215 |     0.2467 |         0 |         0 |         0 |
| DDR write bandwidth [MBytes/s] STAT |    255.5860 |         0 |    255.5860 |    10.6494 |         0 |         0 |         0 |
| DDR write data volume [GBytes] STAT |      3.2024 |         0 |      3.2024 |     0.1334 |         0 |         0 |         0 |
|    DDR bandwidth [MBytes/s] STAT    |    728.1762 |         0 |    728.1762 |    30.3407 |         0 |         0 |         0 |
|    DDR data volume [GBytes] STAT    |      9.1239 |         0 |      9.1239 |     0.3802 |         0 |         0 |         0 |
|  HBM read bandwidth [MBytes/s] STAT | 230380.6355 |         0 | 230380.6355 |  9599.1931 |         0 |         0 |         0 |
|  HBM read data volume [GBytes] STAT |   2886.6302 |         0 |   2886.6302 |   120.2763 |         0 |         0 |         0 |
| HBM write bandwidth [MBytes/s] STAT |  62149.5661 |         0 |  62149.5661 |  2589.5653 |         0 |         0 |         0 |
| HBM write data volume [GBytes] STAT |    778.7235 |         0 |    778.7235 |    32.4468 |         0 |         0 |         0 |
|    HBM bandwidth [MBytes/s] STAT    | 292530.2015 |         0 | 292530.2015 | 12188.7584 |         0 |         0 |         0 |
|    HBM data volume [GBytes] STAT    |   3665.3537 |         0 |   3665.3537 |   152.7231 |         0 |         0 |         0 |
+-------------------------------------+-------------+-----------+-------------+------------+-----------+-----------+-----------+
```
