### PR TITLE
AMD Zen4/Zen4c/Zen5 MEM group: warn and document NPS>1 inaccuracy (#717)

### DIFF
--- a/groups/zen4/MEM.txt
+++ b/groups/zen4/MEM.txt
@@ -54,3 +54,11 @@ Memory data volume [GBytes] = 1.0E-09*(SUM(CAS_CMD_RD)+SUM(CAS_CMD_WR))*64.0
 Profiling group to measure memory bandwidth drawn by all cores of a socket.
 Since this group is based on Uncore events it is only possible to measure on a
 per socket base.
+This group is only known-accurate with NPS=1 (one NUMA domain per socket). With
+NPS>1 (NPS2, NPS4, ...) the reported traffic/bandwidth has been observed to be
+exactly double the correct value in reported cases on Zen5c (both NPS2 and
+NPS4), see https://github.com/RRZE-HPC/likwid/issues/717. The root cause is not
+yet identified, and it is not confirmed whether a flat 2x applies in every
+NPS>1 configuration, so no general correction factor is applied here. If you
+see suspiciously large bandwidth numbers, check your NPS BIOS setting; NPS1 is
+the only configuration currently verified to be accurate.

--- a/groups/zen4c/MEM.txt
+++ b/groups/zen4c/MEM.txt
@@ -54,3 +54,11 @@ Memory data volume [GBytes] = 1.0E-09*(SUM(CAS_CMD_RD)+SUM(CAS_CMD_WR))*64.0
 Profiling group to measure memory bandwidth drawn by all cores of a socket.
 Since this group is based on Uncore events it is only possible to measure on a
 per socket base.
+This group is only known-accurate with NPS=1 (one NUMA domain per socket). With
+NPS>1 (NPS2, NPS4, ...) the reported traffic/bandwidth has been observed to be
+exactly double the correct value in reported cases on Zen5c (both NPS2 and
+NPS4), see https://github.com/RRZE-HPC/likwid/issues/717. The root cause is not
+yet identified, and it is not confirmed whether a flat 2x applies in every
+NPS>1 configuration, so no general correction factor is applied here. If you
+see suspiciously large bandwidth numbers, check your NPS BIOS setting; NPS1 is
+the only configuration currently verified to be accurate.

--- a/groups/zen5/MEM.txt
+++ b/groups/zen5/MEM.txt
@@ -54,3 +54,11 @@ Memory data volume [GBytes] = 1.0E-09*(SUM(CAS_CMD_RD)+SUM(CAS_CMD_WR))*64.0
 Profiling group to measure memory bandwidth drawn by all cores of a socket.
 Since this group is based on Uncore events it is only possible to measure on a
 per socket base.
+This group is only known-accurate with NPS=1 (one NUMA domain per socket). With
+NPS>1 (NPS2, NPS4, ...) the reported traffic/bandwidth has been observed to be
+exactly double the correct value in reported cases on Zen5c (both NPS2 and
+NPS4), see https://github.com/RRZE-HPC/likwid/issues/717. The root cause is not
+yet identified, and it is not confirmed whether a flat 2x applies in every
+NPS>1 configuration, so no general correction factor is applied here. If you
+see suspiciously large bandwidth numbers, check your NPS BIOS setting; NPS1 is
+the only configuration currently verified to be accurate.

--- a/src/perfmon.c
+++ b/src/perfmon.c
@@ -2814,6 +2814,32 @@ past_checks:
         bstrListDestroy(subtokens);
     }
     bstrListDestroy(eventtokens);
+
+    if (!cpuid_info.isIntel && numa_info.numberOfNodes > cpuid_topology.numSockets)
+    {
+        int has_uncore_mem_counter = 0;
+        for (j = 0; j < eventSet->numberOfEvents; j++)
+        {
+            RegisterType t = eventSet->events[j].type;
+            if (t == MBOX0 || (t >= BBOX0 && t <= BBOX69))
+            {
+                has_uncore_mem_counter = 1;
+                break;
+            }
+        }
+        if (has_uncore_mem_counter)
+        {
+            fprintf(stderr,
+                "WARN: This event set uses AMD Data Fabric/UMC uncore counters (DFCx/UMCxCy) while "
+                "the system reports %u NUMA domains for %u socket(s), i.e. NPS>1 (NPS2/NPS4/...). "
+                "Memory-bandwidth accounting through these counters is known to be unreliable in "
+                "NPS>1 configurations on several AMD Zen generations, e.g. exact doubling has been "
+                "observed on Zen5c in NPS4 (see https://github.com/RRZE-HPC/likwid/issues/717). "
+                "Use NPS1 if you need accurate absolute memory bandwidth/traffic numbers.\n",
+                numa_info.numberOfNodes, cpuid_topology.numSockets);
+        }
+    }
+
     int fixed_counters = 0;
     char fix[] = "FIXC";
     char* ptr;


### PR DESCRIPTION
## Summary

Addresses #717 (MEM groups overcounting traffic by 2x on Zen5c in NPS4 mode) with a
diagnostic/documentation fix, not a numeric correction. I don't have access to
Zen4/Zen4c/Zen5 hardware in any NPS>1 configuration, so I can't verify the exact
root cause well enough to ship a corrected formula in good conscience — this PR
makes the known-bad configuration loud and discoverable instead of silent.

## What I found

- PR #745 (merged, fixed DF/UMC counter map generation and RDPMC offsets) does not
  touch this: it fixes how counters are *enumerated*, not how uncore/DF-UMC values
  get aggregated across NUMA domains. #717 is a separate bug.
- `groups/zen2/MEM.txt` and `groups/zen3/MEM1.txt`/`MEM2.txt` already carry an
  explicit, in-file caveat about NPS-dependent DF-counter inaccuracy (`(4.0/(num_numadomains/num_sockets))`
  correction factor for zen2, and an outright "only available in NPS1 mode" note for
  zen3). `groups/zen4/MEM.txt`, `zen4c/MEM.txt`, and `zen5/MEM.txt` never got the
  same treatment even though they hit the identical class of problem (uncore
  memory-controller counters + NPS partitioning) — this looks like an oversight
  from adding UMC-based counting for zen4/4c/5 rather than an intentional decision.
- The two data points in #717's thread (single core and a 72-of-144-core ccNUMA
  domain both showed 2x in NPS4/NPS2; the *full* physical socket was correct) rule
  out a simple `num_numadomains/num_sockets`-proportional correction like zen2 uses
  — NPS2 and NPS4 both produced the same flat 2x, not 2x/4x. I did not want to
  encode an unverified proportional "fix" into a formula that would then be trusted
  as ground truth, so I left out any correction factor.
- `src/affinity.c` builds the "socket" affinity domain from `cpuid_topology.numSockets`
  (itself derived from `physical_package_id` in sysfs), not from NUMA node count, so
  the naive "socket count doubled under NPS>1" theory doesn't hold up against the
  code as it stands today — whatever is duplicating the count is happening somewhere
  in how the representative CPU for uncore/MSR reads is chosen relative to NUMA
  quadrant membership, or in kernel/firmware behavior specific to this hardware. I
  could not chase this further without a machine to instrument (e.g. compare a raw
  UMC/DF register read issued from cores in different quadrants under NPS4).
- AMD's public EPYC 9004 HPC tuning guide (pub 58002) confirms NPS>1 changes memory
  channel interleaving granularity but doesn't describe counter semantics under that
  interleaving, so it doesn't settle the question either.

## What this PR does

1. **`src/perfmon.c`** (`perfmon_addEventSet`): when the event set includes an AMD
   Data Fabric (`MBOX0`) or UMC (`BBOX0`-`BBOX69`) counter and the topology reports
   more NUMA domains than sockets (NPS>1), print a one-line `stderr` warning
   pointing at #717 and recommending NPS1 for accurate absolute bandwidth numbers.
   Gated on `!cpuid_info.isIntel` since `MBOX0` is shared with Intel's IMC uncore
   type in the perf_event translation table and would otherwise false-fire there.
2. **`groups/zen4/MEM.txt`, `groups/zen4c/MEM.txt`, `groups/zen5/MEM.txt`**: add the
   same kind of NPS caveat that zen2/zen3's memory groups already carry, so the
   static docs (`likwid-perfctr -H -g MEM`) match what zen2/zen3 users already see.

## What I could not verify (needs real Zen4/Zen4c/Zen5 hardware)

- The actual root cause / exact mechanism of the doubling.
- Whether the flat 2x from #717's reports generalizes to all NPS>1 configs, or is
  specific to the reported topologies.
- Whether the warning's trigger condition (`numa_info.numberOfNodes > cpuid_topology.numSockets`)
  ever produces a false positive on real multi-socket NPS0/NPS1 AMD systems I don't
  have access to test on.
- The code compiles cleanly by inspection (matches existing types/globals used
  elsewhere in the same function) but I could not build LIKWID itself to confirm —
  I'm on macOS/ARM64 and LIKWID's access layer is Linux/x86-specific. I'd appreciate
  a CI run or a quick local build check.

Happy to iterate — if anyone with NPS>1 Zen4/Zen4c/Zen5 access can dump raw
per-channel UMC/DF register values (ideally from cores in different quadrants) I'm
glad to turn this into an actual numeric fix instead of a warning.
