### PR TITLE
Refactor bitfields

### DIFF
--- a/src/bitUtil.c
+++ b/src/bitUtil.c
@@ -40,12 +40,16 @@
 uint64_t
 field64(uint64_t bitfield, int start, int length)
 {
+    assert(start >= 0 && start < 64);
+    assert(length >= 0 && length <= 64);
     return (bitfield >> start) & (~0ULL >> (64 - length));
 }
 
 uint32_t
 field32(uint32_t bitfield, int start, int length)
 {
+    assert(start >= 0 && start < 32);
+    assert(length >= 0 && length <= 32);
     return (bitfield >> start) & (~0U >> (32 - length));
 }
 
@@ -67,42 +71,19 @@ field32set(uint32_t* bitfield, int start, int length, uint32_t value)
     *bitfield = (*bitfield & ~mask) | ((value << start) & mask);
 }
 
-uint32_t
-extractBitField(uint32_t inField, uint32_t width, uint32_t offset)
+// Get the number of bits required for 'count' - 1.
+// Why -1? Because it calculates the number of bits required for the number
+// of combinations, not the number itself.
+uint32_t fieldWidthForCount(uint64_t count)
 {
-    uint32_t bitMask;
-    uint32_t outField;
-
-    if ((offset+width) == 32)
-    {
-        bitMask = (0xFFFFFFFF<<offset);
-    }
-    else
-    {
-        bitMask = (0xFFFFFFFF<<offset) ^ (0xFFFFFFFF<<(offset+width));
-
-    }
-
-    outField = (inField & bitMask) >> offset;
-    return outField;
-}
-
-uint32_t
-getBitFieldWidth(uint32_t number)
-{
-    uint32_t fieldWidth=0;
-
-    number--;
-    if (number == 0)
-    {
+    if (count == 0 || count == 1)
         return 0;
-    }
-#ifdef __x86_64
-    __asm__ volatile ( "bsr %%eax, %%ecx\n\t"
-            : "=c" (fieldWidth)
-            : "a"(number));
-#endif
 
-    return fieldWidth+1;  /* bsr returns the position, we want the width */
+    // max representable number for N combinations
+    count -= 1;
+
+    const unsigned long long countLL = count;
+    const uint64_t countLLWidth = 8 * sizeof(countLL);
+
+    return (uint32_t)(countLLWidth - __builtin_clzll(countLL));
 }
-

--- a/src/frequency_cpu.c
+++ b/src/frequency_cpu.c
@@ -927,7 +927,7 @@ static int getBaseFreq(const int cpu_id)
     }
     else
     {
-        tmp = extractBitField(tmp,8,8);
+        tmp = field32(tmp,8,8);
         return 100000 * tmp;
     }
 

--- a/src/includes/bitUtil.h
+++ b/src/includes/bitUtil.h
@@ -37,8 +37,7 @@ uint64_t field64(uint64_t bitfield, int start, int length);
 uint32_t field32(uint32_t bitfield, int start, int length);
 void field64set(uint64_t* bitfield, int start, int length, uint64_t value);
 void field32set(uint32_t* bitfield, int start, int length, uint32_t value);
-uint32_t extractBitField(uint32_t inField, uint32_t width, uint32_t offset);
-uint32_t getBitFieldWidth(uint32_t number);
+uint32_t fieldWidthForCount(uint64_t count);
 
 #define setBit(reg,bit)  (reg) |= (1ULL<<(bit))
 #define clearBit(reg,bit) (reg) &= ~(1ULL<<(bit))

--- a/src/includes/perfmon_broadwell.h
+++ b/src/includes/perfmon_broadwell.h
@@ -336,21 +336,21 @@ int bdwep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     break;
                 case EVENT_OPTION_OPCODE:
                     filter_flags1 |= (0x3<<27);
-                    filter_flags1 |= (extractBitField(event->options[j].value,5,0) << 20);
+                    filter_flags1 |= (field32(event->options[j].value,0,5) << 20);
                     break;
                 case EVENT_OPTION_NID:
-                    filter_flags1 |= (extractBitField(event->options[j].value,16,0));
+                    filter_flags1 |= (field32(event->options[j].value,0,16));
                     break;
                 case EVENT_OPTION_STATE:
-                    filter_flags0 |= (extractBitField(event->options[j].value,7,0) << 17);
+                    filter_flags0 |= (field32(event->options[j].value,0,7) << 17);
                     set_state_all = 0;
                     break;
                 case EVENT_OPTION_TID:
-                    filter_flags0 |= (extractBitField(event->options[j].value,6,0));
+                    filter_flags0 |= (field32(event->options[j].value,0,6));
                     flags |= (1ULL<<19);
                     break;
                 case EVENT_OPTION_MATCH0:
-                    filter_flags1 |= (extractBitField(event->options[j].value,2,0) << 30);
+                    filter_flags1 |= (field32(event->options[j].value,0,2) << 30);
                     break;
                 default:
                     break;
@@ -1623,7 +1623,7 @@ int perfmon_stopCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                         eventSet->events[i].threadCounter[thread_id].startData = 0;
                         if (eventSet->events[i].event.eventId == 0x00)
                         {
-                            switch(extractBitField(counter_result, 3, 0))
+                            switch(field32(counter_result, 0, 3))
                             {
                                 case 0x2:
                                     counter_result = 5.6E9;
@@ -1847,7 +1847,7 @@ int perfmon_readCountersThread_broadwell(int thread_id, PerfmonEventSet* eventSe
                         if (eventSet->events[i].event.eventId == 0x00)
                         {
                             HPMread(cpu_id, dev, counter1, &counter_result);
-                            switch(extractBitField(counter_result, 3, 0))
+                            switch(field32(counter_result, 0, 3))
                             {
                                 case 0x2:
                                     counter_result = 5.6E9;

--- a/src/includes/perfmon_haswell.h
+++ b/src/includes/perfmon_haswell.h
@@ -276,26 +276,26 @@ int hasep_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                 case EVENT_OPTION_OPCODE:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter1, &filter_flags));
                     filter_flags |= (0x3<<27);
-                    filter_flags |= (extractBitField(event->options[j].value,5,0) << 20);
+                    filter_flags |= (field32(event->options[j].value,0,5) << 20);
                     VERBOSEPRINTREG(cpu_id, filter1, filter_flags, "SETUP_CBOX_FILTER_OPCODE");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags));
                     break;
                 case EVENT_OPTION_NID:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter1, &filter_flags));
-                    filter_flags |= (extractBitField(event->options[j].value,16,0));
+                    filter_flags |= (field32(event->options[j].value,0,16));
                     VERBOSEPRINTREG(cpu_id, filter1, filter_flags, "SETUP_CBOX_FILTER_NID");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter1, filter_flags));
                     break;
                 case EVENT_OPTION_STATE:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags));
-                    filter_flags |= (extractBitField(event->options[j].value,6,0) << 17);
+                    filter_flags |= (field32(event->options[j].value,0,6) << 17);
                     VERBOSEPRINTREG(cpu_id, filter0, filter_flags, "SETUP_CBOX_FILTER_STATE");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags));
                     set_state_all = 0;
                     break;
                 case EVENT_OPTION_TID:
                     CHECK_MSR_READ_ERROR(HPMread(cpu_id, MSR_DEV, filter0, &filter_flags));
-                    filter_flags |= (extractBitField(event->options[j].value,6,0));
+                    filter_flags |= (field32(event->options[j].value,0,6));
                     VERBOSEPRINTREG(cpu_id, filter0, filter_flags, "SETUP_CBOX_FILTER_TID");
                     CHECK_MSR_WRITE_ERROR(HPMwrite(cpu_id, MSR_DEV, filter0, filter_flags));
                     flags |= (1ULL<<19);
@@ -1613,7 +1613,7 @@ int perfmon_stopCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                     if (eventSet->events[i].event.eventId == 0x00)
                     {
                         HPMread(cpu_id, dev, counter1, &counter_result);
-                        switch(extractBitField(counter_result, 3, 0))
+                        switch(field32(counter_result, 0, 3))
                         {
                             case 0x2:
                                 counter_result = 5.6E9;
@@ -1855,7 +1855,7 @@ int perfmon_readCountersThread_haswell(int thread_id, PerfmonEventSet* eventSet)
                     if (eventSet->events[i].event.eventId == 0x00)
                     {
                         HPMread(cpu_id, dev, counter1, &counter_result);
-                        switch(extractBitField(counter_result, 3, 0))
+                        switch(field32(counter_result, 0, 3))
                         {
                             case 0x2:
                                 counter_result = 5.6E9;

--- a/src/includes/perfmon_ivybridge.h
+++ b/src/includes/perfmon_ivybridge.h
@@ -1185,7 +1185,7 @@ int perfmon_stopCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                     {
                         CHECK_PCI_READ_ERROR(HPMread(cpu_id, dev, counter1, &counter_result));
                         VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX_FIXED");
-                        switch (extractBitField(counter_result,3,0))
+                        switch (field32(counter_result,0,3))
                         {
                             case 0x2:
                                 counter_result = 5600000000ULL;
@@ -1421,7 +1421,7 @@ int perfmon_readCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                         VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX_FIXED");
                         if (eventSet->events[i].event.eventId == 0x00)
                         {
-                            switch (extractBitField(counter_result,3,0))
+                            switch (field32(counter_result,0,3))
                             {
                                 case 0x2:
                                     counter_result = 5600000000ULL;
@@ -1448,7 +1448,7 @@ int perfmon_readCountersThread_ivybridge(int thread_id, PerfmonEventSet* eventSe
                         }
                         else if (eventSet->events[i].event.eventId == 0x01)
                         {
-                            counter_result = extractBitField(counter_result,1,4);
+                            counter_result = field32(counter_result,4,1);
                         }
                         VERBOSEPRINTPCIREG(cpu_id, dev, counter1, LLU_CAST counter_result, "READ_SBOX_FIXED_REAL");
                         eventSet->events[i].threadCounter[thread_id].startData = 0;

--- a/src/includes/perfmon_knl.h
+++ b/src/includes/perfmon_knl.h
@@ -303,26 +303,26 @@ int knl_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     flags |= (event->options[j].value & 0xFFULL) << 24;
                     break;
                 case EVENT_OPTION_OPCODE:
-                    filter_flags1 |= (extractBitField(event->options[j].value,20,0) << 9);
+                    filter_flags1 |= (field32(event->options[j].value,0,20) << 9);
                     set_opcode_all = 0;
                     break;
                 case EVENT_OPTION_STATE:
-                    filter_flags0 |= (extractBitField(event->options[j].value,10,0) << 17);
+                    filter_flags0 |= (field32(event->options[j].value,0,10) << 17);
                     set_state_all = 0;
                     break;
                 case EVENT_OPTION_TID:
-                    filter_flags0 |= (extractBitField(event->options[j].value,9,0));
+                    filter_flags0 |= (field32(event->options[j].value,0,9));
                     flags |= (1ULL<<19);
                     break;
                 case EVENT_OPTION_MATCH0:
-                    filter_flags1 |= (extractBitField(event->options[j].value,3,0) << 29);
+                    filter_flags1 |= (field32(event->options[j].value,0,3) << 29);
                     break;
                 case EVENT_OPTION_MATCH1:
-                    filter_flags1 |= (extractBitField(event->options[j].value,2,0) << 4);
+                    filter_flags1 |= (field32(event->options[j].value,0,2) << 4);
                     set_match1_all = 0;
                     break;
                 case EVENT_OPTION_NID:
-                    filter_flags1 |= extractBitField(event->options[j].value,2,0);
+                    filter_flags1 |= field32(event->options[j].value,0,2);
                     break;
                 default:
                     break;

--- a/src/includes/perfmon_sandybridge.h
+++ b/src/includes/perfmon_sandybridge.h
@@ -1423,7 +1423,7 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                         HPMread(cpu_id, dev, counter1, &counter_result);
                         if (eventSet->events[i].event.eventId == 0x00)
                         {
-                            switch(extractBitField(counter_result, 3, 0))
+                            switch(field32(counter_result, 0, 3))
                             {
                                 case 0x2:
                                     counter_result = 5.6E9;
@@ -1450,7 +1450,7 @@ int perfmon_stopCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                         }
                         else if (eventSet->events[i].event.eventId == 0x01)
                         {
-                            counter_result = extractBitField(counter_result, 1, 4);
+                            counter_result = field32(counter_result, 4, 1);
                         }
                         eventSet->events[i].threadCounter[thread_id].startData = 0;
                         VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "STOP_SBOXFIX");
@@ -1781,7 +1781,7 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                     HPMread(cpu_id, dev, counter1, &counter_result);
                     if (eventSet->events[i].event.eventId == 0x00)
                     {
-                        switch(extractBitField(counter_result, 3, 0))
+                        switch(field32(counter_result, 0, 3))
                         {
                             case 0x2:
                                 counter_result = 5.6E9;
@@ -1808,7 +1808,7 @@ int perfmon_readCountersThread_sandybridge(int thread_id, PerfmonEventSet* event
                     }
                     else if (eventSet->events[i].event.eventId == 0x01)
                     {
-                        counter_result = extractBitField(counter_result, 1, 4);
+                        counter_result = field32(counter_result, 4, 1);
                     }
                     eventSet->events[i].threadCounter[thread_id].startData = 0x0ULL;
                     VERBOSEPRINTPCIREG(cpu_id, dev, counter1,  LLU_CAST counter_result, "READ_SBOXFIX");

--- a/src/includes/perfmon_skylake.h
+++ b/src/includes/perfmon_skylake.h
@@ -416,24 +416,24 @@ int skx_cbox_setup(int cpu_id, RegisterIndex index, PerfmonEvent *event)
                     flags |= (event->options[j].value & 0xFFULL) << 24;
                     break;
                 case EVENT_OPTION_OPCODE:
-                    filter_flags1 |= (extractBitField(event->options[j].value,20,0) << 9);
+                    filter_flags1 |= (field32(event->options[j].value,0,20) << 9);
                     filter_flags1 |= (0x3<<27);
                     filter_flags1 |= (0x3<<17);
                     opc_match = 1;
                     break;
                 case EVENT_OPTION_STATE:
-                    filter_flags0 |= (extractBitField(event->options[j].value,10,0) << 17);
+                    filter_flags0 |= (field32(event->options[j].value,0,10) << 17);
                     set_state_all = 0;
                     break;
                 case EVENT_OPTION_TID:
-                    filter_flags0 |= (extractBitField(event->options[j].value,9,0));
+                    filter_flags0 |= (field32(event->options[j].value,0,9));
                     flags |= (1ULL<<19);
                     break;
                 case EVENT_OPTION_MATCH0:
-                    filter_flags1 |= ((extractBitField(event->options[j].value,2,0) & 0x3ULL) << 30);
+                    filter_flags1 |= ((field32(event->options[j].value,0,2) & 0x3ULL) << 30);
                     break;
                 case EVENT_OPTION_MATCH1:
-                    filter_flags1 |= (extractBitField(event->options[j].value,6,0) & 0x33);
+                    filter_flags1 |= (field32(event->options[j].value,0,6) & 0x33);
                     match1 = 1;
                     break;
                 default:

--- a/src/includes/thermal.h
+++ b/src/includes/thermal.h
@@ -47,7 +47,7 @@ thermal_read(int cpuId, uint32_t *data)
         *data = 0;
         return -EIO;
     }
-    readout = extractBitField(result,7,16);
+    readout = field32(result,16,7);
     *data = (readout == 0 ?
                 thermal_info.activationT - thermal_info.offset :
                 (thermal_info.activationT - thermal_info.offset) - readout );
@@ -65,7 +65,7 @@ thermal_tread(int socket_fd, int cpuId, uint32_t *data)
         *data = 0;
         return -EIO;
     }
-    readout = extractBitField(result,7,16);
+    readout = field32(result,16,7);
     *data = (readout == 0 ?
                 thermal_info.activationT - thermal_info.offset :
                 (thermal_info.activationT - thermal_info.offset) - readout );

--- a/src/power.c
+++ b/src/power.c
@@ -300,8 +300,8 @@ power_init(int cpuId)
         err = HPMread(cpuId, MSR_DEV, MSR_PLATFORM_INFO, &flags);
         if (err == 0)
         {
-            power_info.baseFrequency = busSpeed * (double) extractBitField(flags,8,8);
-            power_info.minFrequency  = busSpeed * (double) extractBitField((flags>>(32)),8,8);
+            power_info.baseFrequency = busSpeed * (double) field64(flags,8,8);
+            power_info.minFrequency  = busSpeed * (double) field64(flags,40,8);
 
             power_info.turbo.numSteps = cpuid_topology.numCoresPerSocket;
             if (cpuid_info.model == WESTMERE_EX)
@@ -482,14 +482,14 @@ power_init(int cpuId)
                     if (err == 0)
                     {
                         power_info.domains[i].supportFlags |= POWER_DOMAIN_SUPPORT_INFO;
-                        power_info.domains[i].tdp = (double) extractBitField(flags,15,0) * power_info.powerUnit;
+                        power_info.domains[i].tdp = (double) field64(flags,0,15) * power_info.powerUnit;
                         if (cpuid_info.model != ATOM_SILVERMONT_C)
                         {
-                            power_info.domains[i].minPower = (double) extractBitField(flags,15,16) * power_info.powerUnit;
-                            power_info.domains[i].maxPower = (double) extractBitField(flags,15,32) * power_info.powerUnit;
+                            power_info.domains[i].minPower = (double) field64(flags,16,15) * power_info.powerUnit;
+                            power_info.domains[i].maxPower = (double) field64(flags,32,15) * power_info.powerUnit;
                             if (power_info.domains[i].minPower > power_info.domains[i].maxPower)
                                 power_info.domains[i].minPower = 0;
-                            power_info.domains[i].maxTimeWindow = (double) extractBitField(flags,7,48) * power_info.timeUnit;
+                            power_info.domains[i].maxTimeWindow = (double) field64(flags,48,7) * power_info.timeUnit;
                         }
                     }
                     else
@@ -639,9 +639,9 @@ power_limitGet(int cpuId, PowerType domain, double* power, double* time)
             ERROR_PRINT("Failed to set power limit for domain %s on CPU %d", power_names[domain], cpuId);
             return -EFAULT;
         }
-        *power = ((double)extractBitField(flags, 15, 0)) * power_info.domains[domain].energyUnit;
-        Y = extractBitField(flags, 5, 17);
-        Z = extractBitField(flags, 2, 22);
+        *power = ((double)field64(flags, 0, 15)) * power_info.domains[domain].energyUnit;
+        Y = field64(flags, 17, 5);
+        Z = field64(flags, 22, 2);
         *time = pow(2,((double)Y)) * (1.0 + (((double)Z)/4.0)) * power_info.timeUnit;
     }
     return 0;
@@ -735,7 +735,7 @@ power_policySet(int cpuId, PowerType domain, uint32_t priority)
     {
         return -EINVAL;
     }
-    priority = extractBitField(priority, 5, 0);
+    priority = field32(priority, 0, 5);
     if (power_info.domains[domain].supportFlags & POWER_DOMAIN_SUPPORT_POLICY)
     {
         err = HPMwrite(cpuId, MSR_DEV, policy_regs[domain], priority);

--- a/src/thermal.c
+++ b/src/thermal.c
@@ -74,15 +74,15 @@ thermal_init(int cpuId)
             thermal_info.highT = 0;
         }
 
-        thermal_info.resolution =  extractBitField(flags,4,27);
+        thermal_info.resolution =  field32(flags,27,4);
 
         flags = 0ULL;
         if (HPMread(cpuId, MSR_DEV, MSR_TEMPERATURE_TARGET, &flags))
         {
             return;
         }
-        thermal_info.activationT =  extractBitField(flags,8,16);
-        thermal_info.offset = extractBitField(flags,6,24);
+        thermal_info.activationT =  field32(flags,16,8);
+        thermal_info.offset = field32(flags,24,6);
     }
 }
 

--- a/src/topology_cpuid.c
+++ b/src/topology_cpuid.c
@@ -71,7 +71,7 @@ intelCpuidFunc_4(CacheLevel** cachePool)
     {
         uint32_t eax = 4, ebx, ecx = level, edx;
         CPUID(eax, ebx, ecx, edx);
-        valid = extractBitField(eax,5,0);
+        valid = field32(eax,0,5);
         if (!valid)
         {
             break;
@@ -88,15 +88,15 @@ intelCpuidFunc_4(CacheLevel** cachePool)
         uint32_t eax = 4, ebx, ecx = i, edx;
         CPUID(eax, ebx, ecx, edx);
 
-        pool[i].level = extractBitField(eax,3,5);
-        pool[i].type = (CacheType) extractBitField(eax,5,0);
-        pool[i].associativity = extractBitField(ebx,8,22)+1;
+        pool[i].level = field32(eax,5,3);
+        pool[i].type = (CacheType) field32(eax,0,5);
+        pool[i].associativity = field32(ebx,22,8)+1;
         pool[i].sets = ecx+1;
-        pool[i].lineSize = extractBitField(ebx,12,0)+1;
+        pool[i].lineSize = field32(ebx,0,12)+1;
         pool[i].size = pool[i].sets *
             pool[i].associativity *
             pool[i].lineSize;
-        pool[i].threads = extractBitField(eax,10,14)+1;
+        pool[i].threads = field32(eax,14,10)+1;
 
         /* WORKAROUND cpuid reports wrong number of threads on SMT processor with SMT
          * turned off */
@@ -207,7 +207,7 @@ cpuid_printTlbTopology()
     {
         uint32_t eax = 2, ebx, ecx = 0, edx;
         CPUID(eax, ebx, ecx, edx);
-        uint32_t loop = extractBitField(eax,8,0);
+        uint32_t loop = field32(eax,0,8);
         for(size_t i=1;i<loop;i++)
         {
             eax = 0x02;
@@ -216,34 +216,34 @@ cpuid_printTlbTopology()
 
         for(size_t i=8;i<32;i+=8)
         {
-            if (extractBitField(eax,8,i) != 0x0)
+            if (field32(eax,i,8) != 0x0)
             {
-                if (intel_tlb_info[extractBitField(eax,8,i)])
-                    printf("%s\n",intel_tlb_info[extractBitField(eax,8,i)]);
+                if (intel_tlb_info[field32(eax,i,8)])
+                    printf("%s\n",intel_tlb_info[field32(eax,i,8)]);
             }
         }
         for(size_t i=0;i<32;i+=8)
         {
-            if (extractBitField(eax,8,i) != 0x0)
+            if (field32(eax,i,8) != 0x0)
             {
-                if (intel_tlb_info[extractBitField(ebx,8,i)])
-                    printf("%s\n",intel_tlb_info[extractBitField(ebx,8,i)]);
+                if (intel_tlb_info[field32(ebx,i,8)])
+                    printf("%s\n",intel_tlb_info[field32(ebx,i,8)]);
             }
         }
         for(size_t i=0;i<32;i+=8)
         {
-            if (extractBitField(eax,8,i) != 0x0)
+            if (field32(eax,i,8) != 0x0)
             {
-                if (intel_tlb_info[extractBitField(ecx,8,i)])
-                    printf("%s\n",intel_tlb_info[extractBitField(ecx,8,i)]);
+                if (intel_tlb_info[field32(ecx,i,8)])
+                    printf("%s\n",intel_tlb_info[field32(ecx,i,8)]);
             }
         }
         for(size_t i=0;i<32;i+=8)
         {
-            if (extractBitField(eax,8,i) != 0x0)
+            if (field32(eax,i,8) != 0x0)
             {
-                if (intel_tlb_info[extractBitField(edx,8,i)])
-                    printf("%s\n",intel_tlb_info[extractBitField(edx,8,i)]);
+                if (intel_tlb_info[field32(edx,i,8)])
+                    printf("%s\n",intel_tlb_info[field32(edx,i,8)]);
             }
         }
     }
@@ -251,32 +251,32 @@ cpuid_printTlbTopology()
     {
         uint32_t eax = 0x80000005, ebx, ecx = 0, edx;
         CPUID(eax, ebx, ecx, edx);
-        printf("L1DTlb2and4MAssoc: 0x%x\n",extractBitField(eax,8,24));
-        printf("L1DTlb2and4MSize: %d entries for 2MB pages\n",(uint32_t)extractBitField(eax,8,16));
-        printf("L1ITlb2and4MAssoc: 0x%x\n",extractBitField(eax,8,8));
-        printf("L1ITlb2and4MSize: %d entries for 2MB pages\n",(uint32_t)extractBitField(eax,8,0));
+        printf("L1DTlb2and4MAssoc: 0x%x\n",field32(eax,24,8));
+        printf("L1DTlb2and4MSize: %d entries for 2MB pages\n",(uint32_t)field32(eax,16,8));
+        printf("L1ITlb2and4MAssoc: 0x%x\n",field32(eax,8,8));
+        printf("L1ITlb2and4MSize: %d entries for 2MB pages\n",(uint32_t)field32(eax,0,8));
         ebx = 0x80000005;
         CPUID(eax, ebx, ecx, edx);
-        printf("L1DTlb4KAssoc: 0x%x\n",extractBitField(ebx,8,24));
-        printf("L1DTlb4KSize: 0x%x\n",extractBitField(ebx,8,16));
-        printf("L1ITlb4KAssoc: 0x%x\n",extractBitField(ebx,8,8));
-        printf("L1ITlb4KSize: 0x%x\n",extractBitField(ebx,8,0));
+        printf("L1DTlb4KAssoc: 0x%x\n",field32(ebx,24,8));
+        printf("L1DTlb4KSize: 0x%x\n",field32(ebx,16,8));
+        printf("L1ITlb4KAssoc: 0x%x\n",field32(ebx,8,8));
+        printf("L1ITlb4KSize: 0x%x\n",field32(ebx,0,8));
         eax = 0x80000006;
         CPUID(eax, ebx, ecx, edx);
-        printf("L2DTlb2and4MAssoc: 0x%x\n",extractBitField(eax,4,24));
-        printf("L2DTlb2and4MAssoc_c: %d\n",amdGetAssociativity(extractBitField(eax,4,24)));
-        printf("L2DTlb2and4MSize: 0x%x\n",extractBitField(eax,12,16));
-        printf("L2ITlb2and4MAssoc: 0x%x\n",extractBitField(eax,4,12));
-        printf("L2ITlb2and4MAssoc_c: %d\n",amdGetAssociativity(extractBitField(eax,4,12)));
-        printf("L2ITlb2and4MSize: 0x%x\n",extractBitField(eax,12,0));
+        printf("L2DTlb2and4MAssoc: 0x%x\n",field32(eax,24,4));
+        printf("L2DTlb2and4MAssoc_c: %d\n",amdGetAssociativity(field32(eax,24,4)));
+        printf("L2DTlb2and4MSize: 0x%x\n",field32(eax,16,12));
+        printf("L2ITlb2and4MAssoc: 0x%x\n",field32(eax,12,4));
+        printf("L2ITlb2and4MAssoc_c: %d\n",amdGetAssociativity(field32(eax,12,4)));
+        printf("L2ITlb2and4MSize: 0x%x\n",field32(eax,0,12));
         ebx = 0x80000006;
         CPUID(eax, ebx, ecx, edx);
-        printf("L2DTlb4KAssoc: 0x%x\n",extractBitField(eax,4,24));
-        printf("L2DTlb4KAssoc_c: %d\n",amdGetAssociativity(extractBitField(eax,4,24)));
-        printf("L2DTlb4KSize: 0x%x\n",extractBitField(eax,12,16));
-        printf("L2ITlb4KAssoc: 0x%x\n",extractBitField(eax,4,12));
-        printf("L2ITlb4KAssoc_c: %d\n",amdGetAssociativity(extractBitField(eax,4,12)));
-        printf("L2ITlb4KSize: 0x%x\n",extractBitField(eax,12,0));
+        printf("L2DTlb4KAssoc: 0x%x\n",field32(eax,24,4));
+        printf("L2DTlb4KAssoc_c: %d\n",amdGetAssociativity(field32(eax,24,4)));
+        printf("L2DTlb4KSize: 0x%x\n",field32(eax,16,12));
+        printf("L2ITlb4KAssoc: 0x%x\n",field32(eax,12,4));
+        printf("L2ITlb4KAssoc_c: %d\n",amdGetAssociativity(field32(eax,12,4)));
+        printf("L2ITlb4KSize: 0x%x\n",field32(eax,0,12));
     }
     return;
 }
@@ -576,24 +576,24 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
 
                 switch ( level ) {
                     case 0:  /* SMT thread */
-                        bitField = extractBitField(apicId,
-                                currOffset,
-                                0);
+                        bitField = field32(apicId,
+                                0,
+                                currOffset);
                         hwThreadPool[id].threadId = bitField;
                         break;
 
                     case 1:  /* Core */
-                        bitField = extractBitField(apicId,
-                                currOffset-prevOffset,
-                                prevOffset);
+                        bitField = field32(apicId,
+                                prevOffset,
+                                currOffset-prevOffset);
                         hwThreadPool[id].coreId = bitField;
                         affinity_thread2core_lookup[hwThreadPool[id].apicId] = hwThreadPool[id].coreId;
                         break;
 
                     case 2:  /* Package */
-                        bitField = extractBitField(apicId,
-                                32-prevOffset,
-                                prevOffset);
+                        bitField = field32(apicId,
+                                prevOffset,
+                                32-prevOffset);
                         hwThreadPool[id].packageId = bitField;
                         break;
 
@@ -615,13 +615,13 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
             case P6_FAMILY:
                 eax = 0x01;
                 CPUID(eax, ebx, ecx, edx);
-                maxNumLogicalProcs = extractBitField(ebx,8,16);
+                maxNumLogicalProcs = field32(ebx,16,8);
 
                 /* Check number of cores per package */
                 eax = 0x04;
                 ecx = 0;
                 CPUID(eax, ebx, ecx, edx);
-                maxNumCores = extractBitField(eax,6,26)+1;
+                maxNumCores = field32(eax,26,6)+1;
                 maxNumLogicalProcsPerCore = maxNumLogicalProcs/maxNumCores;
 
                 for (uint32_t i=0; i<  cpuid_topology.numHWThreads; i++)
@@ -634,28 +634,28 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                     eax = 0x01;
                     CPUID(eax, ebx, ecx, edx);
                     id = i;
-                    hwThreadPool[id].apicId = i;//extractBitField(ebx,8,24);
+                    hwThreadPool[id].apicId = i;//field32(ebx,24,8);
 
                     /* ThreadId is extracted from th apicId using the bit width
                      * of the number of logical processors
                      * */
                     hwThreadPool[id].threadId =
-                        extractBitField(hwThreadPool[id].apicId,
-                                getBitFieldWidth(maxNumLogicalProcsPerCore),0);
+                        field32(hwThreadPool[id].apicId,
+                                0,getBitFieldWidth(maxNumLogicalProcsPerCore));
 
                     /* CoreId is extracted from th apicId using the bitWidth
                      * of the number of logical processors as offset and the
                      * bit width of the number of cores as width
                      * */
                     hwThreadPool[id].coreId =
-                        extractBitField(hwThreadPool[id].apicId,
-                                getBitFieldWidth(maxNumCores),
-                                getBitFieldWidth(maxNumLogicalProcsPerCore));
+                        field32(hwThreadPool[id].apicId,
+                                getBitFieldWidth(maxNumLogicalProcsPerCore),
+                                getBitFieldWidth(maxNumCores));
 
                     hwThreadPool[id].packageId =
-                        extractBitField(hwThreadPool[id].apicId,
-                                8-getBitFieldWidth(maxNumLogicalProcs),
-                                getBitFieldWidth(maxNumLogicalProcs));
+                        field32(hwThreadPool[id].apicId,
+                                getBitFieldWidth(maxNumLogicalProcs),
+                                8-getBitFieldWidth(maxNumLogicalProcs));
 
                     DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
@@ -674,7 +674,7 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                 eax = 0x80000008;
                 CPUID(eax, ebx, ecx, edx);
 
-                maxNumCores =  extractBitField(ecx,8,0)+1;
+                maxNumCores =  field32(ecx,0,8)+1;
 
                 for (uint32_t i=0; i<  cpuid_topology.numHWThreads; i++)
                 {
@@ -685,29 +685,29 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
 
                     eax = 0x01;
                     CPUID(eax, ebx, ecx, edx);
-                    id = extractBitField(ebx,8,24);
-                    hwThreadPool[id].apicId = extractBitField(ebx,8,24);
+                    id = field32(ebx,24,8);
+                    hwThreadPool[id].apicId = field32(ebx,24,8);
 
                     /* ThreadId is extracted from th apicId using the bit width
                      * of the number of logical processors
                      * */
                     hwThreadPool[id].threadId =
-                        extractBitField(hwThreadPool[i].apicId,
-                                getBitFieldWidth(maxNumLogicalProcsPerCore),0);
+                        field32(hwThreadPool[i].apicId,
+                                0,getBitFieldWidth(maxNumLogicalProcsPerCore));
 
                     /* CoreId is extracted from th apicId using the bitWidth
                      * of the number of logical processors as offset and the
                      * bit width of the number of cores as width
                      * */
                     hwThreadPool[id].coreId =
-                        extractBitField(hwThreadPool[i].apicId,
-                                getBitFieldWidth(maxNumCores),
-                                0);
+                        field32(hwThreadPool[i].apicId,
+                                0,
+                                getBitFieldWidth(maxNumCores));
 
                     hwThreadPool[id].packageId =
-                        extractBitField(hwThreadPool[i].apicId,
-                                8-getBitFieldWidth(maxNumCores),
-                                getBitFieldWidth(maxNumCores));
+                        field32(hwThreadPool[i].apicId,
+                                getBitFieldWidth(maxNumCores),
+                                8-getBitFieldWidth(maxNumCores));
                     DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
                                     hwThreadPool[id].coreId, hwThreadPool[id].packageId);
@@ -724,17 +724,17 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                 eax = 0x80000008;
                 CPUID(eax, ebx, ecx, edx);
 
-                width =  extractBitField(ecx,4,12);
+                width =  field32(ecx,12,4);
 
                 if (width == 0)
                 {
-                    width =  extractBitField(ecx,8,0)+1;
+                    width =  field32(ecx,0,8)+1;
                 }
 
                 eax = 0x01;
                 CPUID(eax, ebx, ecx, edx);
-                maxNumLogicalProcs =  extractBitField(ebx,8,16);
-                maxNumCores = extractBitField(ecx,8,0)+1;
+                maxNumLogicalProcs =  field32(ebx,16,8);
+                maxNumCores = field32(ecx,0,8)+1;
 
                 for (uint32_t i=0; i<  cpuid_topology.numHWThreads; i++)
                 {
@@ -745,17 +745,17 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
 
                     eax = 0x01;
                     CPUID(eax, ebx, ecx, edx);
-                    id = extractBitField(ebx,8,24);
-                    hwThreadPool[id].apicId = extractBitField(ebx,8,24);
+                    id = field32(ebx,24,8);
+                    hwThreadPool[id].apicId = field32(ebx,24,8);
                     /* AMD only knows cores */
                     hwThreadPool[id].threadId = 0;
 
                     hwThreadPool[id].coreId =
-                        extractBitField(hwThreadPool[i].apicId,
-                                width, 0);
+                        field32(hwThreadPool[i].apicId,
+                                0, width);
                     hwThreadPool[id].packageId =
-                        extractBitField(hwThreadPool[i].apicId,
-                                (8-width), width);
+                        field32(hwThreadPool[i].apicId,
+                                width, 8-width);
                     DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
                                     hwThreadPool[id].coreId, hwThreadPool[id].packageId);
@@ -805,9 +805,9 @@ cpuid_init_cacheTopology(void)
             CPUID(eax, ebx, ecx, edx);
             cachePool[0].level = 1;
             cachePool[0].type = DATACACHE;
-            cachePool[0].associativity = extractBitField(ecx,8,16);
-            cachePool[0].lineSize = extractBitField(ecx,8,0);
-            cachePool[0].size =  extractBitField(ecx,8,24) * 1024;
+            cachePool[0].associativity = field32(ecx,16,8);
+            cachePool[0].lineSize = field32(ecx,0,8);
+            cachePool[0].size =  field32(ecx,24,8) * 1024;
             if ((cachePool[0].associativity * cachePool[0].lineSize) != 0)
             {
                 cachePool[0].sets = cachePool[0].size/
@@ -821,9 +821,9 @@ cpuid_init_cacheTopology(void)
             cachePool[1].level = 2;
             cachePool[1].type = UNIFIEDCACHE;
             cachePool[1].associativity =
-                amdGetAssociativity(extractBitField(ecx,4,12));
-            cachePool[1].lineSize = extractBitField(ecx,8,0);
-            cachePool[1].size =  extractBitField(ecx,16,16) * 1024;
+                amdGetAssociativity(field32(ecx,12,4));
+            cachePool[1].lineSize = field32(ecx,0,8);
+            cachePool[1].size =  field32(ecx,16,16) * 1024;
             if ((cachePool[0].associativity * cachePool[0].lineSize) != 0)
             {
                 cachePool[1].sets = cachePool[1].size/
@@ -847,9 +847,9 @@ cpuid_init_cacheTopology(void)
             CPUID(eax, ebx, ecx, edx);
             cachePool[0].level = 1;
             cachePool[0].type = DATACACHE;
-            cachePool[0].associativity = extractBitField(ecx,8,16);
-            cachePool[0].lineSize = extractBitField(ecx,8,0);
-            cachePool[0].size =  extractBitField(ecx,8,24) * 1024;
+            cachePool[0].associativity = field32(ecx,16,8);
+            cachePool[0].lineSize = field32(ecx,0,8);
+            cachePool[0].size =  field32(ecx,24,8) * 1024;
             if ((cachePool[0].associativity * cachePool[0].lineSize) != 0)
             {
                 cachePool[0].sets = cachePool[0].size/
@@ -863,9 +863,9 @@ cpuid_init_cacheTopology(void)
             cachePool[1].level = 2;
             cachePool[1].type = UNIFIEDCACHE;
             cachePool[1].associativity = 
-                amdGetAssociativity(extractBitField(ecx,4,12));
-            cachePool[1].lineSize = extractBitField(ecx,8,0);
-            cachePool[1].size =  extractBitField(ecx,16,16) * 1024;
+                amdGetAssociativity(field32(ecx,12,4));
+            cachePool[1].lineSize = field32(ecx,0,8);
+            cachePool[1].size =  field32(ecx,16,16) * 1024;
             if ((cachePool[0].associativity * cachePool[0].lineSize) != 0)
             {
                 cachePool[1].sets = cachePool[1].size/
@@ -877,9 +877,9 @@ cpuid_init_cacheTopology(void)
             cachePool[2].level = 3;
             cachePool[2].type = UNIFIEDCACHE;
             cachePool[2].associativity =
-                amdGetAssociativity(extractBitField(edx,4,12));
-            cachePool[2].lineSize = extractBitField(edx,8,0);
-            cachePool[2].size =  (extractBitField(edx,14,18)+1) * 524288;
+                amdGetAssociativity(field32(edx,12,4));
+            cachePool[2].lineSize = field32(edx,0,8);
+            cachePool[2].size =  (field32(edx,18,14)+1) * 524288;
             if ((cachePool[0].associativity * cachePool[0].lineSize) != 0)
             {
                 cachePool[2].sets = cachePool[1].size/
@@ -914,18 +914,18 @@ cpuid_init_cacheTopology(void)
                 ecx = id;
                 eax = 0x8000001D;
                 CPUID(eax, ebx, ecx, edx);
-                type = (CacheType) extractBitField(eax,4,0);
+                type = (CacheType) field32(eax,0,4);
 
                 if ((type == DATACACHE) || (type == UNIFIEDCACHE))
                 {
-                    cachePool[maxNumLevels].level =   extractBitField(eax,3,5);
+                    cachePool[maxNumLevels].level =   field32(eax,5,3);
                     cachePool[maxNumLevels].type = type;
-                    cachePool[maxNumLevels].associativity = extractBitField(ebx,10,22)+1;
-                    cachePool[maxNumLevels].lineSize = extractBitField(ebx,12,0)+1;
-                    cachePool[maxNumLevels].sets =  extractBitField(ecx,32,0)+1;
+                    cachePool[maxNumLevels].associativity = field32(ebx,22,10)+1;
+                    cachePool[maxNumLevels].lineSize = field32(ebx,0,12)+1;
+                    cachePool[maxNumLevels].sets =  field32(ecx,0,32)+1;
                     cachePool[maxNumLevels].size = cachePool[maxNumLevels].associativity *
                         cachePool[maxNumLevels].lineSize * cachePool[maxNumLevels].sets;
-                    cachePool[maxNumLevels].threads =  extractBitField(eax,12,14)+1;
+                    cachePool[maxNumLevels].threads =  field32(eax,14,12)+1;
                     cachePool[maxNumLevels].inclusive =  (edx & (0x1<<1));
                     maxNumLevels++;
                 }
@@ -948,6 +948,6 @@ int cpuid_get_hwthread_data(int cpu_id, HWThread* hwt)
     (void)cpu_id;
     uint32_t eax = 1, ebx, ecx = 0, edx;
     CPUID(eax, ebx, ecx, edx);
-    hwt->apicId = extractBitField(ebx,8,24);
+    hwt->apicId = field32(ebx,24,8);
     return 0;
 }

--- a/src/topology_cpuid.c
+++ b/src/topology_cpuid.c
@@ -641,7 +641,7 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                      * */
                     hwThreadPool[id].threadId =
                         field32(hwThreadPool[id].apicId,
-                                0,getBitFieldWidth(maxNumLogicalProcsPerCore));
+                                0,fieldWidthForCount(maxNumLogicalProcsPerCore));
 
                     /* CoreId is extracted from th apicId using the bitWidth
                      * of the number of logical processors as offset and the
@@ -649,13 +649,13 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                      * */
                     hwThreadPool[id].coreId =
                         field32(hwThreadPool[id].apicId,
-                                getBitFieldWidth(maxNumLogicalProcsPerCore),
-                                getBitFieldWidth(maxNumCores));
+                                fieldWidthForCount(maxNumLogicalProcsPerCore),
+                                fieldWidthForCount(maxNumCores));
 
                     hwThreadPool[id].packageId =
                         field32(hwThreadPool[id].apicId,
-                                getBitFieldWidth(maxNumLogicalProcs),
-                                8-getBitFieldWidth(maxNumLogicalProcs));
+                                fieldWidthForCount(maxNumLogicalProcs),
+                                8-fieldWidthForCount(maxNumLogicalProcs));
 
                     DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
@@ -693,7 +693,7 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                      * */
                     hwThreadPool[id].threadId =
                         field32(hwThreadPool[i].apicId,
-                                0,getBitFieldWidth(maxNumLogicalProcsPerCore));
+                                0,fieldWidthForCount(maxNumLogicalProcsPerCore));
 
                     /* CoreId is extracted from th apicId using the bitWidth
                      * of the number of logical processors as offset and the
@@ -702,12 +702,12 @@ cpuid_init_nodeTopology(cpu_set_t cpuSet)
                     hwThreadPool[id].coreId =
                         field32(hwThreadPool[i].apicId,
                                 0,
-                                getBitFieldWidth(maxNumCores));
+                                fieldWidthForCount(maxNumCores));
 
                     hwThreadPool[id].packageId =
                         field32(hwThreadPool[i].apicId,
-                                getBitFieldWidth(maxNumCores),
-                                8-getBitFieldWidth(maxNumCores));
+                                fieldWidthForCount(maxNumCores),
+                                8-fieldWidthForCount(maxNumCores));
                     DEBUG_PRINT(DEBUGLEV_DEVELOP, "I[%d] ID[%d] APIC[%d] T[%d] C[%d] P [%d]", i, id,
                                     hwThreadPool[id].apicId, hwThreadPool[id].threadId,
                                     hwThreadPool[id].coreId, hwThreadPool[id].packageId);


### PR DESCRIPTION
This PR removes the redundant and more ambiguous `extractBitField` function. Only `field32` and `field64` are now used, which should make it more clear, if there is possible loss due to data type.

Also the implementation of `extractBitField` is changed, so that it no longer uses inline assembly. New implementation is tested with x86 and ARM, while it previously only worked with x86_64.