### PR TITLE
Add the ability to release and reacquire performance counters in the perfmon API

### DIFF
--- a/src/includes/likwid.h
+++ b/src/includes/likwid.h
@@ -957,8 +957,9 @@ Acquires all performance monitoring counters previously released by
 perfmon_releaseCounters(), takes the same parameters as perfmon_init(...).
 @param [in] nrThreads (Number of Threads)
 @param [in] threadsToCpu (List of CPUs)
+@return error code (0 on success, -ERRORCODE on failure)
 */
-extern void perfmon_acquireCounters(int nrThreads, const int* threadsToCpu) 
+extern int perfmon_acquireCounters(int nrThreads, const int* threadsToCpu) 
     __attribute__((visibility("default")));
 /*! \brief Start performance monitoring counters
 

--- a/src/includes/likwid.h
+++ b/src/includes/likwid.h
@@ -942,6 +942,24 @@ CPU cannot be set up)
 */
 extern int perfmon_setupCounters(int groupId)
     __attribute__((visibility("default")));
+/*! \brief Release all performance monitoring counters
+
+Release the counters previously acquired by initialization so that another
+application can use them in the meantime. This does not release any other
+resources.
+*/
+extern void perfmon_releaseCounters(void) 
+    __attribute__((visibility("default")));
+
+/*! \brief Acquire all performance monitoring counters
+
+Acquires all performance monitoring counters previously released by
+perfmon_releaseCounters(), takes the same parameters as perfmon_init(...).
+@param [in] nrThreads (Number of Threads)
+@param [in] threadsToCpu (List of CPUs)
+*/
+extern void perfmon_acquireCounters(int nrThreads, const int* threadsToCpu) 
+    __attribute__((visibility("default")));
 /*! \brief Start performance monitoring counters
 
 Start the counters that have been previously set up by perfmon_setupCounters().

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -2345,8 +2345,37 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
         return ret;
     }
 
+    /* Initialize access to the performance counters */
+    ret = perfmon_acquireCounters(nrThreads, threadsToCpu);
+    if (ret < 0) {
+        return ret;
+    }
+
+    perfmon_initialized = 1;
+    return 0;
+}
+
+void 
+perfmon_releaseCounters(void) 
+{
+    for(int group=0;group < groupSet->numberOfActiveGroups; group++)
+    {
+        for (int thread=0;thread< groupSet->numberOfThreads; thread++)
+        {
+            perfmon_finalizeCountersThread(thread, &(groupSet->groups[group]));
+        }
+    }
+}
+
+int 
+perfmon_acquireCounters(int nrThreads, const int* threadsToCpu)
+{
+    int initialize_power = FALSE;
+    int initialize_thermal = FALSE;
+
     /* Initialize function pointer to current architecture functions */
-    ret = perfmon_init_funcs(&initialize_power, &initialize_thermal);
+    int ret = perfmon_init_funcs(&initialize_power, &initialize_thermal);
+
     if (ret < 0)
     {
         errno = -ret;
@@ -2412,51 +2441,8 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
         }
         initThreadArch(threadsToCpu[i]);
     }
-    perfmon_initialized = 1;
-    return 0;
-}
 
-void 
-perfmon_releaseCounters(void) 
-{
-    for(int group=0;group < groupSet->numberOfActiveGroups; group++)
-    {
-        for (int thread=0;thread< groupSet->numberOfThreads; thread++)
-        {
-            perfmon_finalizeCountersThread(thread, &(groupSet->groups[group]));
-        }
-    }
-}
-
-void 
-perfmon_acquireCounters(int nrThreads, const int* threadsToCpu)
-{
-    int initialize_power = FALSE;
-    int initialize_thermal = FALSE;
-    perfmon_init_funcs(&initialize_power, &initialize_thermal);
-
-
-        /* Store thread information and reset counters for processor*/
-    /* If the arch supports it, initialize power and thermal measurements */
-    for(int i=0;i<nrThreads;i++)
-    {
-#ifndef LIKWID_USE_PERFEVENT
-        HPMaddThread(threadsToCpu[i]);
-        HPMcheck(MSR_DEV, threadsToCpu[i]);
-#endif
-        groupSet->threads[i].thread_id = i;
-        groupSet->threads[i].processorId = threadsToCpu[i];
-
-        if (initialize_power == TRUE)
-        {
-            power_init(threadsToCpu[i]);
-        }
-        if (initialize_thermal == TRUE)
-        {
-            thermal_init(threadsToCpu[i]);
-        }
-        initThreadArch(threadsToCpu[i]);
-    }
+    return ret;
 }
 
 
@@ -2473,12 +2459,9 @@ perfmon_finalize(void)
     {
         return;
     }
+    perfmon_releaseCounters();
     for(int group=0;group < groupSet->numberOfActiveGroups; group++)
     {
-        for (thread=0;thread< groupSet->numberOfThreads; thread++)
-        {
-            perfmon_finalizeCountersThread(thread, &(groupSet->groups[group]));
-        }
         for (event=0;event < groupSet->groups[group].numberOfEvents; event++)
         {
             if (groupSet->groups[group].events[event].threadCounter)

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -2416,6 +2416,50 @@ perfmon_init(int nrThreads, const int* threadsToCpu)
     return 0;
 }
 
+void 
+perfmon_releaseCounters(void) 
+{
+    for(int group=0;group < groupSet->numberOfActiveGroups; group++)
+    {
+        for (int thread=0;thread< groupSet->numberOfThreads; thread++)
+        {
+            perfmon_finalizeCountersThread(thread, &(groupSet->groups[group]));
+        }
+    }
+}
+
+void 
+perfmon_acquireCounters(int nrThreads, const int* threadsToCpu)
+{
+    int initialize_power = FALSE;
+    int initialize_thermal = FALSE;
+    perfmon_init_funcs(&initialize_power, &initialize_thermal);
+
+
+        /* Store thread information and reset counters for processor*/
+    /* If the arch supports it, initialize power and thermal measurements */
+    for(int i=0;i<nrThreads;i++)
+    {
+#ifndef LIKWID_USE_PERFEVENT
+        HPMaddThread(threadsToCpu[i]);
+        HPMcheck(MSR_DEV, threadsToCpu[i]);
+#endif
+        groupSet->threads[i].thread_id = i;
+        groupSet->threads[i].processorId = threadsToCpu[i];
+
+        if (initialize_power == TRUE)
+        {
+            power_init(threadsToCpu[i]);
+        }
+        if (initialize_thermal == TRUE)
+        {
+            thermal_init(threadsToCpu[i]);
+        }
+        initThreadArch(threadsToCpu[i]);
+    }
+}
+
+
 void
 perfmon_finalize(void)
 {


### PR DESCRIPTION
Hi everyone,

this PR adds the ability to release and (re-)acquire (`perfmon_acquireCounters`, `perfmon_releaseCounters`) the performance counters in the API, extracted from the existing functions `perfmon_init` and `perfmon_finalize`.
This addition has several benefits in the context of performance monitoring:
- A tool to monitor the performance in the background can acquire and release the counters for use so that another application does not have to wait for the finalization upon creation of a lockfile or any other mechanism to pause the monitoring tool for a job requiring access for the counters so the force flag does not need to be used.
- Acquire/Release is much faster than fully initializing/finalizing (around 5-10ms vs. around 3s on the cluster here in Aachen; see attached code example below). The repeated initialization for monitoring the performance of the cluster in the background causes measurable overhead (such as in issue #634) and can be avoided with merely acquiring and releasing the counters.

I refrained from running `make format` on the changes as it changed virtually every line in the two changed files.

To try the [attached code example](https://github.com/user-attachments/files/26023358/likwid_example.zip):
```
$ g++ -std=c++20 -g -O3 -llikwid -o likwid_example.exe likwid_example.cpp
$ ./likwid_minimal.exe
Starting measurements...
....................
20 times initializing/finalizing access took 54471 ms, avg.: 2723 ms 

....................
20 times acquiring/releasing access took 112 ms, avg.: 5 ms 
```