### PR TITLE
New pthread overload

### DIFF
--- a/src/applications/likwid-perfctr.lua
+++ b/src/applications/likwid-perfctr.lua
@@ -1050,6 +1050,12 @@ if pin_cpus then
         end
         likwid.setenv("LIKWID_PIN", pinString)
 
+        local placesString = string.format("{%d}", cpulist[1])
+        for i=2,likwid.tablelength(cpulist) do
+            placesString = placesString .. "," .. string.format("{%d}", cpulist[i])
+        end
+        likwid.setenv("OMP_PLACES", placesString)
+
         local preload = os.getenv("LD_PRELOAD")
         if preload == nil then
             likwid.setenv("LD_PRELOAD", likwid.pinlibpath)
@@ -1057,6 +1063,7 @@ if pin_cpus then
             likwid.setenv("LD_PRELOAD", likwid.pinlibpath .. ":" .. preload)
         end
     elseif num_cpus == 1 then
+        likwid.setenv("OMP_PLACES", string.format("{%d}", cpulist[1]))
         likwid.setenv("LIKWID_PIN", tostring(math.tointeger(cpulist[1])))
         if verbose > 0 then
             likwid.pinProcess(cpulist[1], 0)

--- a/src/applications/likwid-perfctr.lua
+++ b/src/applications/likwid-perfctr.lua
@@ -1044,11 +1044,10 @@ if pin_cpus then
     likwid.setenv("KMP_AFFINITY", "disabled")
 
     if num_cpus > 1 then
-        local pinString = tostring(math.tointeger(cpulist[2]))
-        for i = 3, likwid.tablelength(cpulist) do
+        local pinString = tostring(math.tointeger(cpulist[1]))
+        for i = 2, likwid.tablelength(cpulist) do
             pinString = pinString .. "," .. tostring(math.tointeger(cpulist[i]))
         end
-        pinString = pinString .. "," .. tostring(math.tointeger(cpulist[1]))
         likwid.setenv("LIKWID_PIN", pinString)
 
         local preload = os.getenv("LD_PRELOAD")

--- a/src/applications/likwid-pin.lua
+++ b/src/applications/likwid-pin.lua
@@ -292,6 +292,12 @@ if num_threads > 1 then
     end
     likwid.setenv("LIKWID_PIN", pinString)
 
+    local placesString = string.format("{%d}", cpu_list[1])
+    for i=2,likwid.tablelength(cpu_list) do
+        placesString = placesString .. "," .. string.format("{%d}", cpu_list[i])
+    end
+    likwid.setenv("OMP_PLACES", placesString)
+
     local preload = os.getenv("LD_PRELOAD")
     if preload == nil then
         likwid.setenv("LD_PRELOAD",likwid.pinlibpath)
@@ -307,6 +313,7 @@ if num_threads > 1 then
     end
 else
     likwid.setenv("LIKWID_PIN", tostring(math.tointeger(cpu_list[1])))
+    likwid.setenv("OMP_PLACES", string.format("{%d}", cpu_list[1]))
     likwid.pinProcess(cpu_list[1], quiet)
 end
 

--- a/src/applications/likwid-pin.lua
+++ b/src/applications/likwid-pin.lua
@@ -286,11 +286,10 @@ if skip_mask then
 end
 
 if num_threads > 1 then
-    local pinString = tostring(math.tointeger(cpu_list[2]))
-    for i=3,likwid.tablelength(cpu_list) do
+    local pinString = tostring(math.tointeger(cpu_list[1]))
+    for i=2,likwid.tablelength(cpu_list) do
         pinString = pinString .. "," .. tostring(math.tointeger(cpu_list[i]))
     end
-    pinString = pinString .. "," .. tostring(math.tointeger(cpu_list[1]))
     likwid.setenv("LIKWID_PIN", pinString)
 
     local preload = os.getenv("LD_PRELOAD")

--- a/src/pthread-overload/Makefile
+++ b/src/pthread-overload/Makefile
@@ -46,7 +46,9 @@ INCLUDES += -I../includes
 LIBS     += -ldl
 CPPFLAGS := $(CPPFLAGS) $(DEFINES) $(INCLUDES)
 
-all: ../../$(TARGET)
+.PHONY: all
+
+all: $(TARGET)
 
 $(TARGET): pthread-overload.c
 	$(Q)$(CC) -Wl,-soname,$(notdir $(TARGET)).$(VERSION).$(RELEASE),--no-undefined $(CFLAGS) $(ANSI_CFLAGS) $(CPPFLAGS) $(INCLUDES) $(SHARED_CFLAGS) $(SHARED_LFLAGS) -o $@ pthread-overload.c $(LIBS)

--- a/src/pthread-overload/pthread-overload.c
+++ b/src/pthread-overload/pthread-overload.c
@@ -29,317 +29,304 @@
  * =======================================================================================
  */
 
+#include <assert.h>
+#include <errno.h>
+#include <link.h>
+#include <sched.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <dlfcn.h>
-#include <sched.h>
-#include <sys/types.h>
-#include <errno.h>
-#include <dirent.h>
-#include <unistd.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/syscall.h>
-#include <pthread.h>
+
+#include <types.h>
 
 #ifdef COLOR
 #include <textcolor.h>
 #endif
 
-#define STRINGIFY(x) #x
-#define TOSTRING(x) STRINGIFY(x)
-#define LLU_CAST  (unsigned long long)
+typedef void *(*start_routine_ptr)(void *);
 
-#define gettid() syscall(SYS_gettid)
+typedef int (*pthread_create_ptr)(
+        pthread_t *thread,
+        const pthread_attr_t *attr,
+        start_routine_ptr start_routine,
+        void *arg);
 
-extern int pthread_setaffinity_np(pthread_t thread, size_t cpusetsize, const cpu_set_t *cpuset);
-
-static char * sosearchpaths[] = {
-#ifdef LIBPTHREAD
-    TOSTRING(LIBPTHREAD),
-#endif
-    "/lib64/tls/libpthread.so.0",/* sles9 x86_64 */
-    "libpthread.so.0",           /* Ubuntu */
-    NULL
+struct pthread_create_wrapper_arg {
+    start_routine_ptr start_routine_orig;
+    void *arg_orig;
 };
 
+static bool silent = false;
+
+static uint32_t *pin_ids;
+static size_t pin_ids_count;
+static uint64_t pin_skip_mask;
+
+static uintptr_t openmp_text_start;
+static uintptr_t openmp_text_end;
+static bool openmp_found = false;
+
+static pthread_create_ptr pthread_create_orig;
+
+static void pdie(const char *msg)
+{
+    perror(msg);
+    abort();
+}
+
+static void die(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+
+    vfprintf(stderr, fmt, args);
+    abort();
+
+    va_end(args);
+}
+
+static void color_print_begin(void)
+{
+    if (silent)
+        return;
 
 #ifdef COLOR
-#define color_print(format,...) do { \
-        color_on(BRIGHT, COLOR); \
-        printf(format, ##__VA_ARGS__); \
-        color_reset(); \
-    } while(0)
-#else
-#define color_print(format,...) do { \
-        printf(format, ##__VA_ARGS__); \
-    } while(0)
+    fprintf(stderr, "\e[1;%dm", COLOR + 30);
 #endif
+    fprintf(stderr, "[pthread wrapper] ");
+}
 
-static int *pin_ids = NULL;
-static int ncpus = 0;
-static uint64_t skipMask = 0x0;
-static int silent = 0;
-static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static void color_vprint_main(const char *fmt, va_list args)
+{
+    if (silent)
+        return;
+
+    vfprintf(stderr, fmt, args);
+}
+
+static void __attribute__((format(printf, 1, 2))) color_print_main(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+
+    color_vprint_main(fmt, args);
+
+    va_end(args);
+}
+
+static void color_print_end(void)
+{
+    if (silent)
+        return;
+
+#ifdef COLOR
+    fprintf(stderr, "\e[0m");
+#endif
+}
+
+static void __attribute__((format(printf, 1, 2))) color_print(const char *fmt, ...) 
+{
+    va_list args;
+    va_start(args, fmt);
+
+    color_print_begin();
+    color_vprint_main(fmt, args);
+    color_print_end();
+
+    va_end(args);
+}
+
+static void init_pin_ids(const char *pin_str_orig)
+{
+    const long avail_cpus = sysconf(_SC_NPROCESSORS_CONF);
+
+    char *pin_str = strdup(pin_str_orig);
+    if (!pin_str)
+        pdie("strdup");
+
+    // parse LIKWID_PIN string
+    char *saveptr = NULL;
+    for (char *token = strtok_r(pin_str, ",", &saveptr); token; token = strtok_r(NULL, ",", &saveptr)) {
+        errno = 0;
+        const unsigned long pin_id = strtoul(token, NULL, 10);
+        if (errno != 0)
+            die("Cannot parse CPU ID '%s': %s\n", token, strerror(errno));
+
+        if (pin_id >= (uint32_t)avail_cpus)
+            die("CPU ID %lu exceeds maximum number of CPUs (%ld)\n", pin_id, avail_cpus);
+
+        const size_t pin_ids_count_new = pin_ids_count + 1;
+        uint32_t *pin_ids_new = realloc(pin_ids, pin_ids_count_new * sizeof(*pin_ids));
+        if (!pin_ids_new)
+            pdie("realloc");
+
+        pin_ids = pin_ids_new;
+        pin_ids[pin_ids_count] = (uint32_t)pin_id;
+        pin_ids_count = pin_ids_count_new;
+    }
+
+    free(pin_str);
+
+    color_print_begin();
+    color_print_main("PIN MAP (PID=%d):\n", getpid());
+
+    const size_t COLUMN_COUNT = 8;
+    size_t column = 0;
+    for (size_t i = 0; i < pin_ids_count; i++) {
+        if (column == 0)
+            color_print_main("  %4zu -> %4u", i, pin_ids[i]);
+        else
+            color_print_main(" | %4zu -> %4u", i, pin_ids[i]);
+        if (column + 1 >= COLUMN_COUNT) {
+            color_print_main("\n");
+            column = 0;
+        } else {
+            column += 1;
+        }
+    }
+
+    color_print_end();
+}
+
+static int find_openmp_callback(struct dl_phdr_info *dl_info, size_t size, void *data)
+{
+    (void)size;
+    (void)data;
+
+    static const char *omp_patterns[] = {
+        "libgomp.so.1.0.0",
+        "libgomp.so.1",
+        "libiomp.so",
+        "libiomp5.so",
+        "libomp.so",
+        "libomp5.so",
+        "libomp.so.5",
+    };
+
+
+    /* Check if the current library matches any of our patterns. */
+    bool is_openmp = false;
+    for (size_t i = 0; i < ARRAY_COUNT(omp_patterns); i++) {
+        /* Check if a pattern matches */
+        if (strstr(dl_info->dlpi_name, omp_patterns[i])) {
+            is_openmp = true;
+            break;
+        }
+    }
+
+    if (!is_openmp)
+        return 0;
+
+    /* If we found a matching library previously, raise an error, since we
+     * cannot reliably determine, which one is actually the right.
+     * An application shouldn't be able to ship with multiple OpenMP runtimes.
+     * What could still happen is that our patterns are unreliable
+     * and falsely detects a library as OpenMP library. */
+    if (openmp_found)
+        die("Conflicting OpenMP library detected. Did LIKWID detect one incorrectly?: %s", dl_info->dlpi_name);
+
+    openmp_found = true;
+
+    color_print("Found OpenMP runtime: %s\n", dl_info->dlpi_name);
+
+    /* Okay, we found the OpenMP library. Now let's find the .text section.
+     * While we cannot read the section name, we can see if a section is executable.
+     * We use this section address range in order to determine whether a function
+     * is an OpenMP function or not.
+     *
+     * It may be possible that a library has more than one executable section.
+     * So far we haven't seen this during development. Should it happen in the future,
+     * we will have to memorize the address range of multiple sections instead of just one. */
+
+    bool text_found = false;
+    for (size_t i = 0; i < dl_info->dlpi_phnum; i++) {
+        const ElfW(Phdr) *phdr = &dl_info->dlpi_phdr[i];
+
+        /* If the section isn't loaded or executed, ignore it.
+         * Those sections cannot be our code section. */
+        if (phdr->p_type != PT_LOAD || !(phdr->p_flags & PF_X))
+            continue;
+
+        /* If we've found an executable section previously, raise an error.
+         * This shouldn't happen. If this happens for a legit reason (because the library
+         * actually has multiple executable sections), then we have to memorize all address ranges. */
+        if (text_found)
+            die("Multiple OpenMP executable sections found. "
+                "Support for multiple executable sections is not yet implemented\n");
+
+        openmp_text_start = dl_info->dlpi_addr + phdr->p_vaddr;
+        openmp_text_end = openmp_text_start + phdr->p_memsz;
+        text_found = true;
+    }
+
+    return 0;
+}
+
+static void find_openmp(void)
+{
+    // Search for all loaded shared libraries and see, if they look like an OpenMP library.
+    dl_iterate_phdr(find_openmp_callback, NULL);
+}
+
+static void find_pthread(void)
+{
+    // Clear (possible) previous error
+    dlerror();
+    pthread_create_orig = dlsym(RTLD_NEXT, "pthread_create");
+    const char *err = dlerror();
+    if (err)
+        fprintf(stderr, "Cannot find pthread_create (Does the program use pthreads?): %s\n", err);
+}
+
+static void init_omp_places(void)
+{
+    char *omp_places_str = NULL;
+    for (size_t i = 0; i < pin_ids_count; i++) {
+        char *omp_places_str_new;
+        int ret;
+        if (omp_places_str)
+            ret = asprintf(&omp_places_str_new, "%s,{%u}", omp_places_str, pin_ids[i]);
+        else
+            ret = asprintf(&omp_places_str_new, "{%u}", pin_ids[i]);
+
+        if (ret < 0)
+            pdie("asprintf");
+
+        free(omp_places_str);
+        omp_places_str = omp_places_str_new;
+    }
+
+    if (setenv("OMP_PLACES", omp_places_str, true) < 0)
+        pdie("setenv");
+}
 
 void __attribute__((constructor (103))) init_pthread_overload(void)
 {
-    char *str = NULL, *pinstr = NULL;
-    char *token = NULL, *saveptr = NULL;
-    char *delimiter = ",";
-    int i = 0, ret = 0;
-    static long avail_cpus = 0;
-    avail_cpus = sysconf(_SC_NPROCESSORS_CONF);
-    pin_ids = malloc(avail_cpus * sizeof(int));
-    memset(pin_ids, 0, avail_cpus * sizeof(int));
-    str = getenv("LIKWID_PIN");
-    if (str != NULL)
-    {
-        pinstr = malloc((strlen(str)+2) * sizeof(char));
-        if (!pinstr)
-        {
-            free(pin_ids);
-            pin_ids = NULL;
-            return;
-        }
-        ret = snprintf(pinstr, (strlen(str)+1), "%s", str);
-        if (ret <= 0)
-        {
-            free(pin_ids);
-            pin_ids = NULL;
-            return;
-        }
-        pinstr[ret] = '\0';
-        saveptr = pinstr;
-        token = pinstr;
-        while (token)
-        {
-            token = strtok_r(saveptr, delimiter ,&saveptr);
-            if (token)
-            {
-                ncpus++;
-                pin_ids[i++] = strtoul(token, &token, 10);
-            }
-        }
-        free(pinstr);
-    }
-    str = getenv("LIKWID_SKIP");
-    if (str != NULL)
-    {
-        skipMask = strtoul(str, &str, 16);
-    }
+    pin_ids = NULL;
+    pin_ids_count = 0;
 
-    if (getenv("LIKWID_SILENT") != NULL)
-    {
-        silent = 1;
-    }
-}
+    const char *pin_str_orig = getenv("LIKWID_PIN");
+    if (pin_str_orig)
+        init_pin_ids(pin_str_orig);
+    else
+        color_print("LIKWID_PIN environment variable not set. Disabling pinning.\n");
 
-int __attribute__ ((visibility ("default") ))
-pthread_create(pthread_t* thread,
-        const pthread_attr_t* attr,
-        void* (*start_routine)(void *),
-        void * arg)
-{
-    void *handle;
-    char *error;
-    int (*rptc) (pthread_t *, const pthread_attr_t *, void* (*start_routine)(void *), void *);
-    int ret;
-    static int reallpthrindex = 0;
-    static int npinned = 0;
-    static int ncalled = 0;
-    static int overflow = 0;
-    static int overflowed = 0;
-    static long online_cpus = 0;
-    static int shepherd = 0;
-    online_cpus = sysconf(_SC_NPROCESSORS_ONLN);
-    pthread_mutex_lock(&mutex);
+    const char *skip_str = getenv("LIKWID_SKIP");
+    if (skip_str)
+        pin_skip_mask = strtoull(skip_str, NULL, 16);
 
-    /* On first entry: Get Evironment Variable and initialize pin_ids */
-    if (ncalled == 0 && pin_ids != NULL)
-    {
-        char* str = NULL;
-        cpu_set_t cpuset;
+    if (pin_skip_mask != 0)
+        color_print("PIN SKIP MASK: %#" PRIx64 "\n", pin_skip_mask);
 
-        if (!silent)
-        {
-            color_print("[pthread wrapper] \n");
-        }
+    if (getenv("LIKWID_SILENT"))
+        silent = true;
 
-        str = getenv("LIKWID_PIN");
-        if (str != NULL)
-        {
-            CPU_ZERO(&cpuset);
-            CPU_SET(pin_ids[ncpus-1], &cpuset);
-            ret = sched_setaffinity(getpid(), sizeof(cpu_set_t), &cpuset);
-            if (!silent)
-            {
-                color_print("[pthread wrapper] MAIN -> %d\n",pin_ids[ncpus-1]);
-            }
-            //ncpus--; /* last ID is the first (the process was pinned to) */
-        }
-        else
-        {
-            color_print("[pthread wrapper] ERROR: Environment Variabel LIKWID_PIN not set!\n");
-        }
-
-        if (!silent)
-        {
-            color_print("[pthread wrapper] PIN_MASK: ");
-
-            for (int i=0;i<ncpus-1;i++)
-            {
-                color_print("%d->%d  ",i,pin_ids[i]);
-            }
-            color_print("\n[pthread wrapper] SKIP MASK: 0x%llX\n",LLU_CAST skipMask);
-        }
-
-        overflow = ncpus-1;
-    }
-    Dl_info info;
-    if (dladdr(start_routine, &info) > 0)
-    {
-        FILE* fpipe;
-        char cmd[512];
-        char buff[512];
-        char file[64];
-        unsigned int ptr = ((void*)start_routine) - info.dli_fbase;
-
-        buff[0] = '\0';
-        snprintf(file, sizeof(file), "/tmp/likwidpin.%ld", gettid());
-        if (info.dli_fname[0] != '/') {
-            snprintf(cmd, sizeof(cmd), "rm -f %s; nm $(which %s) 2>/dev/null | grep %x > %s",
-                     file, info.dli_fname, ptr, file);
-        } else {
-            snprintf(cmd, sizeof(cmd), "rm -f %s; nm %s 2>/dev/null | grep %x > %s",
-                     file, info.dli_fname, ptr, file);
-        }
-        ret = system(cmd);
-        fpipe = fopen(file, "r");
-        if (!fpipe)
-        {
-            if (ncalled == 0) {
-                fprintf(stderr, "Problems reading symbols for shepherd thread detection: %s\n", strerror(errno));
-            }
-        }
-        else
-        {
-            if (fgets(buff, sizeof(buff), fpipe) == NULL) {
-                // TODO, how should we handle this error correctly?
-                if (ncalled == 0) {
-                    fprintf(stderr, "Problems reading symbols for shepherd thread detection: %s\n", strerror(errno));
-                }
-                fclose(fpipe);
-            } else {
-                char* tmp = strstr(buff, "monitor");
-                if (tmp != NULL)
-                {
-                    shepherd = 1;
-                    skipMask |= 1ULL<<(ncalled);
-                }
-                fclose(fpipe);
-                snprintf(cmd, 511, "rm -f %s 2>/dev/null", file);
-                ret = system(cmd);
-            }
-        }
-    }
-
-    /* Handle dll related stuff */
-    do
-    {
-        handle = dlopen(sosearchpaths[reallpthrindex], RTLD_LAZY);
-        if (handle)
-        {
-            break;
-        }
-        if (sosearchpaths[reallpthrindex] != NULL)
-        {
-            reallpthrindex++;
-        }
-    }
-
-    while (sosearchpaths[reallpthrindex] != NULL);
-
-    if (!handle)
-    {
-        color_print("%s\n", dlerror());
-        pthread_mutex_unlock(&mutex);
-        return -1;
-    }
-
-    dlerror();    /* Clear any existing error */
-    rptc = dlsym(handle, "pthread_create");
-
-    if ((error = dlerror()) != NULL)
-    {
-        color_print("%s\n", error);
-        pthread_mutex_unlock(&mutex);
-        return -2;
-    }
-
-    ret = (*rptc)(thread, attr, start_routine, arg);
-
-    /* After thread creation pin the thread */
-    if (ret == 0)
-    {
-        cpu_set_t cpuset;
-
-        if ((ncalled<64) && (skipMask&(1ULL<<(ncalled))))
-        {
-            CPU_ZERO(&cpuset);
-            for (int i=0; i<online_cpus; i++)
-                CPU_SET(i, &cpuset);
-            pthread_setaffinity_np(*thread, sizeof(cpu_set_t), &cpuset);
-            if (!silent)
-            {
-                if (shepherd)
-                    color_print("\tthreadid %lu -> SKIP SHEPHERD\n", *thread);
-                else
-                    color_print("\tthreadid %lu -> SKIP \n", *thread);
-                shepherd = 0;
-            }
-        }
-        else
-        {
-            CPU_ZERO(&cpuset);
-            CPU_SET(pin_ids[npinned%ncpus], &cpuset);
-            pthread_setaffinity_np(*thread, sizeof(cpu_set_t), &cpuset);
-            if ((npinned == overflow) && (!overflowed))
-            {
-                if (!silent)
-                {
-                    color_print("Roundrobin placement triggered\n\tthreadid %lu -> hwthread %d - OK", *thread, pin_ids[npinned%ncpus]);
-                }
-                overflowed = 1;
-                npinned = (npinned+1)%ncpus;
-            }
-            else
-            {
-                if (!silent)
-                {
-                    color_print("\tthreadid %lu -> hwthread %d - OK", *thread, pin_ids[npinned%ncpus]);
-                }
-                npinned++;
-                if ((npinned >= ncpus) && (overflowed))
-                {
-                    npinned = 0;
-                }
-            }
-
-            if (!silent)
-            {
-                color_print("\n");
-            }
-        }
-    }
-
-    fflush(stdout);
-    ncalled++;
-    dlclose(handle);
-    pthread_mutex_unlock(&mutex);
-
-    return ret;
+    find_openmp();
+    find_pthread();
+    init_omp_places();
 }
 
 void __attribute__((destructor (103))) close_pthread_overload(void)
@@ -347,3 +334,93 @@ void __attribute__((destructor (103))) close_pthread_overload(void)
     free(pin_ids);
 }
 
+/*
+ * libpthread.so.0 pinning via direct overrides
+ *
+ * We only override pthread_create in order to pin newly created threads.
+ * Threads, which are created as part of an OpenMP runtime are explicitly
+ * excluded here. The reason is that it's not trivial to determine, which
+ * of the OpenMP threads is actually used for execution, and which for
+ * internal management ("shepherd threads").
+ *
+ * Therefore OpenMP pinning is done via the OMP_PLACES environment variable.
+ *
+ * For everything else, pinning is performed by wrapping the start_routine,
+ * doing the pinning there, and then executing the original start_routine.
+ */
+
+static void *start_routine_wrapper(void *arg)
+{
+    assert(arg);
+
+    struct pthread_create_wrapper_arg pcw_arg = *(struct pthread_create_wrapper_arg *)arg;
+    free(arg);
+
+    static size_t threads_started = 0;
+    static size_t threads_pinned = 0;
+
+    const size_t thread_start_id = __atomic_fetch_add(&threads_started, 1, __ATOMIC_ACQ_REL);
+
+    // If no pinning was provided via environment, immediately start original routine
+    if (!pin_ids)
+        return pcw_arg.start_routine_orig(pcw_arg.arg_orig);
+
+    assert(pin_ids_count > 0);
+
+    // If the current thread is in the skip mask, do not pin it.
+    if (thread_start_id < sizeof(pin_skip_mask) * 8 && (pin_skip_mask & (1ull << thread_start_id)))
+        return pcw_arg.start_routine_orig(pcw_arg.arg_orig);
+
+    const size_t thread_pin_id = __atomic_fetch_add(&threads_pinned, 1, __ATOMIC_ACQ_REL);
+
+    cpu_set_t cpu_set;
+    CPU_ZERO(&cpu_set);
+    CPU_SET((int)pin_ids[thread_pin_id % pin_ids_count], &cpu_set);
+
+    if (sched_setaffinity(0, sizeof(cpu_set), &cpu_set) < 0)
+        color_print("PIN ERROR: sched_setaffinity failed: %s\n", strerror(errno));
+
+    return pcw_arg.start_routine_orig(pcw_arg.arg_orig);
+}
+
+int __attribute__ ((visibility ("default") ))
+pthread_create(pthread_t *thread,
+        const pthread_attr_t *attr,
+        void *(*start_routine)(void *),
+        void *arg)
+{
+    bool do_pin = true;
+
+
+    if (openmp_found) {
+        const uintptr_t uip_start_routine = (uintptr_t)start_routine;
+        if (uip_start_routine >= openmp_text_start && uip_start_routine < openmp_text_end)
+            do_pin = false;
+    }
+
+    if (!pthread_create_orig) {
+        color_print("Cannot call pthread_create. The pthread library either isn't "
+                "loaded or pthread_create wasn't found for another reason.\n");
+        return ELIBACC;
+    }
+
+    if (!do_pin)
+        return pthread_create_orig(thread, attr, start_routine, arg);
+
+    /* Call our pthread_create wrapper. We allocate and pass an argument struct to the
+     * wrapper, so it can reconstruct the original start_routine call. If the thread
+     * is successfuly started, the malloc'ed data is freed in the new thread. */
+    struct pthread_create_wrapper_arg *wrapper_arg = malloc(sizeof(*wrapper_arg));
+    if (!wrapper_arg)
+        return errno;
+
+    wrapper_arg->start_routine_orig = start_routine;
+    wrapper_arg->arg_orig = arg;
+
+    int retval = pthread_create_orig(thread, attr, start_routine_wrapper, wrapper_arg);
+    if (retval == 0)
+        return 0;
+
+    free(wrapper_arg);
+    return retval;
+}

--- a/src/pthread-overload/pthread-overload.c
+++ b/src/pthread-overload/pthread-overload.c
@@ -9,7 +9,7 @@
  *      Version:   <VERSION>
  *      Released:  <DATE>
  *
- *      Author:  Jan Treibig (jt), jan.treibig@gmail.com
+ *      Author:  Michael Panzlaff (mp), michale.panzlaff@fau.de
  *      Project:  likwid
  *
  *      Copyright (C) 2016 RRZE, University Erlangen-Nuremberg
@@ -372,7 +372,6 @@ pthread_create(pthread_t *thread,
         void *arg)
 {
     bool do_pin = true;
-
 
     if (openmp_found) {
         const uintptr_t uip_start_routine = (uintptr_t)start_routine;

--- a/src/pthread-overload/pthread-overload.c
+++ b/src/pthread-overload/pthread-overload.c
@@ -281,29 +281,7 @@ static void find_pthread(void)
         fprintf(stderr, "Cannot find pthread_create (Does the program use pthreads?): %s\n", err);
 }
 
-static void init_omp_places(void)
-{
-    char *omp_places_str = NULL;
-    for (size_t i = 0; i < pin_ids_count; i++) {
-        char *omp_places_str_new;
-        int ret;
-        if (omp_places_str)
-            ret = asprintf(&omp_places_str_new, "%s,{%u}", omp_places_str, pin_ids[i]);
-        else
-            ret = asprintf(&omp_places_str_new, "{%u}", pin_ids[i]);
-
-        if (ret < 0)
-            pdie("asprintf");
-
-        free(omp_places_str);
-        omp_places_str = omp_places_str_new;
-    }
-
-    if (setenv("OMP_PLACES", omp_places_str, true) < 0)
-        pdie("setenv");
-}
-
-void __attribute__((constructor (103))) init_pthread_overload(void)
+void __attribute__((constructor)) init_pthread_overload(void)
 {
     pin_ids = NULL;
     pin_ids_count = 0;
@@ -326,10 +304,14 @@ void __attribute__((constructor (103))) init_pthread_overload(void)
 
     find_openmp();
     find_pthread();
-    init_omp_places();
+
+    /* If OMP_PLACES is not set, raise a warning. This should only happen, if there is
+     * a bug in likwid-perfctr or likwid-pin. */
+    if (!getenv("OMP_PLACES"))
+        color_print("OMP_PLACES is not set in the environment. OpenMP pinning will not work\n");
 }
 
-void __attribute__((destructor (103))) close_pthread_overload(void)
+void __attribute__((destructor)) close_pthread_overload(void)
 {
     free(pin_ids);
 }

--- a/src/pthread-overload/pthread-overload.c
+++ b/src/pthread-overload/pthread-overload.c
@@ -60,6 +60,7 @@ struct pthread_create_wrapper_arg {
 };
 
 static bool silent = false;
+static bool pin_ids_printed = false;
 
 static uint32_t *pin_ids;
 static size_t pin_ids_count;
@@ -70,6 +71,23 @@ static uintptr_t openmp_text_end;
 static bool openmp_found = false;
 
 static pthread_create_ptr pthread_create_orig;
+
+#ifdef COLOR
+#define COLOR_PRINT_FORCE_PREFIX(prefix, msg, ...) \
+    fprintf(stderr, "\e[1;%dm" prefix msg "\e[0m", COLOR + 30, ##__VA_ARGS__)
+#else
+#define COLOR_PRINT_FORCE_PREFIX(prefix, msg, ...) \
+    fprintf(stderr, prefix msg, ##__VA_ARGS__)
+#endif
+
+#define COLOR_PRINT_FORCE(msg, ...) \
+    COLOR_PRINT_FORCE_PREFIX("[pin-%d] ", msg, getpid(), ##__VA_ARGS__)
+
+#define COLOR_PRINT(msg, ...) \
+    do { \
+        if (!silent) \
+            COLOR_PRINT_FORCE(msg, ##__VA_ARGS__); \
+    } while (0)
 
 static void pdie(const char *msg)
 {
@@ -88,55 +106,24 @@ static void die(const char *fmt, ...)
     va_end(args);
 }
 
-static void color_print_begin(void)
+static char *get_cmdline(void)
 {
-    if (silent)
-        return;
+    FILE *f = fopen("/proc/self/cmdline", "r");
+    if (!f)
+        return NULL;
+    char cmdline[256];
+    size_t bytes_read = fread(cmdline, 1, sizeof(cmdline), f);
+    if (bytes_read == 0) {
+        fclose(f);
+        return NULL;
+    }
 
-#ifdef COLOR
-    fprintf(stderr, "\e[1;%dm", COLOR + 30);
-#endif
-    fprintf(stderr, "[pthread wrapper] ");
-}
+    for (size_t i = 0; i < bytes_read; i++) {
+        if (cmdline[i] == '\0' && i + 1 < bytes_read)
+            cmdline[i] = ' ';
+    }
 
-static void color_vprint_main(const char *fmt, va_list args)
-{
-    if (silent)
-        return;
-
-    vfprintf(stderr, fmt, args);
-}
-
-static void __attribute__((format(printf, 1, 2))) color_print_main(const char *fmt, ...)
-{
-    va_list args;
-    va_start(args, fmt);
-
-    color_vprint_main(fmt, args);
-
-    va_end(args);
-}
-
-static void color_print_end(void)
-{
-    if (silent)
-        return;
-
-#ifdef COLOR
-    fprintf(stderr, "\e[0m");
-#endif
-}
-
-static void __attribute__((format(printf, 1, 2))) color_print(const char *fmt, ...) 
-{
-    va_list args;
-    va_start(args, fmt);
-
-    color_print_begin();
-    color_vprint_main(fmt, args);
-    color_print_end();
-
-    va_end(args);
+    return strdup(cmdline);
 }
 
 static void init_pin_ids(const char *pin_str_orig)
@@ -170,25 +157,30 @@ static void init_pin_ids(const char *pin_str_orig)
 
     free(pin_str);
 
-    color_print_begin();
-    color_print_main("PIN MAP (PID=%d):\n", getpid());
+    char *cmdline = get_cmdline();
+    if (pin_ids_printed) {
+        COLOR_PRINT("Pinning enabled (%s)\n", cmdline ? cmdline : "(unknown)");
+    } else {
+        COLOR_PRINT_FORCE("Pinning enabled (%s), mapping:\n", cmdline ? cmdline : "(unknown)");
+        const size_t COLUMN_COUNT = 8;
+        size_t column = 0;
+        for (size_t i = 0; i < pin_ids_count; i++) {
+            if (column == 0)
+                COLOR_PRINT_FORCE("  %4zu -> %4u", i, pin_ids[i]);
+            else
+                COLOR_PRINT_FORCE_PREFIX("", " | %4zu -> %4u", i, pin_ids[i]);
 
-    const size_t COLUMN_COUNT = 8;
-    size_t column = 0;
-    for (size_t i = 0; i < pin_ids_count; i++) {
-        if (column == 0)
-            color_print_main("  %4zu -> %4u", i, pin_ids[i]);
-        else
-            color_print_main(" | %4zu -> %4u", i, pin_ids[i]);
-        if (column + 1 >= COLUMN_COUNT) {
-            color_print_main("\n");
-            column = 0;
-        } else {
-            column += 1;
+            if (column + 1 >= COLUMN_COUNT) {
+                COLOR_PRINT_FORCE_PREFIX("", "\n");
+                column = 0;
+            } else {
+                column += 1;
+            }
         }
     }
+    free(cmdline);
 
-    color_print_end();
+    (void)setenv("LIKWID_PIN_PRINTED", "1", 1);
 }
 
 static int find_openmp_callback(struct dl_phdr_info *dl_info, size_t size, void *data)
@@ -230,7 +222,7 @@ static int find_openmp_callback(struct dl_phdr_info *dl_info, size_t size, void 
 
     openmp_found = true;
 
-    color_print("Found OpenMP runtime: %s\n", dl_info->dlpi_name);
+    COLOR_PRINT("Found OpenMP runtime: %s\n", dl_info->dlpi_name);
 
     /* Okay, we found the OpenMP library. Now let's find the .text section.
      * While we cannot read the section name, we can see if a section is executable.
@@ -286,21 +278,24 @@ void __attribute__((constructor)) init_pthread_overload(void)
     pin_ids = NULL;
     pin_ids_count = 0;
 
+    if (getenv("LIKWID_SILENT"))
+        silent = true;
+
+    if (getenv("LIKWID_PIN_PRINTED"))
+        pin_ids_printed = true;
+
     const char *pin_str_orig = getenv("LIKWID_PIN");
     if (pin_str_orig)
         init_pin_ids(pin_str_orig);
     else
-        color_print("LIKWID_PIN environment variable not set. Disabling pinning.\n");
+        COLOR_PRINT("LIKWID_PIN environment variable not set. Disabling pinning.\n");
 
     const char *skip_str = getenv("LIKWID_SKIP");
     if (skip_str)
         pin_skip_mask = strtoull(skip_str, NULL, 16);
 
     if (pin_skip_mask != 0)
-        color_print("PIN SKIP MASK: %#" PRIx64 "\n", pin_skip_mask);
-
-    if (getenv("LIKWID_SILENT"))
-        silent = true;
+        COLOR_PRINT("PIN SKIP MASK: %#" PRIx64 "\n", pin_skip_mask);
 
     find_openmp();
     find_pthread();
@@ -308,7 +303,7 @@ void __attribute__((constructor)) init_pthread_overload(void)
     /* If OMP_PLACES is not set, raise a warning. This should only happen, if there is
      * a bug in likwid-perfctr or likwid-pin. */
     if (!getenv("OMP_PLACES"))
-        color_print("OMP_PLACES is not set in the environment. OpenMP pinning will not work\n");
+        COLOR_PRINT("OMP_PLACES is not set in the environment. OpenMP pinning will not work\n");
 }
 
 void __attribute__((destructor)) close_pthread_overload(void)
@@ -360,7 +355,7 @@ static void *start_routine_wrapper(void *arg)
     CPU_SET((int)pin_ids[thread_pin_id % pin_ids_count], &cpu_set);
 
     if (sched_setaffinity(0, sizeof(cpu_set), &cpu_set) < 0)
-        color_print("PIN ERROR: sched_setaffinity failed: %s\n", strerror(errno));
+        COLOR_PRINT_FORCE("PIN ERROR: sched_setaffinity failed: %s\n", strerror(errno));
 
     return pcw_arg.start_routine_orig(pcw_arg.arg_orig);
 }
@@ -380,7 +375,7 @@ pthread_create(pthread_t *thread,
     }
 
     if (!pthread_create_orig) {
-        color_print("Cannot call pthread_create. The pthread library either isn't "
+        COLOR_PRINT_FORCE("Cannot call pthread_create. The pthread library either isn't "
                 "loaded or pthread_create wasn't found for another reason.\n");
         return ELIBACC;
     }


### PR DESCRIPTION
This should fix #750

The main differences to the new pinning mechanism are the following:
- OpenMP pinning is now done by the OpenMP library itself via OMP_PLACES. Thus there is no longer the need to do any type of shepherd thread detection, which greatly simplifies the code.
- pthread_create based pinning is still available. However, it now explicitly excludes threads start routines lying inside the OpenMP library to avoid pinning conflicts. So applications, which manually implement concurrency are stilled pinned without interfering with OMP_PLACES.