### PR TITLE
Add experimental CUPTI Range Profiling backend for NVIDIA GPU

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ Q         ?= @
 # *.ptt -> *.pas -> *.s -> *.o -> executables
 # *.txt -> *.h (generated)
 
+CONFIG ?= config_range.mk
+include $(CONFIG)
 include ./config.mk
 include $(MAKE_DIR)/include_$(COMPILER).mk
 include $(MAKE_DIR)/config_git.mk
@@ -51,6 +53,19 @@ include $(MAKE_DIR)/config_defines.mk
 
 INCLUDES  += -I./src/includes -I$(LUA_INCLUDE_DIR) -I$(HWLOC_INCLUDE_DIR) -I$(BUILD_DIR)
 LIBS      += -ldl
+
+CUDA_HOME ?= /usr/local/cuda
+CUDA_LIBDIR  ?= $(CUDA_HOME)/lib64
+CUPTI_INC    ?= $(CUDA_HOME)/extras/CUPTI/include
+CUPTI_SAMPLES_COMMON ?= $(CUDA_HOME)/extras/CUPTI/samples/common
+CUPTI_SAMPLES_RANGE  ?= $(CUDA_HOME)/extras/CUPTI/samples/range_profiling
+CUPTI_LIBDIR ?= $(CUDA_HOME)/extras/CUPTI/lib64
+
+CFLAGS   += -I$(CUPTI_INC) -I$(CUPTI_SAMPLES_COMMON) -I$(CUPTI_SAMPLES_RANGE)
+CXXFLAGS += -fPIC -O2 -std=c++17 -I$(CUPTI_INC) -I$(CUPTI_SAMPLES_COMMON) -I$(CUPTI_SAMPLES_RANGE)
+
+LIBS     += -L$(CUDA_LIBDIR) -lcuda -lcudart
+LIBS     += -L$(CUPTI_LIBDIR) -lcupti
 
 #CONFIGURE BUILD SYSTEM
 BUILD_DIR  = ./$(COMPILER)
@@ -128,19 +143,6 @@ OBJ := $(filter-out $(BUILD_DIR)/access_x86_msr.o,$(OBJ))
 OBJ := $(filter-out $(BUILD_DIR)/access_x86_pci.o,$(OBJ))
 OBJ := $(filter-out $(BUILD_DIR)/access_x86_clientmem.o,$(OBJ))
 OBJ := $(filter-out $(BUILD_DIR)/access_x86_rdpmc.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/access_x86_translate.o,$(OBJ))
-else
-OBJ := $(filter-out $(BUILD_DIR)/loadDataARM.o,$(OBJ))
-endif
-ifeq ($(COMPILER), CLANGARMv8)
-OBJ := $(filter-out $(BUILD_DIR)/topology_cpuid.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/loadData.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/access_x86.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/access_x86_msr.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/access_x86_pci.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/access_x86_rdpmc.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/access_x86_mmio.o,$(OBJ))
-OBJ := $(filter-out $(BUILD_DIR)/access_x86_clientmem.o,$(OBJ))
 OBJ := $(filter-out $(BUILD_DIR)/access_x86_translate.o,$(OBJ))
 else
 OBJ := $(filter-out $(BUILD_DIR)/loadDataARM.o,$(OBJ))
@@ -288,7 +290,8 @@ $(STATIC_TARGET_LIB): $(OBJ) $(TARGET_HWLOC_LIB) $(TARGET_LUA_LIB)
 
 $(DYNAMIC_TARGET_LIB): $(OBJ) $(TARGET_HWLOC_LIB) $(TARGET_LUA_LIB)
 	@echo "===>  CREATE SHARED LIB  $(TARGET_LIB)"
-	$(Q)$(CC) $(DEBUG_FLAGS) $(SHARED_LFLAGS) -Wl,-soname,$(TARGET_LIB).$(VERSION).$(RELEASE),--no-undefined $(SHARED_CFLAGS) -o $@ $^ $(LIBS) $(RPATHS)
+# 	$(Q)$(CC) $(DEBUG_FLAGS) $(SHARED_LFLAGS) -Wl,-soname,$(TARGET_LIB).$(VERSION).$(RELEASE),--no-undefined $(SHARED_CFLAGS) -o $@ $^ $(LIBS) $(RPATHS)
+	$(Q)$(CXX) $(DEBUG_FLAGS) $(SHARED_LFLAGS) -Wl,-soname,$(TARGET_LIB).$(VERSION).$(RELEASE),--no-undefined $(SHARED_CFLAGS) -o $@ $^ $(LIBS) $(RPATHS)
 	@ln -sf $(TARGET_LIB) $(TARGET_LIB).$(VERSION).$(RELEASE)
 	@sed -e s#'@PREFIX@'#$(INSTALLED_PREFIX)#g \
 		-e s#'@NVIDIA_INTERFACE@'#$(NVIDIA_INTERFACE)#g \
@@ -363,25 +366,17 @@ $(BENCH_TARGET): $(TARGET_LIB)
 	$(Q)$(MAKE) --no-print-directory -C $(BENCH_FOLDER)
 
 #PATTERN RULES
-$(BUILD_DIR)/%.o: %.c
+$(BUILD_DIR)/%.o: %.c $(PERFMONHEADERS)
 	@echo "===>  COMPILE  $@"
 	@mkdir -p $(BUILD_DIR)
 	$(Q)$(CC) -c $(DEBUG_FLAGS) $(CFLAGS) $(ANSI_CFLAGS) $(CPPFLAGS) $< -o $@
 	$(Q)$(CC) $(DEBUG_FLAGS) $(CPPFLAGS) -MT $(@:.d=.o) -MM  $< > $(BUILD_DIR)/$*.d
 
-# At the moment the perfmon code is too complex to fix all unused variable warnings, so supress those for now
-$(BUILD_DIR)/perfmon.o: perfmon.c $(PERFMONHEADERS)
+$(BUILD_DIR)/rocmon_marker.o:  rocmon_marker.c
 	@echo "===>  COMPILE  $@"
 	@mkdir -p $(BUILD_DIR)
-	$(Q)$(CC) -c $(DEBUG_FLAGS) $(CFLAGS) $(ANSI_CFLAGS) -Wno-unused-variable $(CPPFLAGS) $< -o $@
-	$(Q)$(CC) $(DEBUG_FLAGS) $(CPPFLAGS) -MT $(@:.d=.o) -MM  $< > $(@:.o=.d)
-
-# same here
-$(BUILD_DIR)/intel_perfmon_uncore_discovery.o: intel_perfmon_uncore_discovery.c $(PERFMONHEADERS)
-	@echo "===>  COMPILE  $@"
-	@mkdir -p $(BUILD_DIR)
-	$(Q)$(CC) -c $(DEBUG_FLAGS) $(CFLAGS) $(ANSI_CFLAGS) -Wno-unused-variable $(CPPFLAGS) $< -o $@
-	$(Q)$(CC) $(DEBUG_FLAGS) $(CPPFLAGS) -MT $(@:.d=.o) -MM  $< > $(@:.o=.d)
+	$(Q)$(CC) -c $(DEBUG_FLAGS) $(CFLAGS) $(ANSI_CFLAGS) $(CPPFLAGS) $< -o $@
+	$(Q)objcopy --redefine-sym HSA_VEN_AMD_AQLPROFILE_LEGACY_PM4_PACKET_SIZE=HSA_VEN_AMD_AQLPROFILE_LEGACY_PM4_PACKET_SIZE2 $@
 
 $(BUILD_DIR)/%.o:  %.cc
 	@echo "===>  COMPILE  $@"
@@ -633,9 +628,6 @@ install: install_daemon install_freq install_appdaemon install_container_helper
 	@sed -e "s#<VERSION>#$(VERSION)#g" -e "s#<DATE>#$(DATE)#g" -e "s#<GITCOMMIT>#$(GITCOMMIT)#g" -e "s#<MINOR>#$(MINOR)#g" < $(DOC_DIR)/likwid-bench.1 > $(MANPREFIX)/man1/likwid-bench.1
 	@sed -e "s#<VERSION>#$(VERSION)#g" -e "s#<DATE>#$(DATE)#g" -e "s#<GITCOMMIT>#$(GITCOMMIT)#g" -e "s#<MINOR>#$(MINOR)#g" < $(DOC_DIR)/likwid-setFrequencies.1 > $(MANPREFIX)/man1/likwid-setFrequencies.1
 	@sed -e "s#.TH LUA#.TH LIKWID-LUA#g" -e "s#lua - Lua interpreter#likwid-lua - Lua interpreter included in LIKWID#g" -e "s#.B lua#.B likwid-lua#g" -e "s#.BR luac (1)##g" $(DOC_DIR)/likwid-lua.1 > $(MANPREFIX)/man1/likwid-lua.1
-	@if [ "$(BUILD_SYSFEATURES)" = "true" ]; then \
-		sed -e "s#<VERSION>#$(VERSION)#g" -e "s#<DATE>#$(DATE)#g" -e "s#<GITCOMMIT>#$(GITCOMMIT)#g" -e "s#<MINOR>#$(MINOR)#g" < $(DOC_DIR)/likwid-sysfeatures.1 > $(MANPREFIX)/man1/likwid-sysfeatures.1; \
-	fi
 	@chmod 644 $(MANPREFIX)/man1/likwid-*
 	@echo "===> INSTALL headers to $(PREFIX)/include"
 	@mkdir -p $(PREFIX)/include
@@ -869,12 +861,6 @@ help:
 	@echo "The common configuration is INSTALLED_PREFIX = PREFIX, so changing PREFIX is enough."
 	@echo "If PREFIX and INSTALLED_PREFIX differ, you have to move anything after 'make install' to"
 	@echo "the INSTALLED_PREFIX. You can also use 'make move' which does the job for you."
-
-.PHONY: format
-format:
-	find bench/ -type f -iname \*.c -exec clang-format -i '{}' '+'
-	find src/ -type f \( -iname \*.c -or \( -iname \*.h -and -not -iname \*perfmon_\*counters.h \) \) -exec clang-format -i '{}' '+'
-	find src/ -type f -iname \*perfmon_\*counters.h -exec clang-format --style='{BasedOnStyle: InheritParentConfig, ColumnLimit: 180}' -i '{}' '+'
 
 .PHONY: rpm RPM
 rpm: RPM

--- a/config.mk
+++ b/config.mk
@@ -9,7 +9,8 @@
 # Supported: GCC, CLANG, ICC, MIC (ICC), GCCX86 (for 32bit systems)
 # GCCARMv8, GCCARMv7, GCCPOWER and CLANGARMv8
 # Since 5.3, there is a generic GCCARM target
-COMPILER = GCC#NO SPACE
+# COMPILER = GCC#NO SPACE
+COMPILER = GCCARMv8#NO SPACE
 
 # Absolute path where to install likwid. If you need just an intermediate
 # install location, e.g. for packaging, use PREFIX for the intermediate
@@ -20,7 +21,8 @@ PREFIX ?= /usr/local#NO SPACE
 # Set the default mode for MSR access.
 # This can usually be overriden on the commandline.
 # Valid values are: direct, accessdaemon and perf_event
-ACCESSMODE = accessdaemon#NO SPACE
+# ACCESSMODE = accessdaemon#NO SPACE
+ACCESSMODE = perf_event
 
 # Build Fortran90 module interface for Marker API. Adopt Fortran compiler
 # in ./make/include_<COMPILER>.mk if necessary. Default: ifort (even for
@@ -32,7 +34,8 @@ INSTRUMENT_BENCH = true#NO SPACE
 
 # Build LIKWID with NVIDIA interface (CUDA, CUPTI)
 # For configuring include paths, go to CUDA section
-NVIDIA_INTERFACE = false#NO SPACE
+# NVIDIA_INTERFACE = false#NO SPACE
+NVIDIA_INTERFACE = true#NO SPACE
 
 # Build LIKWID with AMD GPU interface (ROCm)
 # For configuring include paths, go to ROCm section

--- a/config_range.mk
+++ b/config_range.mk
@@ -1,0 +1,22 @@
+CUDA_HOME ?= /usr/local/cuda
+
+# CUPTI headers + CUPTI sample helper headers
+CUPTI_INC := $(CUDA_HOME)/extras/CUPTI/include
+CUPTI_SAMPLES_COMMON := $(CUDA_HOME)/extras/CUPTI/samples/common
+CUPTI_SAMPLES_RANGE  := $(CUDA_HOME)/extras/CUPTI/samples/range_profiling
+
+CXX ?= g++
+CXXFLAGS += -fPIC -O2 -std=c++17 -I$(CUPTI_INC) -I$(CUPTI_SAMPLES_COMMON) -I$(CUPTI_SAMPLES_RANGE)
+LDFLAGS  += -L$(CUDA_HOME)/lib64 -L$(CUDA_HOME)/extras/CUPTI/lib64
+LDLIBS   += -lcupti -lcuda
+
+LIBS += -L$(CUDA_HOME)/extras/CUPTI/lib64 -lcupti -L$(CUDA_HOME)/lib64 -libcuda
+
+CUDA_LIBDIR  ?= $(CUDA_HOME)/lib64
+CUPTI_LIBDIR ?= $(CUDA_HOME)/extras/CUPTI/lib64
+
+LIBS += -L$(CUDA_LIBDIR)  -lcuda -lcudart
+LIBS += -L$(CUPTI_LIBDIR) -lcupti
+LIBS += -ldl -lpthread
+
+LDFLAGS += -Wl,-rpath,$(CUDA_LIBDIR) -Wl,-rpath,$(CUPTI_LIBDIR)

--- a/src/includes/nvmon_perfworks.h
+++ b/src/includes/nvmon_perfworks.h
@@ -38,10 +38,15 @@
 #include <cuda.h>
 #include <cuda_runtime_api.h>
 #ifndef bool
-#include <stdbool.h>
+#define bool int
+#define LOCAL_BOOL_DEF
 #endif
 #include <cupti_profiler_target.h>
 #include <cupti_target.h>
+#include "nvmon_range.h"
+#ifdef LOCAL_BOOL_DEF
+#undef bool
+#endif
 
 #include <nvperf_cuda_host.h>
 #include <nvperf_host.h>
@@ -1017,6 +1022,14 @@ static void dev_freeEventList(NvmonDevice *dev) {
 
 static void nvmon_perfworks_freeDevice(NvmonDevice_t dev) {
     if (dev) {
+        /* If the Range Profiling backend was selected, release its resources.
+         * (Safe to call even when the range backend wasn't initialized.)
+         */
+        if (getenv("LIKWID_NVMON_BACKEND") &&
+            strcmp(getenv("LIKWID_NVMON_BACKEND"), "range") == 0) {
+            (void)nvmon_range_finalize_device(dev->deviceId);
+        }
+
         free(dev->chip);
         dev->chip = NULL;
 
@@ -1068,6 +1081,17 @@ static void nvmon_perfworks_freeDevice(NvmonDevice_t dev) {
             dev_freeEventList(dev);
         }
     }
+}
+
+/* Range backend selection helper.
+ *
+ * We intentionally key off the same environment variable used by the existing
+ * nvmon_range prototype backend so users can switch behavior at runtime.
+ */
+static inline int nvmon_perfworks_use_range_backend(void)
+{
+    const char* bk = getenv("LIKWID_NVMON_BACKEND");
+    return (bk && (strcmp(bk, "range") == 0));
 }
 
 static void prepare_metric_name(bstring metric) {
@@ -2008,11 +2032,6 @@ static int nvmon_perfworks_addEventSet(NvmonDevice_t device,
             .structSize = CUpti_Profiler_GetCounterAvailability_Params_STRUCT_SIZE,
             .ctx = device->context,
         };
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 13010
-        if (cuda_version >= 13010 && cuda_runtime_version >= 13010) {
-            getCounterAvailabilityParams.bAllowDeviceLevelCounters = 1;
-        }
-#endif
         CUPTI_CALL(cuptiProfilerGetCounterAvailability,
                     &getCounterAvailabilityParams);
 
@@ -2374,9 +2393,54 @@ static int nvmon_perfworks_setupCounters(NvmonDevice_t device,
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Setup Counters on device %d",
             device->deviceId);
 
-    // cuptiProfiler_init();
+    /* Select implementation based on LIKWID_NVMON_BACKEND.
+     *
+     *  - default: CUPTI Profiling API (cuptiProfiler*)
+     *  - range  : CUPTI Range Profiling API (via nvmon_range.cc)
+     */
+    int ret = 0;
+    const char* backend = getenv("LIKWID_NVMON_BACKEND");
+    const int use_range = (backend && (strcmp(backend, "range") == 0));
 
-    int ret = nvmon_perfworks_setupCounterImageData(eventSet);
+    if (use_range)
+    {
+        /* Build list of real NVPerf metric names from the already-parsed
+         * LIKWID group definition.
+         */
+        const int nMetrics = eventSet->events ? eventSet->events->qty : 0;
+        const char** metricNames = NULL;
+        if (nMetrics > 0)
+        {
+            metricNames = (const char**)calloc((size_t)nMetrics, sizeof(char*));
+            if (!metricNames)
+            {
+                ret = -ENOMEM;
+            }
+            else
+            {
+                for (int i = 0; i < nMetrics; i++)
+                    metricNames[i] = bdata(eventSet->events->entry[i]);
+
+                /* Initialize the Range Profiling target for these metrics.
+                 * This keeps LIKWID's public interface unchanged (-W groups),
+                 * while switching the underlying collection API.
+                 */
+                if (nvmon_range_init_device(device->deviceId, metricNames, nMetrics) != 0)
+                    ret = -EFAULT;
+            }
+        }
+        else
+        {
+            /* No metrics -> nothing to set up */
+            ret = 0;
+        }
+        free((void*)metricNames);
+    }
+    else
+    {
+        ret = nvmon_perfworks_setupCounterImageData(eventSet);
+    }
+
     device->activeEventSet = eventSet->id;
     nvGroupSet->activeGroup = eventSet->id;
     if (popContext > 0) {
@@ -2406,6 +2470,34 @@ static int nvmon_perfworks_startCounters(NvmonDevice_t device) {
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Start Counters on device %d (Eventset %d)",
             device->deviceId, device->activeEventSet);
     NvmonEventSet *eventSet = &device->nvEventSets[device->activeEventSet];
+
+    const char* backend = getenv("LIKWID_NVMON_BACKEND");
+    const int use_range = (backend && (strcmp(backend, "range") == 0));
+    if (use_range)
+    {
+        /* In Range mode, we collect the metrics configured in setupCounters()
+         * using CUPTI Range Profiling API (implemented in nvmon_range.cc).
+         * We push a single user range per start/stop window.
+         */
+        const char* tag = "likwid_nvmon";
+        (void)eventSet;
+        if (nvGroupSet && nvGroupSet->groups && device->activeEventSet >= 0)
+        {
+            const char* gname = nvGroupSet->groups[device->activeEventSet].groupname;
+            if (gname && gname[0] != '\0')
+                tag = gname;
+        }
+        if (nvmon_range_region_start(device->deviceId, tag) != 0)
+            return -EFAULT;
+
+        if (popContext > 0) {
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %p for device %d", device->context, device->deviceId);
+            CU_CALL(cuCtxPopCurrent,&device->context);
+        }
+        if (curDeviceId != device->deviceId)
+            CUDA_CALL(cudaSetDevice,curDeviceId);
+        return 0;
+    }
 
     CUpti_Profiler_BeginSession_Params beginSessionParams = {
         .structSize = CUpti_Profiler_BeginSession_Params_STRUCT_SIZE,
@@ -2489,6 +2581,81 @@ static int nvmon_perfworks_stopCounters(NvmonDevice_t device) {
     GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Stop Counters on device %d (Eventset %d)",
             device->deviceId, device->activeEventSet);
     NvmonEventSet *eventSet = &device->nvEventSets[device->activeEventSet];
+
+    const char* backend = getenv("LIKWID_NVMON_BACKEND");
+    const int use_range = (backend && (strcmp(backend, "range") == 0));
+    if (use_range)
+    {
+        /* Stop the range and decode counter data. */
+        if (nvmon_range_region_stop(device->deviceId, NULL) != 0)
+            return -EFAULT;
+        if (nvmon_range_decode_counter_data(device->deviceId) != 0)
+            return -EFAULT;
+
+        /* Copy counter data image into the event set buffer so we can reuse
+         * nvmon_perfworks_getMetricValue() without duplicating the evaluator.
+         */
+        const uint8_t* pData = NULL;
+        size_t dataSize = 0;
+        if (nvmon_range_get_counter_data(device->deviceId, &pData, &dataSize) != 0 || !pData || dataSize == 0)
+            return -EFAULT;
+
+        if (eventSet->counterDataImage == NULL || eventSet->counterDataImageSize != dataSize)
+        {
+            free(eventSet->counterDataImage);
+            eventSet->counterDataImage = (uint8_t*)malloc(dataSize);
+            if (!eventSet->counterDataImage)
+                return -ENOMEM;
+            eventSet->counterDataImageSize = dataSize;
+        }
+        memcpy(eventSet->counterDataImage, pData, dataSize);
+
+        double *values = NULL;
+        int err = nvmon_perfworks_getMetricValue(device->chip, eventSet, &values);
+        if (err < 0)
+            return err;
+
+        for (int j = 0; j < eventSet->numberOfEvents; j++) {
+            double res = values[j];
+            NvmonEvent_t nve = eventSet->nvEvents[j];
+            eventSet->results[j].lastValue = res;
+            switch (nve->rtype) {
+            case ENTITY_TYPE_SUM:
+                eventSet->results[j].fullValue += res;
+                break;
+            case ENTITY_TYPE_MIN:
+                eventSet->results[j].fullValue = (res < eventSet->results[j].fullValue
+                        ? res
+                        : eventSet->results[j].fullValue);
+                break;
+            case ENTITY_TYPE_MAX:
+                eventSet->results[j].fullValue = (res > eventSet->results[j].fullValue
+                        ? res
+                        : eventSet->results[j].fullValue);
+                break;
+            case ENTITY_TYPE_INSTANT:
+                eventSet->results[j].fullValue = res;
+                break;
+            }
+            eventSet->results[j].stopValue = eventSet->results[j].fullValue;
+            eventSet->results[j].overflows = 0;
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "%s Last %f Full %f",
+                    bdata(eventSet->events->entry[j]),
+                    eventSet->results[j].lastValue,
+                    eventSet->results[j].fullValue);
+        }
+
+        free(values);
+
+        if (popContext > 0) {
+            GPUDEBUG_PRINT(DEBUGLEV_DEVELOP, "Pop Context %p for device %d", device->context, device->deviceId);
+            CU_CALL(cuCtxPopCurrent,&device->context);
+        }
+        if (curDeviceId != device->deviceId)
+            CUDA_CALL(cudaSetDevice,curDeviceId);
+
+        return 0;
+    }
 
     size_t CUpti_Profiler_EndPass_Params_size = 0;
     size_t CUpti_Profiler_FlushCounterData_Params_size = 0;

--- a/src/includes/nvmon_range.h
+++ b/src/includes/nvmon_range.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+int nvmon_range_init_device(int devid, const char** metricNames, int nMetrics);
+int nvmon_range_region_start(int devid, const char* tag);
+int nvmon_range_region_stop (int devid, const char* tag);
+int nvmon_range_evaluate   (int devid, const char* tag);
+int nvmon_range_finalize_device(int devid);
+
+int nvmon_range_decode_counter_data(int devid);
+int nvmon_range_get_counter_data(int devid, const uint8_t** pData, size_t* pSize);
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/src/nvmon_range.cc
+++ b/src/nvmon_range.cc
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0
+#include "includes/nvmon_range.h"
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <range_profiling.h>   // CUDA: extras/CUPTI/samples/range_profiling
+
+#include <vector>
+#include <string>
+#include <memory>
+#include <unordered_map>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#define CHECK_CUDA(call) do {                                     \
+    CUresult _r = (call);                                         \
+    if (_r != CUDA_SUCCESS) {                                     \
+        const char* errstr = nullptr;                             \
+        cuGetErrorString(_r, &errstr);                            \
+        fprintf(stderr, "CUDA Driver error %d (%s) at %s:%d\n",   \
+                (int)_r, errstr ? errstr : "unknown", __FILE__, __LINE__); \
+        return -1;                                                \
+    }                                                             \
+} while(0)
+
+struct RangeCtx {
+    CUdevice device = 0;
+    CUcontext ctx  = nullptr;
+    RangeProfilerConfig    cfg;
+    RangeProfilerTargetPtr pTgt;
+    CuptiProfilerHostPtr   pHost;
+    std::vector<uint8_t>   availabilityImage;
+    std::vector<uint8_t>   configImage;
+    std::vector<uint8_t>   counterDataImage;
+    std::vector<std::string> metricsOwned;
+    std::vector<const char*> metricsCStr;
+    // CUpti_ProfilerReplayMode replayMode = CUPTI_KernelReplay;
+    CUpti_ProfilerReplayMode  replayMode = CUPTI_UserReplay;
+    bool enabled = false;
+};
+static std::unordered_map<int, RangeCtx> g_ctx;
+
+static void fill_metrics(RangeCtx& C, const char** metricNames, int nMetrics)
+{
+    C.metricsOwned.clear(); C.metricsCStr.clear();
+    C.metricsOwned.reserve(nMetrics); C.metricsCStr.reserve(nMetrics);
+    for (int i = 0; i < nMetrics; ++i)
+        C.metricsOwned.emplace_back(metricNames && metricNames[i] ? metricNames[i] : "");
+    for (auto& s : C.metricsOwned) C.metricsCStr.push_back(s.c_str());
+}
+
+int nvmon_range_init_device(int devid, const char** metricNames, int nMetrics)
+{
+    RangeCtx& C = g_ctx[devid];
+    CHECK_CUDA(cuInit(0));
+    CHECK_CUDA(cuDeviceGet(&C.device, devid));
+    CHECK_CUDA(cuDevicePrimaryCtxRetain(&C.ctx, C.device));
+    CHECK_CUDA(cuCtxSetCurrent(C.ctx));
+
+    if (metricNames && nMetrics > 0) fill_metrics(C, metricNames, nMetrics);
+    else {
+        static const char* kDefault[] = {"sm__ctas_launched.sum"};
+        fill_metrics(C, kDefault, 1);
+    }
+
+    C.cfg.maxNumOfRanges = 4;
+    C.cfg.minNestingLevel = 1;
+    C.cfg.numOfNestingLevel = 1;
+
+    C.pHost = std::make_shared<CuptiProfilerHost>();
+    C.pTgt  = std::make_shared<RangeProfilerTarget>(C.ctx, C.cfg);
+
+    std::string chipName;
+    CUPTI_API_CALL(RangeProfilerTarget::GetChipName(C.device, chipName));
+    CUPTI_API_CALL(RangeProfilerTarget::GetCounterAvailabilityImage(C.ctx, C.availabilityImage));
+
+    C.pHost->SetUp(chipName, C.availabilityImage);
+    CUPTI_API_CALL(C.pHost->CreateConfigImage(C.metricsCStr, C.configImage));
+    CUPTI_API_CALL(C.pTgt->EnableRangeProfiler());
+    CUPTI_API_CALL(C.pTgt->CreateCounterDataImage(C.metricsCStr, C.counterDataImage));
+
+    // if (const char* rm = std::getenv("LIKWID_NVMON_REPLAY"))
+    //     C.replayMode = (strcmp(rm, "user")==0) ? CUPTI_UserReplay : CUPTI_KernelReplay;
+
+    // CUPTI_API_CALL(C.pTgt->SetConfig(
+    //     CUPTI_UserRange, C.replayMode, C.configImage, C.counterDataImage
+    // ));
+    // C.enabled = true;
+    // return 0;
+
+    C.replayMode = CUPTI_UserReplay;
+
+    if (const char* rm = std::getenv("LIKWID_NVMON_REPLAY")) {
+        if (strcmp(rm, "kernel") == 0)
+            C.replayMode = CUPTI_KernelReplay;
+        else
+            C.replayMode = CUPTI_UserReplay; 
+    }
+
+    CUPTI_API_CALL(C.pTgt->SetConfig(
+        CUPTI_UserRange,
+        C.replayMode,
+        C.configImage,
+        C.counterDataImage
+    ));
+
+    C.enabled = true;
+    return 0;
+}
+
+int nvmon_range_region_start(int devid, const char* tag)
+{
+    auto it = g_ctx.find(devid);
+    if (it == g_ctx.end() || !it->second.enabled) return -1;
+    RangeCtx& C = it->second;
+
+    /* The counter data image must be (re)initialized for every measurement window.
+     * The CUDA samples do this in the "set up" phase; LIKWID may call start/stop
+     * multiple times (marker mode, readCounters, etc.). Re-create + re-set config
+     * so each measurement starts from a clean counter data image.
+     */
+    CUPTI_API_CALL(C.pTgt->CreateCounterDataImage(C.metricsCStr, C.counterDataImage));
+    CUPTI_API_CALL(C.pTgt->SetConfig(
+        CUPTI_UserRange,
+        C.replayMode,
+        C.configImage,
+        C.counterDataImage
+    ));
+
+    CUPTI_API_CALL(C.pTgt->StartRangeProfiler());
+    CUPTI_API_CALL(C.pTgt->PushRange(tag ? tag : "LIKWID"));
+    return 0;
+}
+
+int nvmon_range_region_stop(int devid, const char*)
+{
+    auto it = g_ctx.find(devid);
+    if (it == g_ctx.end() || !it->second.enabled) return -1;
+    RangeCtx& C = it->second;
+    CUPTI_API_CALL(C.pTgt->PopRange());
+    CUPTI_API_CALL(C.pTgt->StopRangeProfiler());
+    return 0;
+}
+
+int nvmon_range_decode_counter_data(int devid)
+{
+    auto it = g_ctx.find(devid);
+    if (it == g_ctx.end() || !it->second.enabled) return -1;
+    RangeCtx& C = it->second;
+    CUPTI_API_CALL(C.pTgt->DecodeCounterData());
+    return 0;
+}
+
+int nvmon_range_get_counter_data(int devid, const uint8_t** pData, size_t* pSize)
+{
+    if (!pData || !pSize) return -1;
+    auto it = g_ctx.find(devid);
+    if (it == g_ctx.end() || !it->second.enabled) return -1;
+    RangeCtx& C = it->second;
+    *pData = C.counterDataImage.data();
+    *pSize = C.counterDataImage.size();
+    return 0;
+}
+
+int nvmon_range_evaluate(int devid, const char*)
+{
+    auto it = g_ctx.find(devid);
+    if (it == g_ctx.end() || !it->second.enabled) return -1;
+    RangeCtx& C = it->second;
+
+    // ここで Decode するように変更
+    CUPTI_API_CALL(C.pTgt->DecodeCounterData());
+
+    size_t numRanges = 0;
+    CUPTI_API_CALL(C.pHost->GetNumOfRanges(C.counterDataImage, numRanges));
+    for (size_t r = 0; r < numRanges; ++r)
+        CUPTI_API_CALL(C.pHost->EvaluateCounterData(r, C.metricsCStr, C.counterDataImage));
+    C.pHost->PrintProfilerRanges();
+    return 0;
+}
+
+int nvmon_range_finalize_device(int devid)
+{
+    auto it = g_ctx.find(devid);
+    if (it == g_ctx.end()) return 0;
+    RangeCtx& C = it->second;
+    if (C.pTgt) { (void)C.pTgt->DisableRangeProfiler(); C.pTgt.reset(); }
+    if (C.pHost){ C.pHost->TearDown(); C.pHost.reset(); }
+    if (C.ctx)  { cuDevicePrimaryCtxRelease(C.device); C.ctx = nullptr; }
+    C.enabled = false;
+    g_ctx.erase(it);
+    return 0;
+}


### PR DESCRIPTION
This is a draft PR for an experimental LIKWID 5.5.1 derivative with a CUPTI Range Profiling backend for NVIDIA GPUs.

This branch is range-backend-oriented and was tested in my environment with CUDA 12.6.

The main purpose of this change is to replace the CUPTI Profiling API backend currently used for NVIDIA GPU performance counter measurements with the newer CUPTI Range Profiling API.
In my H100 environment, this resolved run-to-run power fluctuation and incorrect counter value issues observed when using `likwid-perfctr`, improving the reliability of NVIDIA GPU counter measurements.

Main changes:
- Add `src/nvmon_range.cc`
- Add `src/includes/nvmon_range.h`
- Add Range Profiling API integration in `src/includes/nvmon_perfworks.h`
- Update `Makefile`, `config.mk`, and add `config_range.mk` for this derivative build

Build example:

```bash
module load cuda/12.6
export CUDA_HOME=${CUDA_HOME:-$(dirname $(dirname "$(which nvcc)"))}
export LD_LIBRARY_PATH=$CUDA_HOME/lib64:$CUDA_HOME/extras/CUPTI/lib64:$LD_LIBRARY_PATH

export LIKWID_INSTALL_PREFIX=/path/to/likwid-range-backend

make distclean

make -j all \
  PREFIX=$LIKWID_INSTALL_PREFIX \
  INSTALLED_PREFIX=$LIKWID_INSTALL_PREFIX \
  BINPREFIX=$LIKWID_INSTALL_PREFIX/bin \
  LIBPREFIX=$LIKWID_INSTALL_PREFIX/lib \
  MANPREFIX=$LIKWID_INSTALL_PREFIX/share/man \
  SBINPREFIX=$LIKWID_INSTALL_PREFIX/sbin \
  INSTALLED_BINPREFIX=$LIKWID_INSTALL_PREFIX/bin \
  INSTALLED_LIBPREFIX=$LIKWID_INSTALL_PREFIX/lib

make install \
  PREFIX=$LIKWID_INSTALL_PREFIX \
  INSTALLED_PREFIX=$LIKWID_INSTALL_PREFIX \
  BINPREFIX=$LIKWID_INSTALL_PREFIX/bin \
  LIBPREFIX=$LIKWID_INSTALL_PREFIX/lib \
  MANPREFIX=$LIKWID_INSTALL_PREFIX/share/man \
  SBINPREFIX=$LIKWID_INSTALL_PREFIX/sbin \
  INSTALLED_BINPREFIX=$LIKWID_INSTALL_PREFIX/bin \
  INSTALLED_LIBPREFIX=$LIKWID_INSTALL_PREFIX/lib
  
Runtime example:

```bash
module load cuda/12.6
export CUDA_HOME=${CUDA_HOME:-$(dirname $(dirname "$(which nvcc)"))}

export LIKWID_INSTALL_PREFIX=/path/to/likwid-range-backend
export LIKWID_BIN=$LIKWID_INSTALL_PREFIX/bin
export LIKWID_LIB=$LIKWID_INSTALL_PREFIX/lib
export LIKWID_INC=$LIKWID_INSTALL_PREFIX/include

export LD_LIBRARY_PATH=$LIKWID_LIB:$CUDA_HOME/extras/CUPTI/lib64:$CUDA_HOME/lib64:${LD_LIBRARY_PATH:-}
export LIKWID_NVMON_BACKEND=range

$LIKWID_BIN/likwid-perfctr -G 0 -W EVENT_SET -m -O ./app