### PR TITLE
Apply LD_PRELOAD only in child processes

### DIFF
--- a/doc/lua-doxygen.md
+++ b/doc/lua-doxygen.md
@@ -2641,12 +2641,12 @@ or<BR>
       <TD>String containing the executable and its arguments. Executable and arguments are separated by ' '</TD>
     </TR>
     <TR>
-      <TD>\a numThreads</TD>
-      <TD>Number of HW thread IDs in the cpulist (third parameter)</TD>
-    </TR>
-    <TR>
       <TD>\a cpulist</TD>
       <TD>List of HW thread IDs. The application's cpuset is limited to these hw threads</TD>
+    </TR>
+    <TR>
+      <TD>\a preloaded_libraries</TD>
+      <TD>List of library paths, which to add to the target process' LD_PRELOAD environment</TD>
     </TR>
   </TABLE></TD>
 </TR>

--- a/src/applications/likwid-perfctr.lua
+++ b/src/applications/likwid-perfctr.lua
@@ -1018,6 +1018,7 @@ if verbose == 0 then
     likwid.setenv("LIKWID_SILENT", "true")
 end
 
+preloaded_libraries = {}
 if pin_cpus then
     local omp_threads = os.getenv("OMP_NUM_THREADS")
     if omp_threads == nil then
@@ -1056,12 +1057,7 @@ if pin_cpus then
         end
         likwid.setenv("OMP_PLACES", placesString)
 
-        local preload = os.getenv("LD_PRELOAD")
-        if preload == nil then
-            likwid.setenv("LD_PRELOAD", likwid.pinlibpath)
-        else
-            likwid.setenv("LD_PRELOAD", likwid.pinlibpath .. ":" .. preload)
-        end
+        table.insert(preloaded_libraries, likwid.pinlibpath)
     elseif num_cpus == 1 then
         likwid.setenv("OMP_PLACES", string.format("{%d}", cpulist[1]))
         likwid.setenv("LIKWID_PIN", tostring(math.tointeger(cpulist[1])))
@@ -1180,15 +1176,7 @@ if nvSupported and #cuda_event_string_list > 0 then
         perfctr_exit(1)
     end
     if use_marker == false then
-        local preload = os.getenv("LD_PRELOAD")
-        if preload == nil then
-            likwid.setenv("LD_PRELOAD", "likwid-appDaemon.so")
-        else
-            likwid.setenv("LD_PRELOAD", "likwid-appDaemon.so" .. ":" .. preload)
-        end
-        if verbose > 0 then
-            print_stdout("LD_PRELOAD=" .. os.getenv("LD_PRELOAD"))
-        end
+        table.insert(preloaded_libraries, "likwid-appDaemon.so")
     end
     local devices = os.getenv("CUDA_VISIBLE_DEVICES")
     if devices == nil then
@@ -1202,15 +1190,7 @@ if rocmSupported and #rocm_event_string_list > 0 then
     --likwid.init_rocm(gpulist_rocm)
     --rocmInitialized = true
     if use_marker == false then
-        local preload = os.getenv("LD_PRELOAD")
-        if preload == nil then
-            likwid.setenv("LD_PRELOAD", "likwid-appDaemon.so")
-        else
-            likwid.setenv("LD_PRELOAD", preload .. ":" .. "likwid-appDaemon.so")
-        end
-        if verbose > 0 then
-            print_stdout("LD_PRELOAD=" .. os.getenv("LD_PRELOAD"))
-        end
+        table.insert(preloaded_libraries, "likwid-appDaemon.so")
     end
     local devices = os.getenv("ROCR_VISIBLE_DEVICES")
     if devices == nil then
@@ -1269,9 +1249,9 @@ if #execList > 0 then
         likwid.setenv("LIKWID_PERF_EXECPID", "1")
     end
     if pin_cpus then
-        pid = likwid.startProgram(execString, #cpulist, cpulist)
+        pid = likwid.startProgram(execString, cpulist, preloaded_libraries)
     else
-        pid = likwid.startProgram(execString, 0, cpulist)
+        pid = likwid.startProgram(execString, {}, preloaded_libraries)
     end
     if execpid then
         perfpid = pid

--- a/src/applications/likwid-pin.lua
+++ b/src/applications/likwid-pin.lua
@@ -285,6 +285,7 @@ if skip_mask then
     likwid.setenv("LIKWID_SKIP", skip_mask)
 end
 
+preloaded_libraries = {}
 if num_threads > 1 then
     local pinString = tostring(math.tointeger(cpu_list[1]))
     for i=2,likwid.tablelength(cpu_list) do
@@ -298,12 +299,7 @@ if num_threads > 1 then
     end
     likwid.setenv("OMP_PLACES", placesString)
 
-    local preload = os.getenv("LD_PRELOAD")
-    if preload == nil then
-        likwid.setenv("LD_PRELOAD",likwid.pinlibpath)
-    else
-        likwid.setenv("LD_PRELOAD",likwid.pinlibpath .. ":" .. preload)
-    end
+    table.insert(preloaded_libraries, likwid.pinlibpath)
     local ldpath = os.getenv("LD_LIBRARY_PATH")
     local libpath = likwid.pinlibpath:match("([^%s]+)/[^%s]+.so")
     if ldpath == nil then
@@ -331,7 +327,7 @@ if verbose > 0 and quiet == 0 then
     end
     print_stdout(string.format("Using %d thread(s) (cpuset: 0x%x)", num_threads, mask))
 end
-local pid = likwid.startProgram(table.concat(execList," "), num_threads, cpu_list)
+local pid = likwid.startProgram(table.concat(execList," "), cpu_list, preloaded_libraries)
 if (pid == nil) then
     print_stderr("Failed to execute command: ".. exec)
     close_and_exit(1)

--- a/src/applications/likwid-powermeter.lua
+++ b/src/applications/likwid-powermeter.lua
@@ -344,7 +344,7 @@ if not print_info and not print_temp then
                 likwid.sleep(time_interval)
             end
         else
-            local pid = likwid.startProgram(execString, 0, {})
+            local pid = likwid.startProgram(execString, {}, {})
             if not pid then
                 print_stderr(string.format("Failed to execute %s!",execString))
                 likwid.finalize()

--- a/src/configuration.c
+++ b/src/configuration.c
@@ -39,6 +39,7 @@
 #include <sys/stat.h>
 #include <errno.h>
 #include <lw_alloc.h>
+#include <util.h>
 
 #include <configuration.h>
 
@@ -54,19 +55,13 @@ static int groupPath_len = 0;
 
 /* #####   FUNCTION DEFINITIONS  -  LOCAL TO THIS SOURCE FILE   ########### */
 
-static int
-default_configuration(void)
+static int default_configuration(void)
 {
-    int ret = 0;
-    char filename[1024] = { [0 ... 1023] = '\0' };
-    char *fptr = NULL;
-    size_t len = 0;
-    filename[0] = '\0';
+    int err;
 
     groupPath_len = strlen(TOSTRING(GROUPPATH))+10;
     config.groupPath = lw_malloc(groupPath_len+1);
-    ret = snprintf(config.groupPath, groupPath_len, "%s", TOSTRING(GROUPPATH));
-    config.groupPath[ret] = '\0';
+    snprintf(config.groupPath, groupPath_len, "%s", TOSTRING(GROUPPATH));
 #ifndef LIKWID_USE_PERFEVENT
     if (ACCESSMODE == 0)
     {
@@ -76,29 +71,19 @@ default_configuration(void)
     }
     config.daemonMode = ACCESSMODE_DAEMON;
 
-    FILE* fp = popen("bash --noprofile -c \"which likwid-accessD 2>/dev/null | tr -d '\n'\"","r");
-    if (fp == NULL)
-    {
+    char *accessDaemonPath = NULL;
+    err = search_path_env("likwid-accessD", &accessDaemonPath);
+    if (err < 0)
         goto use_hardcoded;
-    }
-    ret = getline(&fptr, &len, fp);
-    pclose(fp);
-    if (ret < 0)
+
+    if (!access(accessDaemonPath, X_OK))
     {
-        if (fptr)
-            free(fptr);
-        goto use_hardcoded;
-    }
-    if (!access(fptr, X_OK))
-    {
-        config.daemonPath = lw_strdup(fptr);
-        free(fptr);
+        config.daemonPath = accessDaemonPath;
     }
     else
     {
-        fprintf(stderr, "Found access daemon at %s but it is not executable, using compiled in daemon path.\n", fptr);
-        if (fptr)
-            free(fptr);
+        fprintf(stderr, "Found access daemon at %s but it is not executable, using compiled in daemon path.\n", accessDaemonPath);
+        free(accessDaemonPath);
         goto use_hardcoded;
     }
 #else
@@ -106,24 +91,25 @@ default_configuration(void)
 #endif
     init_config = 1;
     return 0;
+
 #ifndef LIKWID_USE_PERFEVENT
 use_hardcoded:
 #endif
-    ret = sprintf(filename,"%s", TOSTRING(ACCESSDAEMON));
-    filename[ret] = '\0';
-    if (!access(filename, X_OK))
+
+    const char *hardcodedAccessDaemonPath = TOSTRING(ACCESSDAEMON);
+    if (access(hardcodedAccessDaemonPath, X_OK) == 0)
     {
-        config.daemonPath = lw_strdup(filename);
-        init_config = 1;
+        config.daemonPath = lw_strdup(hardcodedAccessDaemonPath);
     }
     else
     {
-        if (getenv("LIKWID_NO_ACCESS") == NULL)
+        if (!getenv("LIKWID_NO_ACCESS"))
         {
             ERROR_PRINT("Unable to get path to access daemon. Maybe your PATH environment variable does not contain the folder where you installed it or the file was moved away / not copied to that location?");
             return -1;
         }
     }
+    init_config = 1;
     return 0;
 }
 

--- a/src/includes/util.h
+++ b/src/includes/util.h
@@ -6,4 +6,6 @@
 char *xvasprintf(const char *__restrict__ fmt, va_list ap);
 char *xasprintf(const char *__restrict__ fmt, ...);
 
+int search_path_env(const char *binary, char **pathFinal);
+
 #endif // INCLUDE_UTIL_H

--- a/src/luawid.c
+++ b/src/luawid.c
@@ -1806,79 +1806,95 @@ static void catch_sigchild(int signo) {
 }
 
 static int lua_likwid_startProgram(lua_State *L) {
-  pid_t pid;
-  int status;
-  char *exec;
-  char *argv[MAX_NUM_CLIARGS];
-  exec = (char *)luaL_checkstring(L, 1);
-  int nrThreads = luaL_checknumber(L, 2);
-  CpuTopology_t cputopo = get_cpuTopology();
+    const char *exec = luaL_checkstring(L, 1);
+    char *execCopy = strdup(exec);
+    if (!execCopy)
+        return luaL_error(L, "strdup failed: %s\n", strerror(errno));
 
-  luaL_argcheck(L, nrThreads >= 0, nrThreads, "Number of threads must be >= 0");
+    luaL_checktype(L, 2, LUA_TTABLE);
+    size_t nrThreads = lua_rawlen(L, 2);
 
-  if ((uint32_t)nrThreads > cputopo->numHWThreads) {
-    lua_pushstring(L, "Number of threads greater than available HW threads");
-    lua_error(L);
-    return 0;
-  }
-  int *cpus = malloc(cputopo->numHWThreads * sizeof(int));
-  if (!cpus)
-    return 0;
-  if (nrThreads > 0) {
-    if (!lua_istable(L, -1)) {
-      lua_pushstring(L, "No table given as second argument");
-      lua_error(L);
-      free(cpus);
-    }
-    for (status = 1; status <= nrThreads; status++) {
-      lua_rawgeti(L, -1, status);
+    luaL_checktype(L, 3, LUA_TTABLE);
+    size_t nrLibs = lua_rawlen(L, 3);
+
+    CpuTopology_t cputopo = get_cpuTopology();
+    if (nrThreads > cputopo->numHWThreads)
+        return luaL_error(L, "Number of threads greater than available HW threads");
+
+    int *cpus = calloc(cputopo->numHWThreads, sizeof(*cpus));
+    if (!cpus)
+        return luaL_error(L, "calloc failed: %s", strerror(errno));
+
+    for (size_t i = 1; i <= nrThreads; i++) {
+        lua_rawgeti(L, 2, i);
 #if LUA_VERSION_NUM == 501
-      cpus[status - 1] = ((lua_Integer)lua_tointeger(L, -1));
+        cpus[i - 1] = (lua_Integer)lua_tointeger(L, -1);
 #else
-      cpus[status - 1] = ((lua_Unsigned)lua_tointegerx(L, -1, NULL));
+        cpus[i - 1] = (lua_Unsigned)lua_tointegerx(L, -1, NULL);
 #endif
-      lua_pop(L, 1);
+        lua_pop(L, 1);
     }
-  }
-  /*else
-  {
-      int count = 0;
-      for (nrThreads = 0; nrThreads < cpuid_topology.numHWThreads; nrThreads++)
-      {
-          if (cpuid_topology.threadPool[nrThreads].inCpuSet == 1)
-          {
-              cpus[count] = cpuid_topology.threadPool[nrThreads].apicId;
-              count++;
-          }
-      }
-      nrThreads = count;
-  }*/
-  int args = parse(exec, argv, MAX_NUM_CLIARGS);
-  if (args < 0) {
-    lua_pushstring(L, "Number of CLI args greater than configured");
-    lua_error(L);
-    free(cpus);
-    return 0;
-  }
-  pid = fork();
-  if (pid < 0) {
-    free(cpus);
-    return 0;
-  } else if (pid == 0) {
-    if (nrThreads > 0) {
-      affinity_pinProcesses(nrThreads, cpus);
+
+    // TODO The parse function should really be eliminated. It doesn't make sense that
+    // likwid-perfctr first converts the list of arguments to a string, and it is then
+    // converted back to a list here. Because of mistakes in escaping, this won't work
+    // with arguments that contain quotes.
+    char *argv[MAX_NUM_CLIARGS];
+    int args = parse(execCopy, argv, ARRAY_COUNT(argv));
+    if (args < 0) {
+        free(execCopy);
+        free(cpus);
+        return luaL_error(L, "Number of CLI args greater than configured");
     }
-    // Why is there a sleep here?
-    timer_sleep(10);
-    execvp(*argv, argv);
-    ERROR_PRINT("Failed to run program '%s'", *argv);
-    exit(EXIT_FAILURE);
-  } else {
+
     signal(SIGCHLD, catch_sigchild);
-    free(cpus);
-    lua_pushnumber(L, pid);
-  }
-  return 1;
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        free(execCopy);
+        free(cpus);
+        return luaL_error(L, "Unable to spawn child: %s\n", strerror(errno));
+    } else if (pid == 0) {
+        // Pin threads
+        if (nrThreads > 0)
+            affinity_pinProcesses(nrThreads, cpus);
+
+        // Set LD_PRELOAD for child process
+        if (nrLibs > 0) {
+            char *currentLdPreload = getenv("LD_PRELOAD");
+            if (currentLdPreload) {
+                currentLdPreload = strdup(currentLdPreload);
+                if (!currentLdPreload)
+                    return luaL_error(L, "strdup failed: %s", strerror(errno));
+            }
+            for (size_t i = 1; i <= nrLibs; i++) {
+                lua_rawgeti(L, 3, i);
+                const char *lib = luaL_checkstring(L, -1);
+                char *newLdPreload; int err;
+                if (currentLdPreload)
+                    err = asprintf(&newLdPreload, "%s:%s", currentLdPreload, lib);
+                else
+                    err = asprintf(&newLdPreload, "%s", lib);
+                if (err < 0)
+                    return luaL_error(L, "asprintf failed: %s", strerror(errno));
+                free(currentLdPreload);
+                currentLdPreload = newLdPreload;
+                lua_pop(L, 1);
+            }
+            if (setenv("LD_PRELOAD", currentLdPreload, 1))
+                return luaL_error(L, "setenv failed: %s\n", strerror(errno));
+            free(currentLdPreload);
+        }
+
+        execvp(*argv, argv);
+        ERROR_PRINT("Failed to run program '%s'", *argv);
+        exit(EXIT_FAILURE);
+    } else {
+        free(execCopy);
+        free(cpus);
+        lua_pushnumber(L, pid);
+        return 1;
+    }
 }
 
 static int lua_likwid_checkProgram(lua_State *L) {

--- a/src/util.c
+++ b/src/util.c
@@ -1,7 +1,10 @@
 #include <util.h>
 
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
 
 char *xvasprintf(const char *__restrict__ fmt, va_list ap) {
     va_list ap2;
@@ -29,4 +32,47 @@ char *xasprintf(const char *__restrict__ fmt, ...) {
     char *retval = xvasprintf(fmt, ap);
     va_end(ap);
     return retval;
+}
+
+int search_path_env(const char *binary, char **pathFinal)
+{
+    const char *pathEnv = getenv("PATH");
+    if (!pathEnv)
+        return -ENOENT;
+
+    char *path = strdup(pathEnv);
+    if (!path)
+        return -errno;
+
+    int err = 0;
+    char *saveptr;
+    for (char *tok = strtok_r(path, ":", &saveptr); tok; tok = strtok_r(NULL, ":", &saveptr)) {
+        char *pathCandidate;
+        err = asprintf(&pathCandidate, "%s/%s", tok, binary);
+        if (err < 0) {
+            err = -errno;
+            goto ret;
+        }
+
+        struct stat s;
+        err = stat(pathCandidate, &s);
+        if (err < 0) {
+            err = -errno;
+            free(pathCandidate);
+            continue;
+        }
+
+        if ((s.st_mode & S_IFMT) == S_IFREG) {
+            err = -ENOENT;
+            free(pathCandidate);
+            continue;
+        }
+
+        *pathFinal = pathCandidate;
+        goto ret;
+    }
+
+ret:
+    free(path);
+    return err;
 }


### PR DESCRIPTION
Currently, LD_PRELOAD is applied to all likwid-* frontend tools before starting a child process. This PR changes it to only affect the child process. The intention being, that it's safe to run shell processes in the frontend application without having to worry, that unwanted processes are affected by e.g. pinning.