### PR TITLE
Fix fork bomb (exit child process after a failed fork+exec)

### DIFF
--- a/src/access_client.c
+++ b/src/access_client.c
@@ -136,7 +136,6 @@ access_client_startDaemon_direct(uint32_t cpu_id, struct sockaddr_un *address)
     char *newenv[] = { NULL };
     const char *safeexeprog = TOSTRING(ACCESSDAEMON);
     char exeprog[1024];
-    int  ret;
     pid_t pid;
 
     if (config.daemonPath != NULL)
@@ -167,14 +166,9 @@ access_client_startDaemon_direct(uint32_t cpu_id, struct sockaddr_un *address)
 /*            CPU_SET(cpu_id, &cpuset);*/
 /*            sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);*/
 /*        }*/
-        ret = execve (exeprog, newargv, newenv);
-
-        if (ret < 0)
-        {
-            //ERRNO_PRINT;
-            ERROR_PRINT("Failed to execute the daemon '%s'\n", exeprog);
-            return ret;
-        }
+        execve (exeprog, newargv, newenv);
+        ERROR_PRINT("Failed to execute the daemon '%s'\n", exeprog);
+        exit(EXIT_FAILURE);
     }
     else if (pid < 0)
     {

--- a/src/access_client.c
+++ b/src/access_client.c
@@ -167,7 +167,7 @@ access_client_startDaemon_direct(uint32_t cpu_id, struct sockaddr_un *address)
 /*            sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);*/
 /*        }*/
         execve (exeprog, newargv, newenv);
-        ERROR_PRINT("Failed to execute the daemon '%s'\n", exeprog);
+        ERROR_PRINT("Failed to execute the daemon '%s'", exeprog);
         exit(EXIT_FAILURE);
     }
     else if (pid < 0)

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -49,10 +49,8 @@
 
 NORETURN_ATTR void access_daemon_main() {
     char *argv[1] = {NULL};
-    int ret = execvp("likwid-accessD", argv);
-    if (ret < 0) {
-        printf("Failed to start likwid-accessD daemon\n", ret);
-    }
+    execvp("likwid-accessD", argv);
+    perror("Failed to start likwid-accessD daemon\n", ret);
     exit(ret);
 }
 

--- a/src/frequency_cpu.c
+++ b/src/frequency_cpu.c
@@ -308,7 +308,6 @@ freq_client_startDaemon()
     char *exeprog = TOSTRING(FREQDAEMON);
     struct sockaddr_un address;
     size_t address_length;
-    int  ret;
     pid_t pid;
     int timeout = 1000;
     int socket_fd = -1;
@@ -332,14 +331,9 @@ freq_client_startDaemon()
 /*            CPU_SET(cpu_id, &cpuset);*/
 /*            sched_setaffinity(0, sizeof(cpu_set_t), &cpuset);*/
 /*        }*/
-        ret = execve (exeprog, newargv, newenv);
-
-        if (ret < 0)
-        {
-            //ERRNO_PRINT;
-            fprintf(stderr, "Failed to execute the daemon '%s'\n", exeprog);
-            return -1;
-        }
+        execve (exeprog, newargv, newenv);
+        ERROR_PRINT("Failed to execute the daemon '%s'\n", exeprog);
+        exit(EXIT_FAILURE);
     }
     else if (pid < 0)
     {

--- a/src/luawid.c
+++ b/src/luawid.c
@@ -1805,7 +1805,7 @@ static void catch_sigchild(int signo) {
 }
 
 static int lua_likwid_startProgram(lua_State *L) {
-  pid_t pid, ppid;
+  pid_t pid;
   int status;
   char *exec;
   char *argv[MAX_NUM_CLIARGS];
@@ -1859,7 +1859,6 @@ static int lua_likwid_startProgram(lua_State *L) {
     free(cpus);
     return 0;
   }
-  ppid = getpid();
   pid = fork();
   if (pid < 0) {
     free(cpus);
@@ -1869,11 +1868,9 @@ static int lua_likwid_startProgram(lua_State *L) {
       affinity_pinProcesses(nrThreads, cpus);
     }
     timer_sleep(10);
-    status = execvp(*argv, argv);
-    if (status < 0) {
-      kill(ppid, SIGCHLD);
-    }
-    return 0;
+    execvp(*argv, argv);
+    perror("execvp");
+    exit(EXIT_FAILURE);
   } else {
     signal(SIGCHLD, catch_sigchild);
     free(cpus);

--- a/src/luawid.c
+++ b/src/luawid.c
@@ -49,6 +49,7 @@
 
 #include <likwid.h>
 #include <tree.h>
+#include <error.h>
 
 #include <access.h>
 #include <bstrlib.h>
@@ -1867,9 +1868,10 @@ static int lua_likwid_startProgram(lua_State *L) {
     if (nrThreads > 0) {
       affinity_pinProcesses(nrThreads, cpus);
     }
+    // Why is there a sleep here?
     timer_sleep(10);
     execvp(*argv, argv);
-    perror("execvp");
+    ERROR_PRINT("Failed to run program '%s'", *argv);
     exit(EXIT_FAILURE);
   } else {
     signal(SIGCHLD, catch_sigchild);


### PR DESCRIPTION
All I can tell there used to be exit calls in the code, but they accidentally got removed during refactoring in 4551810d8. This PR restores this.

Otherwise during a failed exec, we now suddenly have two processes running the same code, which can possibly accumulate to an exponentially growing number of processes.