### PR TITLE
configuration.c: fix label-before-declaration error (pre-C23)

### DIFF
--- a/src/configuration.c
+++ b/src/configuration.c
@@ -94,6 +94,7 @@ static int default_configuration(void)
 
 #ifndef LIKWID_USE_PERFEVENT
 use_hardcoded:
+    ;
 #endif
 
     const char *hardcodedAccessDaemonPath = TOSTRING(ACCESSDAEMON);


### PR DESCRIPTION
`use_hardcoded:` was immediately followed by a declaration, invalid in C99/C11. Add empty statement after label. Fixes #754.