### PR TITLE
make: add makefile for oneapi/ICX

### DIFF
--- a/make/include_ICX.mk
+++ b/make/include_ICX.mk
@@ -1,0 +1,32 @@
+CC  = icx-cc
+FC  = ifx
+AS  = as
+AR  = ar
+PAS = ./perl/AsmGen.pl 
+GEN_PAS = ./perl/generatePas.pl 
+GEN_GROUPS = ./perl/generateGroups.pl 
+GEN_PMHEADER = ./perl/gen_events.pl 
+
+ANSI_CFLAGS  = -std=c99 #-strict-ansi
+
+CFLAGS   =  -Ofast -fPIC -pthread
+FCFLAGS  = -module ./
+ASFLAGS  = -gdwarf-2
+PASFLAGS  = x86-64
+CPPFLAGS =
+LFLAGS   = -pthread
+
+SHARED_CFLAGS = -fPIC -pthread -fvisibility=hidden
+SHARED_LFLAGS = -shared -pthread -fvisibility=hidden
+
+DEFINES  = -D_GNU_SOURCE
+DEFINES  += -DPAGE_ALIGNMENT=4096
+
+INCLUDES =
+LIBS     = -lrt
+
+# colon seperated list of paths to search for libs at runtime on Xeon Phi file system
+ICC_LIB_RPATHS =
+ifneq (strip $(ICC_LIB_RPATHS),)
+RPATHS += -Wl,-rpath=$(ICC_LIB_RPATHS)
+endif


### PR DESCRIPTION
Here's a naive makefile for the new clang-based Intel "oneAPI" compilers. It's copied from `include_ICC.mk`, I only changed the compiler names.

To make this work with spack, at least the following edit to likwid's `package.py` is needed:

```diff
diff --git a/var/spack/repos/builtin/packages/likwid/package.py b/var/spack/repos/builtin/packages/likwid/package.py
index c3f297445f..2782c8b8ab 100644
--- a/var/spack/repos/builtin/packages/likwid/package.py
+++ b/var/spack/repos/builtin/packages/likwid/package.py
@@ -159,6 +159,7 @@ def install(self, spec, prefix):
             "clang": "CLANG",
             "gcc": "GCC",
             "intel": "ICC",
+            "oneapi": "ICX",
         }
         if spec.target.family == "aarch64":
             supported_compilers = {"gcc": "GCCARMv8", "clang": "ARMCLANG", "arm": "ARMCLANG"}
```

feel free to edit!