### PR TITLE
Fixes some bugs in the ROCm modules

### DIFF
--- a/src/rocmon.c
+++ b/src/rocmon.c
@@ -1627,7 +1627,7 @@ rocmon_setupCounters(int gid)
         else
         {
             // Unknown event
-            ERROR_PRINT(""Event '%s' has no prefix ('ROCP_' or 'RSMI_'")", name);
+            ERROR_PRINT("Event '%s' has no prefix ('ROCP_' or 'RSMI_')", name);
             return -EINVAL;
         }
     }

--- a/src/rocmon.c
+++ b/src/rocmon.c
@@ -1288,7 +1288,7 @@ rocmon_finalize(void)
                     // Free events of event result lists
                     for (int j = 0; j < device->numGroupResults; j++)
                     {
-                        FREE_IF_NOT_NULL(device->groupResults[i].results);
+                        FREE_IF_NOT_NULL(device->groupResults[j].results);
                     }
                     // Free list
                     free(device->groupResults);

--- a/src/rocmon.c
+++ b/src/rocmon.c
@@ -1319,6 +1319,8 @@ rocmon_finalize(void)
         ROCMON_DEBUG_PRINT(DEBUGLEV_DEVELOP, "Shutdown HSA");
         // fall through
     });
+
+    rocmon_initialized = FALSE;
 }
 
 

--- a/src/topology_rocm.c
+++ b/src/topology_rocm.c
@@ -89,9 +89,17 @@ topo_link_libraries(void)
     uint64_t flags = 0; // No special flags
     hipDriverProcAddressQueryResult symbolStatus;
 
-    
-    res = (*hipGetProcAddressTopoPtr)("hipGetDeviceProperties", (void**)&hipGetDevicePropertiesFunc, hipVersion, flags, &symbolStatus); 
+
+    res = (*hipGetProcAddressTopoPtr)("hipGetDeviceProperties", (void**)&hipGetDevicePropertiesFunc, hipVersion, flags, &symbolStatus);
+    if (res != hipSuccess) {
+        ERROR_PRINT("Failed to obtaian hipGetDeviceProperties address");
+        return EXIT_FAILURE;
+    }
     res = (*hipGetProcAddressTopoPtr)("hipGetDeviceCount", (void**)&hipGetDeviceCountFunc, hipVersion, flags, &symbolStatus);
+    if (res != hipSuccess) {
+        ERROR_PRINT("Failed to obtaian hipGetDeviceCount address");
+        return EXIT_FAILURE;
+    }
 
     return 0;
 }

--- a/src/topology_rocm.c
+++ b/src/topology_rocm.c
@@ -280,6 +280,7 @@ topology_rocm_finalize(void)
     {
         topo_rocm_cleanup(_rocmTopology.numDevices);
     }
+    topo_rocm_initialized = 0;
 }
 
 RocmTopology_t


### PR DESCRIPTION
This PR proposes fixes for bugs in the ROCm performace monitoring and topology module of LIKWID.

- Changed the method for obtaining HIP function pointers by using the hipGetProcAddress function to prevent incorrect identifier substitution in the HIP library
- Fixes the freeing of events in the event result lists by using the event index instead of the device index
- Adds the reset of the initialization flag to the finalization processes to prevent invalid memory accesses when calling the finalization function multiple times
- Removes excess quotation marks in ERROR_PRINT